### PR TITLE
Implement the 'apropos' command

### DIFF
--- a/pkg/softools/mkapropos.hlp
+++ b/pkg/softools/mkapropos.hlp
@@ -1,0 +1,66 @@
+.help mkapropos Aug16 softools
+.ih
+NAME
+mkapropos -- Make the apropos database.
+.ih
+USAGE
+mkapropos pkglist aproposdb
+.ih
+DESCRIPTION
+The 'mkapropos' task descends a tree of help directory ('.hd') files
+and compiles a text database from the information found there, specifically
+from the package menu files ('.men').
+
+The apropos database is used to speed global searches when information
+is requested for a particular subject.
+Each line of the apropos database contains the name of the task or package,
+along with a brief description (from the '.men' files) and its package.
+
+By default, 'mkapropos' parameters are set to recompile the standard
+IRAF and NOAO apropos database (placed in 'lib$apropos.db'), although any other
+similar database may be recompiled, for example, for other add-on packages such
+as 'stsdas', 'xray' and 'ctio'. 
+
+Additionally, you can build apropos databases for your own packages.
+
+This is the mkapropos from stsdas.toolbox.tools, copied into Ureka/AstroConda
+IRAF's softools to facilitate building IRAF packages before stsdas is installed.
+.ih
+PARAMETERS
+.ls pkglist = "iraf, noao" [string]
+The names of the packages to examine when building the apropos database.
+By default, the
+IRAF, NOAO, and STSDAS packages are used.   Any IRAF external package may be 
+included.
+.le
+.ls helpdir = "lib/root.hd" [string]
+The filename of the root help directory file ('.hd' file)
+defining the help tree to be updated. This string is appended to each of the
+packages listed in the 'pkglist' parameter above. 
+.le
+.ls aproposdb = "lib$apropos.db" [string]
+The filename of the apropos database to be written. 
+.le
+.ls verbose = no [boolean]
+Print a detailed description of the help database as it is compiled?
+
+A more concise summary listing only the packages and the number
+of help modules in each package is printed by default.
+.le
+.ih
+EXAMPLES
+1. Update the stsdas package apropos database.
+
+.nf
+  cl> mkapropos stsdas lib/root.hd stsdas$lib/apropos.db
+.fi
+
+2. Update a user apropos database.
+
+.nf
+  cl> mkap pkglist=home helpdir=myroot.hd aproposdb=my.db
+.fi
+.ih
+SEE ALSO
+apropos, mkhelpdb
+.endhelp

--- a/pkg/softools/mkapropos.par
+++ b/pkg/softools/mkapropos.par
@@ -1,0 +1,5 @@
+# mkapropos parameter file
+pkglist,s,a,"iraf,noao",,,Packages to be included
+helpdir,s,a,"lib/root.hd",,,Root help directory to be compiled
+aproposdb,s,a,"lib$apropos.db",,,Output apropos database name
+verbose,b,h,no,,,verbose output ?

--- a/pkg/softools/mkapropos/help.h
+++ b/pkg/softools/mkapropos/help.h
@@ -1,0 +1,99 @@
+# Help Definitions.
+
+# Control Structure.  Contains all control parameters.  Pointer to structure
+# is passed to Lroff and on by Lroff to the input and output procedures.
+# With the exceptions of H_EOF and H_NLINES, the control parameters are
+# read only outside the main routine.
+
+define	LEN_CTRLSTRUCT	180
+define	SZ_SECNAME	39		# section name, single section mode
+define	SZ_PARNAME	39		# parameter name
+define	SZ_TEMPLATE	79		# the original modules template
+define	SZ_HELPDB	512		# max chars in helpdb file list
+
+define	H_IN		Memi[$1]	# input file descriptor
+define	H_OUT		Memi[$1+1]	# output file descriptor
+define	H_OPTION	Memi[$1+2]	# option code (see below)
+define	H_TTY		Memi[$1+3]	# TTY device descriptor
+define	H_LMARGIN	Memi[$1+4]	# permanent left margin for Lroff
+define	H_RMARGIN	Memi[$1+5]	# permanent right margin for Lroff
+define	H_RAWIN		Memi[$1+6]	# if YES, do not look at input
+define	H_RAWOUT	Memi[$1+7]	# if YES, do not process output
+define	H_FILTER_INPUT	Memi[$1+8]	# if YES, filter out part of input
+define	H_PAGINATE	Memi[$1+9]	# paginate output?
+define	H_MANPAGE	Memi[$1+10]	# manpage style output?
+define	H_NLPP		Memi[$1+11]	# number of lines per manual page
+define	H_NLINES	Memi[$1+12]	# number of output lines on page
+define	H_STATE		Memi[$1+13]	# input state, hinput()
+define	H_EOF		Memi[$1+14]	# input should return EOF to Lroff
+define	H_QUIT		Memi[$1+15]	# stop program
+define	H_LENTL		Memi[$1+16]	# length of the TL template list
+define	H_ALLMODULES	Memi[$1+17]	# process all modules matching template
+			# (extra space)
+define	H_SECNAME	Memc[P2C($1+20)]	# section name
+define	H_PARNAME	Memc[P2C($1+60)]	# parameter name
+define	H_TEMPLATE	Memc[P2C($1+100)]	# module name template
+
+# The nomore flag is set whenever the user responds negatively to the more?
+# query.  A nomore at the beginning of a help block or two nomores in a row
+# stop the program.
+
+define	NOMORE		(-1)
+
+# Option codes.  Max_options is used by the get_option keyword recognizer,
+# which handles abbreviations.
+
+define	O_HELP		1		# print full help block
+define	O_SOURCE	2		# print source code
+define	O_SYSDOC	3		# print technical system documentation
+define	O_ALLDOC	4		# print all documentation (!source)
+define	O_FILES		5		# print file names
+define	O_DIR		6		# print directory of help blocks
+define	O_SUMMARY	7		# summarize contents of help file
+define	MAX_OPTIONS	7
+
+define	O_PARAM		7		# output text for single parameter
+define	O_SECTION	8		# output text for single section
+define	O_MENU		9		# print package menu
+
+# Type codes for filenames.  Passed to hd_getname to fetch the module name
+# or a filename from a help directory.
+
+define	TY_MODNAME	0
+define	TY_HLP		1
+define	TY_SYS		2
+define	TY_SRC		3
+define	TY_PKG		4
+define	TY_MEN		5
+define	TY_UNKNOWN	6
+
+# Help block header structure.  A ".help" directive is decoded into this
+# structure.  The line number counter should be zeroed when the structure
+# is allocated.
+
+define	LEN_HBSTRUCT	1124
+define	MAX_KEYS	50
+define	SZ_TYPESTR	9		# help block type string
+define	SZ_KEY		19		# max size of a key
+define	SZ_SECTION	39		# section label, i.e., (Mar84)
+define	SZ_TITLE	63		# block title
+
+define	HB_TYPE		Memi[$1]	# type of block (default TY_HLP)
+define	HB_LINENO	Memi[$1+1]	# line number within file
+define	HB_NKEYS	Memi[$1+2]	# number of keys
+define	HB_TYPESTR	Memc[P2C($1+10)]		# blk type string
+define	HB_KEY		Memc[P2C($1+20+($2-1)*20)]	# keys
+define	HB_SECTION	Memc[P2C($1+1020)]		# section label
+define	HB_TITLE	Memc[P2C($1+1060)]		# block title
+
+# Pagination Control Codes.  The pagination directives BP, TP, KS, and KE
+# are ignored when output is directed to the terminal, but are important
+# when output is piped to the printer.  When the line input routine HINPUT sees
+# one of these directives in the input it places a control code in the
+# data stream read by Lroff.  Lroff passes control codes on to the output,
+# i.e., to HOUTPUT, where pagination takes place.
+
+define	BREAK_PAGE	1		# .bp
+define	TEST_PAGE	2		# .tp n
+define	START_KEEP	3		# .ks
+define	END_KEEP	4		# .ke

--- a/pkg/softools/mkapropos/helpdir.h
+++ b/pkg/softools/mkapropos/helpdir.h
@@ -1,0 +1,34 @@
+# Size limiting definitions.
+
+define	MAX_LDIRS	50			# maximum ldirs for package
+define	MAX_MODULES	100			# initial maximum no. modules
+define	INC_MODULES	50			# increment if overflow
+define	SZ_SBUF		2048			# initial size string buffer
+define	INC_SZSBUF	1024			# increment if overflow
+
+define	LEN_HDSTRUCT	(10+MAX_LDIRS+MAX_MODULES*LEN_MODSTRUCT)
+define	LEN_BASEHD	10
+define	LEN_MODSTRUCT	6
+
+# Helpdir descriptor structure.
+
+define	HD_SBUF		Memi[$1]		# string buffer
+define	HD_NEXTCH	Memi[$1+1]		# index of next char in sbuf
+define	HD_SZSBUF	Memi[$1+2]		# size of string buffer
+define	HD_DEFDIR	Memi[$1+3]		# offset to defdir
+define	HD_NLDIRS	Memi[$1+4]		# number of logical directories
+define	HD_NMODULES	Memi[$1+5]		# number of modules in package
+define	HD_MAXMODULES	Memi[$1+6]		# max no. of modules in package
+define	HD_LENHD	Memi[$1+7]		# length of this structure
+define	HD_PAKNAME	Memi[$1+8]		# offset of package name string
+define	HD_LDIR		Memi[$1+10+$2-1]	# indices of ldir strings
+define	HD_MODULE	($1+60+($2-1)*6)	# module descriptors
+
+# Module descriptor structure.
+
+define	M_NAME		Memi[$1]		# module name index
+define	M_HLP		Memi[$1+1]		# help file index
+define	M_SYS		Memi[$1+2]		# system docs file index
+define	M_SRC		Memi[$1+3]		# source code file index
+define	M_PKG		Memi[$1+4]		# pkg helpdir file index
+define	M_MEN		Memi[$1+5]		# package menu file index

--- a/pkg/softools/mkapropos/helpdir.x
+++ b/pkg/softools/mkapropos/helpdir.x
@@ -1,0 +1,696 @@
+# Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
+
+include	<ctype.h>
+include	<error.h>
+include	"help.h"
+include	"helpdir.h"
+
+.help helpdir
+.nf ___________________________________________________________________________
+HELPDIR -- Routines for accessing helpdir files.  A helpdir lists the
+modules in a package, as well as the files containing the help text and
+source for each module.  There are two kinds of helpdir files: the 'packhelp'
+file lists the packages, and each package has its own helpdir file listing
+the modules within that package.  The following functions are required to
+access help module lists:
+
+	hp =        hd_open (fname)
+		   hd_close (hp)
+
+	modnum = hd_findmod (hp, modname)
+	nchars = hd_getname (hp, modnum, field, outstr, maxch)
+
+The HD_OPEN function opens the helpdir file and decodes the contents, producing
+a binary structure pointed to by hp.  HD_FINDMOD searches for a module by name,
+returning the module number within the helpdir.  HD_GETNAME fetches either
+the module name (field "mod") or a file name (fields "hlp", "sys", etc.).
+File names are returned as OS pathnames, with logical directory expansion taking
+place within the helpdir package.
+
+Helpdir files have the following structure:
+
+	$defdir = pathname|ldir
+	$ldir1  = pathname|ldir
+	$ldir2  = pathname|ldir
+			...
+	$ldirN  = pathname|ldir
+
+	module1 hlp=file, sys=file, src=file, pkg=file, men=file
+	module2 hlp=file, etc.
+			...
+	moduleN hlp=file, etc.
+
+The dollar signs are required to make it easy to distinguish logical directory
+declarations from module entries.  Logical directories defined local to the
+help directory file are not expanded recursively.  If the last nonwhite char
+on a line is a comma, the file list is assumed to be continued on the next
+line.  If two or more files in a module list are the same, all but the first
+may be set to ".." and the last file name given will be used.  Quotes are
+optional.  All file assignments are optional, and they may occur in any order.
+.endhelp _______________________________________________________________________
+
+
+# HD_OPEN -- Open the helpdir file, allocate descriptor and decode file
+# into descriptor.  Sort module list when done, unless sorting is disabled
+# by inclusion of the directive ".nosort" in the text. Ignore comment lines and
+# blank lines.  Ldir declarations and module entries may be given in any
+# order.
+
+pointer procedure hd_open (helpdir_file)
+
+char	helpdir_file[ARB]
+bool	sort_modules
+pointer	sp, hp, ip, lbuf, defdir, word
+int	fd, junk
+
+bool	streq()
+int	open(), getline(), fnroot(), fnldir(), ctowrd()
+pointer	hd_putstr()
+errchk	salloc, open, calloc, malloc, getline, hd_putstr
+errchk	hd_putldiry, hd_putmodule, hd_sort_modules
+
+begin
+	call smark (sp)
+	call salloc (lbuf, SZ_LINE, TY_CHAR)
+	call salloc (defdir, SZ_PATHNAME, TY_CHAR)
+	call salloc (word, SZ_FNAME, TY_CHAR)
+
+	# If helpdir file is not yet installed, print warning message
+	# and return the NULL pointer, indicating that the help directory
+	# could not be loaded.
+
+	iferr (fd = open (helpdir_file, READ_ONLY, TEXT_FILE)) {
+	    call sfree (sp)
+	    call erract (EA_ERROR)
+	    return (NULL)
+	}
+
+	# Allocate and initialize descriptor and string buffer.  Must init
+	# nextch to 1 because 0 is the null index.
+
+	call calloc (hp, LEN_HDSTRUCT, TY_STRUCT)
+	call malloc (HD_SBUF(hp), SZ_SBUF, TY_CHAR)
+	HD_DEFDIR(hp) = NULL
+	HD_NEXTCH(hp) = 1
+	HD_SZSBUF(hp) = SZ_SBUF
+	HD_MAXMODULES(hp) = MAX_MODULES
+	HD_LENHD(hp) = LEN_HDSTRUCT
+	sort_modules = true
+
+	# Extract package name into string buffer.  The package name is assumed
+	# to be the root of the filename.
+
+	junk = fnroot (helpdir_file, Memc[lbuf], SZ_LINE)
+	HD_PAKNAME(hp) = hd_putstr (hp, Memc[lbuf])
+
+	# Extract directory prefix of the package help directory file.  Make
+	# it the default directory prefix for all filenames in the directory.
+
+	if (fnldir (helpdir_file, Memc[defdir], SZ_PATHNAME) == 0) {
+	    call fpathname (helpdir_file, Memc[lbuf], SZ_LINE)
+	    junk = fnldir (Memc[lbuf], Memc[defdir], SZ_PATHNAME)
+	}
+	call sprintf (Memc[lbuf], SZ_LINE, "defdir = %s\n")
+	    call pargstr (Memc[defdir])
+	call hd_putldiry (hp, Memc[lbuf])
+
+	# Compile the file, processing all logical directory definitions,
+	# set option statments, and module declarations. Ignore blank lines
+	# and comment lines.
+
+	while (getline (fd, Memc[lbuf]) != EOF) {
+	    for (ip=lbuf;  IS_WHITE (Memc[ip]);  ip=ip+1)
+		;
+	    if (Memc[ip] == '#' || Memc[ip] == '\n' || Memc[ip] == EOS)
+		next
+
+	    # A leading dollar sign denotes a logical directory declaration.
+	    # A leading period denotes a compiler directive.
+	    # Anything else is a module entry.
+
+	    if (Memc[ip] == '$') {
+		call hd_putldiry (hp, Memc[ip+1])
+	    } else if (Memc[ip] == '.') {
+		ip = ip + 1
+		if (ctowrd (Memc, ip, Memc[word], SZ_FNAME) <= 0)
+		    next
+		# The directive ".nosort" disables sorting of the module list.
+		# There are no other such directives at present, but they are
+		# easy to add.
+		if (streq (Memc[word], "nosort"))
+		    sort_modules = false
+		else {
+		    call eprintf ("Warning: unknown directive %s in helpdir\n")
+			call pargstr (Memc[word])
+		}
+		next
+	    } else
+		call hd_putmodule (hp, fd, Memc[lbuf])
+	}
+
+	# We are all done with the helpdir file, so close it.  Sort module
+	# list alphabetically by name.
+
+	call close (fd)
+	if (sort_modules && HD_NMODULES(hp) > 1)
+	    call hd_sort_modules (hp)
+
+	# Return any unused space in string buffer.
+	call realloc (HD_SBUF(hp), HD_NEXTCH(hp), TY_CHAR)
+	HD_SZSBUF(hp) = HD_NEXTCH(hp)
+
+	# Return any unused module descriptors.
+	HD_LENHD(hp) = HD_LENHD(hp) -
+	    LEN_MODSTRUCT * (HD_MAXMODULES(hp) - HD_NMODULES(hp))
+	HD_MAXMODULES(hp) = HD_NMODULES(hp)
+	call realloc (hp, HD_LENHD(hp), TY_STRUCT)
+
+	call sfree (sp)
+	return (hp)
+end
+
+
+# HD_CLOSE -- Close the helpdir descriptor.  The helpdir file has already
+# been closed; all we need do is return the string buffer and the helpdir
+# descriptor structure.
+
+procedure hd_close (hp)
+
+pointer	hp
+
+begin
+	if (hp != NULL) {
+	    call mfree (HD_SBUF(hp), TY_CHAR)
+	    call mfree (hp, TY_STRUCT)
+	}
+end
+
+
+# HD_PUTLDIRY -- Decode a logical directory declaration and store it away
+# in the descriptor.  We are passed the declaration minus the leading
+# dollar sign.  Format: "variable = string".
+
+procedure hd_putldiry (hp, decl)
+
+pointer	hp
+char	decl[ARB]
+
+int	ip, nldir, strp
+pointer	sp, buf, op
+char	hd_getc()
+int	strncmp(), hd_putstr()
+errchk	salloc, hd_getc, hd_putstr
+
+begin
+	call smark (sp)
+	call salloc (buf, SZ_LINE, TY_CHAR)
+
+	# Do nothing if null declaration.
+	for (ip=1;  IS_WHITE(decl[ip]);  ip=ip+1)
+	    ;
+	if (decl[ip] == '\n' || decl[ip] == EOS || decl[ip] == '#') {
+	    call sfree (sp)
+	    return
+	}
+
+	# Extract "ldir=string", eliminating all whitespace, and deleting
+	# the newline at the end of the statement.  Quotes around the string
+	# are optional and are deleted in hl_getc.
+
+	for (op=buf;  hd_getc (decl, ip, Memc[op]) != EOS;  op=op+1)
+	    if (Memc[op] == '\n')
+		op = op - 1
+
+	# Deposit the "ldir=string" in the string buffer, and set the
+	# appropriate pointers for either defdir or a new ldir.
+
+	strp = hd_putstr (hp, Memc[buf])
+	if (strncmp (Memc[buf], "defdir", 6) == 0)
+	    HD_DEFDIR(hp) = strp
+	else {
+	    nldir = HD_NLDIRS(hp) + 1
+	    if (nldir > MAX_LDIRS)
+		call error (8, "Too many ldir declarations in helpdir")
+	    HD_NLDIRS(hp) = nldir
+	    HD_LDIR(hp,nldir) = strp
+	}
+
+	call sfree (sp)
+end
+
+
+# HD_PUTMODULE -- Put a module declaration into the helpdir descriptor.
+# Start new entry; save module name; process file names.  If line ends
+# in a comma, get a new line.  Print warning if an unknown file type
+# keyword is encountered.
+
+procedure hd_putmodule (hp, fd, lbuf)
+
+pointer	hp
+int	fd
+char	lbuf[ARB]
+
+char	ch
+int	ip, junk, m, ftype, strp
+pointer	sp, buf, op, sbuf, mp
+
+bool	streq()
+char	hd_getc(), hd_peekc()
+int	getline(), ctowrd(), hd_putstr()
+errchk	salloc, getline, hd_putstr, hd_getc
+
+begin
+	call smark (sp)
+	call salloc (buf, SZ_LINE, TY_CHAR)
+	sbuf = HD_SBUF(hp)
+
+	# Fetch module name.  Cannot be null or line is blank and we would
+	# not have been called.
+	ip = 1
+	junk = ctowrd (lbuf, ip, Memc[buf], SZ_LINE)
+
+	# Check if this is a redefinition of a module already defined.
+	# If so, overwrite descriptor of earlier module, else allocate
+	# a new descriptor.
+
+	for (m=1;  m <= HD_NMODULES(hp);  m=m+1) {
+	    mp = HD_MODULE(hp,m)
+	    if (streq (Memc[buf], Memc[sbuf+M_NAME(mp)]))
+		break
+	}
+
+	if (m > HD_NMODULES(hp)) {
+	    # If we are out of space for modules, increase the descriptor
+	    # structure size to allow more module descriptors.
+	    if (m > HD_MAXMODULES(hp)) {
+		HD_LENHD(hp) = HD_LENHD(hp) + (INC_MODULES * LEN_MODSTRUCT)
+		call realloc (hp, HD_LENHD(hp), TY_STRUCT)
+		HD_MAXMODULES(hp) = HD_MAXMODULES(hp) + INC_MODULES
+	    }
+	    HD_NMODULES(hp) = m
+	}
+
+	mp = HD_MODULE(hp,m)
+	call aclri (Memi[mp], LEN_MODSTRUCT)
+
+	# Put module name in string buffer and save index of string in descr.
+	M_NAME(mp) = hd_putstr (hp, Memc[buf])
+
+	# Process file name fields, if any.  Unrecognized file type keywords
+	# cause a warning to be issued.  Redundant entires overwrite old
+	# entries.  Order makes no diff, absence is ok.
+
+	op = buf
+	ftype = TY_UNKNOWN
+	strp = 0
+
+	repeat {
+	    ch = hd_getc (lbuf, ip, ch)
+
+	    switch (ch) {
+	    case '=':
+		# Buffer contains the code word for the file being set.
+		Memc[op] = EOS
+		call strlwr (Memc[buf])
+		if (     streq (Memc[buf], "hlp"))
+		    ftype = TY_HLP
+		else if (streq (Memc[buf], "sys"))
+		    ftype = TY_SYS
+		else if (streq (Memc[buf], "src"))
+		    ftype = TY_SRC
+		else if (streq (Memc[buf], "pkg"))
+		    ftype = TY_PKG
+		else if (streq (Memc[buf], "men"))
+		    ftype = TY_MEN
+		else {
+		    ftype = TY_UNKNOWN
+		    call eprintf ("Warning: bad file type `%s' in helpdir\n")
+			call pargstr (Memc[buf])
+		}
+		op = buf
+
+	    case ',', '\n', EOS:
+		# Buffer contains the file name string.  Put it in the string
+		# buffer and save pointer in appropriate field of module
+		# descriptor.
+
+		Memc[op] = EOS
+
+		# If filename is "..", i.e., "sys=..", the filename is identical
+		# to that last specified.  Use the file name pointer.
+
+		if (streq (Memc[buf], "..")) {
+		    if (strp == 0)
+			call error (9, "helpdir: `..' reference, no prev file")
+		} else
+		    strp = hd_putstr (hp, Memc[buf])
+
+		switch (ftype) {
+		case TY_HLP:
+		    M_HLP(mp) = strp
+		case TY_SYS:
+		    M_SYS(mp) = strp
+		case TY_SRC:
+		    M_SRC(mp) = strp
+		case TY_PKG:
+		    M_PKG(mp) = strp
+		case TY_MEN:
+		    M_MEN(mp) = strp
+		}
+		op = buf
+
+		if (ch == '\n' || ch == EOS)
+		    break				# end of statement
+		else {
+		    # Check for continuation on next line.  Read a new line into
+		    # the buffer if end of line follows comma.
+
+		    if (hd_peekc(lbuf,ip) == '\n' || hd_peekc(lbuf,ip) == EOS) {
+			if (getline (fd, lbuf) == EOF) {
+			    call eprintf ("Unexpected EOF in helpdir file\n")
+			    call sfree (sp)
+			    return
+			}
+			ip = 1
+		    }
+		}
+
+	    default:
+		# Regular character.  Deposit in buffer.
+		if (op >= buf+SZ_LINE)
+		    call error (10, "helpdir: buffer overflow reading modspec")
+		Memc[op] = ch
+		op = op + 1
+	    }
+	}
+
+	call sfree (sp)
+end
+
+
+# HD_GETC -- Get next nonwhite character from the input line.  Leave pointer
+# pointing to next character.  Ignore quotes, so that file name strings can
+# be quoted without penalty.
+
+char procedure hd_getc (lbuf, ip, ch)
+
+char	lbuf[ARB]
+int	ip
+char	ch
+char	hd_peekc()
+
+begin
+	ch = hd_peekc (lbuf, ip)
+	if (ch != EOS)
+	    ip = ip + 1
+	
+	return (ch)
+end
+
+
+# HD_PEEKC -- Peek at the next nonwhite character on a line, but do not
+# advance the input pointer past the character.  Ignore quote characters
+# and comments.
+
+char procedure hd_peekc (lbuf, ip)
+
+char	lbuf[ARB]
+int	ip
+char	ch
+
+begin
+	for (ch=lbuf[ip];  ch != EOS;  ch=lbuf[ip])
+	    if (IS_WHITE(ch) || ch == '\'' || ch == '"') {
+		ip = ip + 1
+	    } else if (ch == '#') {
+		while (lbuf[ip] != '\n' && lbuf[ip] != EOS)
+		    ip = ip + 1
+	    } else
+		break
+	
+	return (ch)
+end
+
+
+# HD_PUTSTR -- Put a string (incl EOS) in the string buffer at nextch.
+# If there is not enough space in the buffer, reallocate a larger buffer.
+# Return the index of the string in the string buffer.
+
+int procedure hd_putstr (hp, str)
+
+pointer	hp
+char	str[ARB]
+int	nextch, nchars, strlen()
+errchk	realloc
+
+begin
+	# Null strings are not stored and cause a null index to be returned.
+	nchars = strlen (str)
+	if (nchars == 0)
+	    return (0)
+
+	nextch = HD_NEXTCH(hp)
+	if (nextch + nchars + 1 > HD_SZSBUF(hp)) {
+	    HD_SZSBUF(hp) = HD_SZSBUF(hp) + INC_SZSBUF
+	    call realloc (HD_SBUF(hp), HD_SZSBUF(hp), TY_CHAR)
+	}
+
+	call strcpy (str, Memc[HD_SBUF(hp) + nextch], ARB)
+	HD_NEXTCH(hp) = nextch + nchars + 1
+
+	return (nextch)
+end
+
+
+# HD_SORT_MODULES -- Sort the module list alphabetically by name.
+# A simple exchange sort is ok because the sort time is negligible
+# compared to all the file accesses, Lroff etc.
+
+procedure hd_sort_modules (hp)
+
+pointer	hp
+
+bool	sorted
+int	nmodules, m, mlen, i, temp
+pointer	sbuf, mp1, mp2
+bool	strgt()
+
+begin
+	nmodules = HD_NMODULES(hp)
+	sbuf = HD_SBUF(hp)
+	mlen = LEN_MODSTRUCT
+	if (nmodules < 2)
+	    return
+
+	repeat {
+	    sorted = true
+	    do m = 1, nmodules-1 {
+		mp1 = HD_MODULE(hp,m)
+		mp2 = mp1 + mlen
+		if (strgt (Memc[sbuf+M_NAME(mp1)], Memc[sbuf+M_NAME(mp2)])) {
+		    do i = 0, mlen-1 {
+			temp = Memi[mp1+i]
+			Memi[mp1+i] = Memi[mp2+i]
+			Memi[mp2+i] = temp
+		    }
+		    sorted = false
+		}
+	    }
+	} until (sorted)
+end
+
+
+# HD_FINDMOD -- Search for the named module and return the module number
+# if found.  Abbreviations are permitted.  An ambiguous abbreviation is
+# an error.
+
+int procedure hd_findmod (hp, modname)
+
+pointer	hp
+char	modname[ARB]
+int	m, namelen, module
+pointer	mp, sbuf
+int	strlen(), strncmp()
+
+begin
+	namelen = strlen (modname)
+	if (namelen == 0)
+	    return (0)
+	module = 0
+	sbuf = HD_SBUF(hp)
+
+	for (m=1;  m <= HD_NMODULES(hp);  m=m+1) {
+	    mp = HD_MODULE(hp,m)
+
+	    if (strncmp (Memc[sbuf+M_NAME(mp)], modname, namelen) == 0) {
+		if (strlen (Memc[sbuf+M_NAME(mp)]) == namelen) {
+		    return (m)				# exact match
+		} else if (module != 0) {
+		    call eprintf ("\n--> %s <--\n")
+			call pargstr (modname)
+		    call error (11, "Ambiguous module name abbreviation")
+		} else
+		    module = m
+	    }
+	}
+
+	return (module)
+end
+
+
+# HD_GETNAME -- Get the module name or a filename.  If a filename is requested,
+# check if filename contains a logical directory reference.  If yes, try to
+# satisfy the reference from the local list of ldirs (but no recursive refs
+# permitted here).  If no, prepend the defdir string.
+
+define	nullstr_	91
+define	nodefdir_	92
+
+int procedure hd_getname (hp, m, field, outstr, maxch)
+
+pointer	hp
+int	m				# module number
+int	field				# field code
+char	outstr[ARB]
+int	maxch
+
+int	len_ldir, op
+pointer	mp, sp, ldir, sbuf, fname_ptr, ip, subdir
+int	strncmp(), gstrcpy(), hd_getldir(), fnldir()
+errchk	salloc, hd_getldir
+
+begin
+	call smark (sp)
+	call salloc (ldir, SZ_PATHNAME, TY_CHAR)
+	call salloc (subdir, SZ_FNAME, TY_CHAR)
+
+	if (hp == NULL)
+	    call error (12, "hd_getname: bad helpdir descriptor")
+
+	if (m < 1 || m > HD_NMODULES(hp)) {
+nullstr_    call sfree (sp)
+	    outstr[1] = EOS
+	    return (0)
+	}
+
+	mp = HD_MODULE(hp,m)
+	sbuf = HD_SBUF(hp)
+
+	switch (field) {
+	case TY_MODNAME:
+	    call sfree (sp)
+	    return (gstrcpy (Memc[sbuf+M_NAME(mp)], outstr, maxch))
+	case TY_HLP:
+	    fname_ptr = M_HLP(mp)
+	case TY_SYS:
+	    fname_ptr = M_SYS(mp)
+	case TY_SRC:
+	    fname_ptr = M_SRC(mp)
+	case TY_PKG:
+	    fname_ptr = M_PKG(mp)
+	case TY_MEN:
+	    fname_ptr = M_MEN(mp)
+	default:
+	    goto nullstr_
+	}
+
+	# If index is zero, no filename was given.
+	if (fname_ptr == 0)
+	    goto nullstr_
+
+	# Get ldir substring, if any, from filename.  If no ldir, prepend
+	# defdir and quit.  Otherwise lookup ldir in local list.  If found,
+	# prepend value.  Otherwise the ldir is a CL global one, and return
+	# filename without modification.  If the given ldir string begins
+	# with "./", substitute the value of defdir for the ".".
+
+	len_ldir = fnldir (Memc[sbuf+fname_ptr], Memc[ldir], SZ_PATHNAME)
+
+	if (len_ldir == 0) {
+	    if (HD_DEFDIR(hp) == 0)
+		goto nodefdir_
+	    for (ip = sbuf + HD_DEFDIR(hp);  Memc[ip] != '=';  ip=ip+1)
+		;
+	    op = gstrcpy (Memc[ip+1], outstr, maxch) + 1
+	    ip = sbuf + fname_ptr
+	} else if (hd_getldir (hp, Memc[ldir], Memc[subdir], SZ_FNAME) == 0) {
+	    op = 1
+	    ip = sbuf + fname_ptr
+	} else {
+	    if (strncmp (Memc[subdir], "./", 2) == 0) {
+		if (HD_DEFDIR(hp) == 0)
+nodefdir_	    call error (13, "Default directory omitted in helpdir")
+		for (ip = sbuf + HD_DEFDIR(hp);  Memc[ip] != '=';  ip=ip+1)
+		    ;
+		op = gstrcpy (Memc[ip+1], outstr, maxch) + 1
+		ip = subdir + 2
+	    } else {
+		op = 1
+		ip = subdir
+	    }
+	    op = op + gstrcpy (Memc[ip], outstr[op], maxch - op + 1)
+	    ip = sbuf + fname_ptr + len_ldir
+	}
+
+	call sfree (sp)
+	return (gstrcpy (Memc[ip], outstr[op], maxch - op + 1))
+end
+
+
+# HD_GETLDIR -- Search the logical directory list for the package helpdir
+# file for the given ldir name.  Return value in output string if found.
+
+int procedure hd_getldir (hp, ldir, outstr, maxch)
+
+pointer	hp
+char	ldir[ARB]
+char	outstr[ARB]
+int	maxch
+
+int	i
+pointer	sp, ip, op, sbuf, envvar, filvar
+bool	streq()
+int	gstrcpy()
+
+begin
+	call smark (sp)
+	call salloc (envvar, SZ_FNAME, TY_CHAR)
+	call salloc (filvar, SZ_FNAME, TY_CHAR)
+
+	sbuf = HD_SBUF(hp)
+
+	# Ldir string has the form "ldir$".  Extract the ldir name into the
+	# filvar buffer, omitting the $ delimiter.
+	i = 1
+	for (op=filvar;  ldir[i] != '$' && ldir[i] != EOS;  op=op+1) {
+	    Memc[op] = ldir[i]
+	    i = i + 1
+	}
+	Memc[op] = EOS
+
+	for (i=1;  i <= HD_NLDIRS(hp);  i=i+1) {
+	    # Extract the helpdir env variable name into the envvar buffer,
+	    # stopping when the '=' is reached.
+
+	    ip = sbuf + HD_LDIR(hp,i)
+	    for (op=envvar;  Memc[ip] != '=';  op=op+1) {
+		if (Memc[ip] == EOS)
+		    call error (14, "helpdir: missing '=' in ldir declaration")
+		Memc[op] = Memc[ip]
+		ip = ip + 1
+	    }
+	    Memc[op] = EOS
+
+	    # Return whatever follows the '=' if we have a match.  The input
+	    # pointer is left pointing at the '='.
+
+	    if (streq (Memc[filvar], Memc[envvar])) {
+		call sfree (sp)
+		return (gstrcpy (Memc[ip+1], outstr, maxch))
+	    }
+	}
+
+	outstr[1] = EOS
+	call sfree (sp)
+	return (0)
+end

--- a/pkg/softools/mkapropos/mkpkg
+++ b/pkg/softools/mkapropos/mkpkg
@@ -1,0 +1,13 @@
+# mkapropos mkpkg file (Wed Aug 31 16:58:39 CST 2016)
+
+$checkout libpkg.a ../
+$update   libpkg.a
+$checkin  libpkg.a ../
+$exit
+
+libpkg.a:
+	t_mkapropos.x	"help.h" "helpdir.h" <error.h> <syserr.h>
+        helpdir.x       "help.h" "helpdir.h" <ctype.h> <error.h>
+	strext.x	<ctype.h>
+	word.x
+	;

--- a/pkg/softools/mkapropos/strext.x
+++ b/pkg/softools/mkapropos/strext.x
@@ -1,0 +1,47 @@
+include	<ctype.h>
+
+# STREXT - Extract a word (delimited substring) from a string.
+# The input string is scanned from the given initial value until one
+# of the delimiters is found. The delimiters are not included in the
+# output word.
+# Leading white spaces in a word may be optionally skipped. White 
+# spaces are skipped before looking at the delimiters string, so it's
+# possible to remove leading white spaces and use them as delimiters
+# at the same time.
+# The value returned is the number of characters in the output string.
+# Upon return, the pointer is located at the begining of the next word.
+
+int procedure strext (str, ip, dict, skip, outstr, maxch)
+
+char	str[ARB]			# input string
+int	ip				# pointer into input string
+char	dict[ARB]			# dictionary of delimiters
+int	skip				# skip leading white spaces ?
+char	outstr[ARB]			# extracted word
+int	maxch				# max number of chars
+
+int	op
+int	stridx()
+
+begin
+	# Skip leading white spaces
+	if (skip == YES) {
+	    while (IS_WHITE (str[ip]))
+		ip = ip + 1
+    	}
+
+	# Process input string
+	for (op=1;  str[ip] != EOS && op <= maxch;  op=op+1)
+	    if (stridx (str[ip], dict) == 0) {
+		outstr[op] = str[ip]
+		ip = ip + 1
+	    } else {
+		repeat {
+		    ip = ip + 1
+		} until (stridx (str[ip], dict) == 0 || str[ip] == EOS)
+		break
+	    }
+
+	outstr[op] = EOS
+	return (op - 1)
+end

--- a/pkg/softools/mkapropos/t_mkapropos.x
+++ b/pkg/softools/mkapropos/t_mkapropos.x
@@ -1,0 +1,307 @@
+include	<syserr.h>
+include	<error.h>
+include	"help.h"
+include	"helpdir.h"
+
+define	MAX_DEPTH	20		# max nesting of packages
+
+
+# T_MKAPROPOS -- Make the apropos database.
+
+procedure t_mkapopos()
+
+bool	verbose
+pointer	sp, helpdir, hlpdir, aproposdb, tempname, pkglist
+int 	ic				# list counter for word_fetch 
+int 	fc				# File counter
+int	access()
+bool	clgetb()
+int	word_fetch()
+
+begin
+	call smark (sp)
+	call salloc (pkglist, SZ_PATHNAME + 1, TY_CHAR)
+	call salloc (hlpdir, SZ_FNAME + 1, TY_CHAR)
+	call salloc (helpdir, SZ_FNAME + 1, TY_CHAR)
+	call salloc (aproposdb, SZ_FNAME + 1, TY_CHAR)
+	call salloc (tempname, SZ_FNAME + 1, TY_CHAR)
+
+	# Fetch the names of the packages 
+	# and the new database file.
+	call clgstr ("pkglist", Memc[pkglist], SZ_PATHNAME)
+	call clgstr ("helpdir", Memc[hlpdir], SZ_FNAME)
+	call clgstr ("aproposdb", Memc[aproposdb], SZ_FNAME)
+
+	# Get verbose flag and echo parameters
+	verbose = clgetb ("verbose")
+	if (verbose) {
+	    call printf ("helpdir = %s\n")
+		call pargstr (Memc[helpdir])
+	    call printf ("aproposdb = %s\n")
+		call pargstr (Memc[aproposdb])
+	    call flush (STDOUT)
+	}
+
+	# The database is compiled into a temporary file to protect the current
+	# database in the event the compile is aborted.  When the compile has
+	# successfully completed we will delete the original and replace it
+	# with the new database.  This also has the advantage that the switch
+	# takes very little time, making it less likely that anyone will notice
+	# when the database is updated.
+
+	call mktemp ("tmp$hdb", Memc[tempname], SZ_FNAME)
+
+	# Now, for each package on the list, build the file name for the root
+	# helpdb and Compile the help strings
+
+	ic=1	
+	fc=1
+	while(word_fetch (Memc[pkglist], ic, Memc[helpdir], SZ_PATHNAME) > 0 ) {
+	    # Append the help directory to the package name
+	    call strcat ("$", Memc[helpdir], SZ_FNAME)
+	    call strcat (Memc[hlpdir], Memc[helpdir], SZ_FNAME)
+	    # Perform the compilation.
+	    call app_compile (Memc[helpdir], Memc[tempname], fc, verbose)
+	}
+
+	# Now attempt to delete the old database and replace it with the new.
+	# If the old file cannot be deleted we delete the new database and
+	# abort.
+
+	    if (access (Memc[aproposdb], 0, 0) == YES) {
+	         iferr (call delete (Memc[aproposdb])) {
+	            call delete (Memc[tempname])
+	            call erract (EA_ERROR)
+	        }
+	    }
+
+	call rename (Memc[tempname], Memc[aproposdb])
+	call sfree (sp)
+end
+
+
+# APP_COMPILE - Compile the help directory file, and generate the apropos
+# databse.
+
+procedure app_compile (root_helpdir_file, app_db, fc, verbose)
+
+char	root_helpdir_file[ARB]	# name of root help directory file
+char	app_db[ARB]		# output apropos database name
+bool	verbose			# print notes on structure of database
+
+bool	found_a_subpackage
+pointer	hp_stk[MAX_DEPTH]	# help directory pointer stack
+int	pk_stk[MAX_DEPTH]	# subpackage index stack
+char	fname[SZ_FNAME]		# helpdir filename
+int	fd, sp, pk, fc
+pointer	hp, modname
+
+int	hd_getname()
+int	open(), access()
+pointer	hd_open()
+errchk	hd_getname
+
+begin
+	# Initialize the stacks and current file name
+	# processed, i.e., the root directory file.
+	sp = 0
+	pk = 1
+	call strcpy (root_helpdir_file, fname, SZ_FNAME)
+
+	# Open root help file
+	iferr (hp = hd_open (root_helpdir_file)) {
+		call printf ("file: %s")
+		call pargstr (root_helpdir_file) 
+		call error (0, "cannot open root help directory file")
+	}
+
+	# Open output file name
+	    if (fc == 1) {	
+	    iferr (fd = open (app_db, NEW_FILE, TEXT_FILE))
+	        call error (0, "cannot open apropos database file")
+	    fc=2
+	    } else {
+	        iferr (fd = open (app_db, APPEND, TEXT_FILE))
+	        call error (0, "cannot open apropos database file")
+	    }
+	# We enter the compile loop ready to scan the next help directory file,
+	# which has been pushed onto the top of the stack.  The help directory
+	# file is first entered into the database, then we scan the directory
+	# until a subdirectory is found.  If a subdirectory is found it is
+	# opened and pushed onto the stack and the process repeats (hd_open
+	# does not leave the physical file open so running out of file
+	# descriptors is not a problem).  When the end of a directory is
+	# reached the stack is popped, closing the current directory, and 
+	# we continue to scan the previous directory until another subdirectory
+	# is found.
+
+	repeat {
+	    call printf ("%3d %15s (%s): %d help modules\n")
+		call pargi (sp + 1)
+		if (HD_PAKNAME (hp) != NULL)
+		    call pargstr (Memc[HD_SBUF (hp) + HD_PAKNAME (hp)])
+		else
+		    call pargstr ("")
+		call pargstr (fname)
+		call pargi (HD_NMODULES (hp))
+	    call flush (STDOUT)
+
+	    # Now scan the directory for subdirectories.  If one is found,
+	    # open it and push it on the stack, otherwise pop the stack and
+	    # resume scanning the previous directory.
+
+	    repeat {
+		# Search for a module which is a subpackage.
+		found_a_subpackage = false
+		for (;  pk <= HD_NMODULES(hp);  pk=pk+1) {
+		    if (verbose) {
+			modname = M_NAME(HD_MODULE(hp,pk))
+			call printf ("\t\t[%d.%02d] %s\n")
+			    call pargi (sp + 1)
+			    call pargi (pk)
+			    call pargstr (Memc[HD_SBUF(hp) + modname])
+		    }
+		    if (hd_getname (hp, pk, TY_PKG, fname, SZ_FNAME) > 0) {
+			found_a_subpackage = true
+			break
+		    } 
+		}
+
+		if (found_a_subpackage) {
+		    if (access (fname, READ_ONLY, TEXT_FILE) == NO) {
+			call printf ("\t\t%4w(cannot access '%s')\n")
+			    call pargstr (fname)
+			# ...and continue searching the current helpdir
+			pk = pk + 1
+
+		    } else {
+			# Got one; push it on the stack.  Bump PK so that we
+			# resume scanning the package with the module following
+			# the subpackage.
+			sp = sp + 1
+			if (sp > MAX_DEPTH)
+			    call fatal (3, "packages nested too deeply")
+			hp_stk[sp] = hp
+			pk_stk[sp] = pk + 1
+			iferr (call app_men (fd, hp_stk, pk_stk, sp))
+			    call erract (EA_WARN)
+			iferr (hp = hd_open (fname)) {
+			    hp = hp_stk[sp]
+			    sp = sp - 1
+			    call printf ("cannot open helpdir '%s'\n")
+				call pargstr (fname)
+			    next
+			}
+			pk = 1
+			break			# go process new helpdir
+		    }
+
+		} else {
+		    # Helpdir has been exhausted.  Close it and pop the
+		    # stack, continue scanning on the previous helpdir.
+
+		    call hd_close (hp)
+		    if (sp > 0) {
+			hp = hp_stk[sp]
+			pk = pk_stk[sp]
+			sp = sp - 1
+			if (verbose)
+			    call printf ("\t\t\t[end of package]\n")
+		    } else {
+			call close (fd)
+			return			# ALL DONE
+		    }
+		}
+		call flush (STDOUT)
+	    }
+	}
+end
+
+
+# APP_MEN - Write a menu file in a proper format to the output file.
+
+procedure app_men (ofd, hp_stk, pk_stk, sp)
+
+int	ofd			# output file descritor
+int	hp_stk[ARB]		# help descriptors stack
+int	pk_stk[ARB]		# current package number
+int	sp			# stack pointer
+
+char	fname[SZ_FNAME]
+char	pkname[SZ_FNAME]
+char	pkpath[SZ_LINE]
+char	line[SZ_LINE]
+char	name[SZ_LINE]
+char	text[SZ_LINE]
+int	fd			# output file descriptor
+int	i, ip, pk, pkindex
+pointer	hp
+
+bool	streq(), strne()
+int	open(), fscan()
+int	hd_getname()
+int	stridx(), stridxs(), strext()
+errchk	open(), fscan(), hd_getname()
+
+begin
+	# Get help structure and package
+	# index from top of stack
+	hp = hp_stk[sp]
+	pk = pk_stk[sp] - 1
+
+	# Get name of menu file for the package
+	if (hd_getname (hp, pk, TY_MEN, fname, SZ_FNAME) > 0) {
+
+	    # Build package path
+	    call strcpy ("", pkpath, SZ_LINE)
+	    do i = 1, sp {
+
+		# Get package name
+		hp = hp_stk[i]
+		pk = pk_stk[i] - 1
+		pkindex = M_NAME (HD_MODULE( hp, pk))
+		call strcpy (Memc[HD_SBUF (hp) + pkindex], pkname, SZ_LINE)
+
+		# Throw away the first component if it begins
+		# with an underscore.
+		if (i == 1 && stridx ("_", pkname) == 1)
+		    next
+
+		# Compress the name "clpackage" to "cl" to make
+		# it more familiar to the user.
+		if (streq (pkname, "clpackage"))
+		    call strcpy ("cl", pkname, SZ_LINE)
+
+		# Concatenate the package name delimited with
+		# a colon, if necessary. 
+		if (strne (pkpath, ""))
+		    call strcat (".", pkpath, SZ_LINE)
+		call strcat (pkname, pkpath, SZ_LINE)
+	    }
+
+	    # Try to open menu file
+	    fd = open (fname, READ_ONLY, TEXT_FILE)
+	    while (fscan (fd) != EOF) {
+
+		# Read line from file and split it
+		# into components
+		call gargstr (line, SZ_LINE)
+		if (stridxs (line, "-*") > 0) {
+		    ip = 1
+		    if (strext (line, ip, " -*", YES, name, SZ_LINE) == 0)
+			next
+		    if (strext (line, ip, "", YES, text, SZ_LINE) == 0)
+			next
+		} else
+		    next
+		    
+	        call fprintf (ofd, "%10s - %s (%s)\n")
+		    call pargstr (name)
+		    call pargstr (text)
+		    call pargstr (pkpath)
+	    }
+
+	    # Close input file
+	    call close (fd)
+	}
+end

--- a/pkg/softools/mkapropos/word.x
+++ b/pkg/softools/mkapropos/word.x
@@ -1,0 +1,229 @@
+# Definition of delimeters used in parsing words
+
+define	IS_DELIM	(($1) <= ' ' || ($1) == ',')
+define	NOT_DELIM	(($1) > ' ' && ($1) != ',')
+
+.help
+.nf_________________________________________________________________________
+
+The procedures in this file perform simple processing on lists of
+words.  These procedures count the number of words in a list, fetch
+the next word in a list, find the n-th word in a list, check for an
+exact match between a word and a list of words.  A word is any group
+of contiguous characters which are neither whitespace or commas. The
+definition of whitespace is anomalous, it includes any character whose
+integer value is less than or equal to a blank. Note that words cannot
+be delimeted by quotes and that escape processing is not done.
+
+.endhelp____________________________________________________________________
+
+#______________________________HISTORY______________________________________
+#
+# B.Simon	20-Apr-1990	Modified versions of CDBS routines adb_*tok.x
+#
+#___________________________________________________________________________
+
+# WORD_COUNT -- Return the number of words in a list of words
+
+int procedure word_count (list)
+
+char	list[ARB]	# i: List of words
+#--
+char	ch
+int	count, ic
+
+begin
+
+	# The absolute value of count is the number of the current
+	# word of the list, count is negative if we are currently
+	# between words.
+
+	count = 0
+
+	# Loop over all characters in the list
+
+	for (ic = 1 ; list[ic] != EOS; ic = ic + 1) {
+	    ch = list[ic]
+
+	    if (count > 0) {
+		if (IS_DELIM(ch))
+		    count = - count
+
+	    } else if (NOT_DELIM(ch)) {
+		count = - count + 1
+	    }
+	}
+
+	return (abs(count))
+end
+
+# WORD_FETCH -- Retrieve next word from string
+
+int procedure word_fetch (str, ic, word, maxch)
+
+char	str[ARB]	#  i: String containing words
+int	ic		# io: Index of starting character
+char	word[ARB]	#  o: Word string
+int	maxch		#  i: Declared length of output string
+#--
+char	ch
+int	jc
+
+begin
+	# Skip leading whitespace or commas. Don't go past string terminator.
+
+	for (ch = str[ic]; IS_DELIM(ch); ch = str[ic]) {
+	    if (ch == EOS)
+		break
+	    ic = ic + 1
+	}
+
+	# Copy characters to word. End when maxch is reached, or
+	# when commas, whitespace, or EOS is found
+
+	for (jc = 1; jc <= maxch; jc = jc + 1) {
+	    if (IS_DELIM(ch))
+		break
+
+	    word[jc] = ch
+	    ic = ic + 1
+	    ch = str[ic]
+	}
+	word[jc] = EOS
+
+	# If loop is terminated because of maxch, eat remaining characters
+	# in field
+
+	while (NOT_DELIM(ch)) {
+	    ic = ic + 1
+	    ch = str[ic]
+	}
+
+	# Return number of characters in word
+
+	return (jc - 1)
+
+end
+
+# WORD_FIND -- Find the i-th word in a list of words
+
+int procedure word_find (index, list, word, maxch)
+
+int	index		# i: Index to word within list
+char	list[ARB]	# i: List of words
+char	word[ARB]	# o: Word returned by this procedure
+int	maxch		# i: Declared length of output string
+#--
+char	ch
+int	count, ic, jc
+
+begin
+	# The absolute value of count is the number of the current
+	# word of the list, count is negative if we are currently
+	# between words
+
+	count = 0
+
+	# Loop until i-th word is reached in list
+
+	for (ic = 1 ; count < index && list[ic] != EOS; ic = ic + 1) {
+	    ch = list[ic]
+
+	    if (count > 0) {
+		if (IS_DELIM(ch))
+		    count = - count
+
+	    } else if (NOT_DELIM(ch)) {
+		count = - count + 1
+	    }
+	}
+
+	# If index is out of bounds, return zero
+
+	if (index < 0 || index > count)
+	    return (0)
+
+	jc = 1
+	for (ic = ic - 1; NOT_DELIM(list[ic]); ic = ic + 1) {
+	    if (jc > maxch)
+		break
+
+	    word[jc] = list[ic]
+	    jc = jc + 1
+	}
+	word[jc] = EOS
+
+	# Return number of characters in word
+
+	return (jc - 1)
+end
+
+# WORD_MATCH -- Return number of the word in the list which matches the word
+
+int procedure word_match (word, list)
+
+char	word[ARB]	# i: Word to be matched
+char	list[ARB]	# i: List of words
+#--
+char	ch
+int	match, inword, ic, jc
+
+begin
+	# The absolute value of inword is the number of the current
+	# word of the list, inword is negative if we are currently
+	# between words in the list
+
+	jc = 1
+	match = 0
+	inword = 0
+
+	# Loop over all characters in the list
+
+	for (ic = 1 ; list[ic] != EOS; ic = ic + 1) {
+	    ch = list[ic]
+
+	    # First case: current character is within a word
+
+	    if (inword > 0) {
+
+		# Check for conversion to second case
+
+		if (IS_DELIM(ch)) {
+		    inword = - inword
+
+		    # Simultaneous end of word in list and word 
+		    # means a match has been found
+
+		    if (match != 0 && word[jc] == EOS)
+			break
+		    else
+			match = 0
+
+		} else if (match != 0) {
+
+		    # Check for match between list and word
+
+		    if (ch == word[jc])
+			jc = jc + 1
+		    else 
+			match = 0
+		}
+
+	    # Second case: current character is between words
+	    # Check for conversion to first case
+
+	    } else if (NOT_DELIM(ch)) {
+		jc = 1
+		ic = ic - 1
+		inword = - inword + 1
+		match = inword
+	    }
+	}
+
+	# If list ended before word, there was no match
+
+	if (word[jc] != EOS)
+	    match = 0
+
+	return (match)
+end

--- a/pkg/softools/mkpkg
+++ b/pkg/softools/mkpkg
@@ -16,9 +16,11 @@ relink:
 
 install:
 	$move	xx_softools.e bin$x_softools.e
+	;
 
 libpkg.a:
 	memchk.x        <ctype.h>
 	mktags.x        <ctotok.h> <ctype.h> <error.h>
 	tgutil.x        <ctotok.h> <ctype.h> <error.h>
+	@mkapropos
 	;

--- a/pkg/softools/softools.cl
+++ b/pkg/softools/softools.cl
@@ -14,7 +14,8 @@ task	$generic,
 	$xyacc		= "$foreign"
 
 task	mktags,
-	memchk		= "softools$x_softools.e"
+	memchk,
+	mkapropos	= "softools$x_softools.e"
 
 task	mkttydata	= "softools$x_mkttydata.e"
 task	mkmanpage	= "softools$mkmanpage.cl"

--- a/pkg/softools/softools.hd
+++ b/pkg/softools/softools.hd
@@ -2,10 +2,12 @@
 
 $help		= "pkg$system/help/"
 $lroff		= "pkg$system/help/lroff/"
+$mkapropos	= "pkg$softools/mkapropos/"
 
 generic		hlp = host$boot/generic/generic.hlp
 hdbexamine	hlp = help$hdbexamine.hlp
 lroff		hlp = lroff$lroff.hlp
+mkapropos	hlp = mkapropos.hlp, src=mkapropos$t_mkapropos.x
 mkhelpdb	hlp = help$mkhelpdb.hlp
 mkmanpage	hlp = mkmanpage.hlp
 mkpkg		hlp = host$boot/mkpkg/mkpkg.hlp

--- a/pkg/softools/softools.men
+++ b/pkg/softools/softools.men
@@ -2,6 +2,7 @@
      hdbexamine - Examine a help database
 	  lroff - Lroff (line-roff) text formatter
 	 memchk - Process a memdbg mem.log file for errors
+      mkapropos - Make the apropos database (from STSDAS).
        mkhelpdb - Make (compile) a help database
       mkmanpage - Make a manual page
 	  mkpkg - Make or update an object library or package

--- a/pkg/softools/x_softools.x
+++ b/pkg/softools/x_softools.x
@@ -3,4 +3,5 @@
 # Link the SOFTOOLS package.
 
 task	mktags		= t_mktags,
-	memchk		= t_memchk
+	memchk		= t_memchk,
+	mkapropos	= t_mkapropos

--- a/pkg/system/apropos.cl
+++ b/pkg/system/apropos.cl
@@ -1,0 +1,66 @@
+procedure apropos ( topic )
+
+string	topic {prompt = ">Apropos ? ", mode="ql"}
+file	index = "aproposdb" {prompt=">index to search"}
+
+begin
+
+string csubject, dblist, fname, pvar
+int len, n, iend
+bool var_ok
+
+	# Remove case sensitivity
+	csubject = "{"//topic//"}"
+
+	# As a special case, if we're given the name of the "aproposdb"
+	# environment variable then get the list of database filenames
+	# from that:
+	if (index == "aproposdb") {
+		if (defvar("aproposdb")) {
+			dblist = envget("aproposdb")
+		} else {
+			error(1, "variable aproposdb is not set!")
+		}
+	} else {
+		dblist = index
+	}
+	
+	len = strlen(dblist)
+
+	# Loop over the database filenames in the list:
+	while (len > 0) {
+
+		# Parse next name and remove it from the start of the list:
+		iend = stridx(",", dblist) - 1
+		if (iend < 0) iend = len     # no more commas; use what's left
+		fname = substr(dblist, 1, iend) # parse next filename
+		if (iend > len-2) {          # no more filenames; empty list
+			dblist=""
+		} else {                     # still have another file
+			dblist = substr(dblist, iend+2, len)
+		}
+		len = strlen(dblist)
+
+		# Extract any path variable and check that it exists,
+		# otherwise IRAF will complain:
+		var_ok = yes
+		iend = stridx("$", fname) - 1
+		if (iend > -1) {
+			pvar = substr(fname, 1, iend)
+			if (!defvar(pvar))
+				var_ok = no
+		}
+
+		# Try to match the query if the database file exists:
+		if (var_ok)
+			if (access(fname)) {
+
+				# Print any matches in this database file:
+				match ( csubject, fname, stop=no, meta=yes, \
+					print_file_names=no)
+
+			}
+
+	} # while loop over database files
+
+end

--- a/pkg/system/system.cl
+++ b/pkg/system/system.cl
@@ -50,6 +50,8 @@ task	$devices	= "system$devices.cl"
 task	references	= "system$references.cl"
 task	phelp		= "system$phelp.cl"
 
+task	apropos		= "system$apropos.cl"
+
 hidetask mtclean
 
 keep

--- a/unix/hlib/extern.pkg
+++ b/unix/hlib/extern.pkg
@@ -7,11 +7,13 @@ reset	extern		= iraf$extern/
 # Initialize the helpdb string.  We'll add to this when dyanamically 
 # loading packages when the next load the CLPACKAGE.
 reset	helpdb		= "lib$helpdb.mip"
+reset   aproposdb       = "lib$apropos.db"
 
 if (access ("iraf$noao/noao.cl") == yes) {
     reset	noao		= iraf$noao/
     task	noao.pkg	= noao$noao.cl
     reset	helpdb		= (envget("helpdb") // ",noao$lib/helpdb.mip")
+    reset	aproposdb       = (envget("aproposdb") + ",noao$lib/apropos.db" )
 }
 ;
 if (access ("iraf$vo/vo.cl") == yes) {


### PR DESCRIPTION
`apropos` searches the documentation for a given keyword. This patch also includes the tasks required to build the apropos database.

 This is taken from the STSCI Ureka svn tree, mostly from adbb8e6589867f63b4844b05fd8d3faa2ea35aff committed by @jehturner.