### PR TITLE
votable: Fix data type of loop variable

### DIFF
--- a/vendor/libvotable/votHandle.c
+++ b/vendor/libvotable/votHandle.c
@@ -92,7 +92,7 @@ vot_lookupHandle (Element *elem)
 handle_t
 vot_setHandle (Element *elem)
 {
-    unsigned int i = 0;
+    int i = 0;
     Element **old_handles;
     
     if (elem == NULL)


### PR DESCRIPTION
The loop variable is [counted down as long as it is not negative](https://github.com/iraf-community/iraf/blob/667d7eba16e599d3fc75492e8648d36c950388db/vendor/libvotable/votHandle.c#L113). This however requires the variable to be a signed `int`.