### PR TITLE
Fix variable declaration in noao/obsutil/src/findgain.cl

### DIFF
--- a/noao/obsutil/src/findgain.cl
+++ b/noao/obsutil/src/findgain.cl
@@ -33,7 +33,7 @@ string	*fd
 begin
 	bool	err
 	file	f1, f2, z1, z2, lf1, lf2, lz1, lz2
-	file	flatdiff, zerodiff, statsfile
+	file	flatdif, zerodif, statsfile
 	real	e_per_adu, readnoise, m_f1, m_f2, m_b1, m_b2, s_fd, s_bd, junk
 	struct	images
 


### PR DESCRIPTION
Closes #46 - Thanks to @dxwayne for the fix!

Quoting:

> Cause: The variables are declared with one spelling, the code attempts to work with a slightly different spelling. This is one fix: may choose to alter the few more lines to use the original spelling.
> 
> test:
> ```
> findgain flat1.fits flat2.fits zero1.fits zero2.fits section="[650:750,650:750]"
> ```
> where the fits files are zeros/flats at least this big.
> 