### PR TITLE
Upload binary packages for MacOS X to github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
             - libreadline-dev:i386
     - os: osx
       osx_image: xcode10
-      env: IRAFARCH=macintel OS_VERS=highsierra
+      env: IRAFARCH=macintel OS_VERS=highsierra TARFILE=iraf.macintel.tar.gz
     - os: osx
       osx_image: xcode6.4
       env: IRAFARCH=macintel OS_VERS=yosemite
@@ -70,3 +70,19 @@ before_script:
 
 script:
   - ./test/run_tests
+
+before_deploy:
+ - git checkout unix/hlib/
+ - tar --exclude ${TARFILE} -czf ${TARFILE} *
+ - ls -l
+
+deploy:
+  provider: releases
+  api_key:
+    secure: dGZRYkRPIz1jcJa8CGBc54eyqUx+7x2yHoezF4IWnl83dU1NC95/zretldXuQ5SP4ksRGp+TMnsH1x8hvaC3qd9G2ZXYnsKTAfWvRThXZW1LA8B1kEZfLikz0rBs7bw7qQirpdy64S0VAooeav4sTF7CHdqXCjqgQNlD/FGDwYKLOxhUq30YBDeCYOMn/CvvumQmwhynd74eTueCykEGFcVJe8k08+AS3V8N4AhN6gger9W2bZVxhPPaxUx1qyHurDAj+fq89QtOHwh+sq7VK7hDMmB2mfQvfekesUb0WUWx5VoNhHb+NzCfOWgaw0VKSQYuFte6Wy4xTTpyPr0H4AO8kGWFIn9fF/F41mQB+EtFZk0Cf84+rHgzUKn2wxr0nQUGUEmbeUT+gdyC5myegc5E6FThnPmbsTX8sebDj5VJP1ptJgeStJA0mD2C+mU86dU/nzLVjm8YApj7vxzs3k02DUmfayCcnUbZ8byBtxL5or0Wu70YJdJ7K0YDb09ABKJm/7oGNZHt6aTef2yxb/2iick8EsQxehT4qaqAypVcPHyalL9CsjEjAKYygCkhh/seVyeT37WB54k8G4fDuGYKLhO5If/E6igaZECcQaff5RQkw1a10ZHuWfC4hHOOGrA2i/g+JhHAasofeoHNq4W6dp8ymfV2/HmIb6feC/k=
+  file: ${TARFILE}
+  skip_cleanup: true
+  overwrite: true
+  on:
+    tags: true
+    condition: ${TARFILE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      env: IRAFARCH=linux64 OS_VERS=trusty
+      env: IRAFARCH=linux64 OS_VERS=trusty CARCH="-fpie"
       addons:
         apt:
           packages:
@@ -18,7 +18,7 @@ matrix:
             - libreadline-dev
     - os: linux
       dist: trusty
-      env: IRAFARCH=linux OS_VERS=trusty CARCH="-m32"
+      env: IRAFARCH=linux OS_VERS=trusty CARCH="-m32 -fpie"
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
             - libreadline-dev:i386
     - os: osx
       osx_image: xcode10
-      env: IRAFARCH=macintel OS_VERS=highsierra TARFILE=iraf.macintel.tar.gz
+      env: IRAFARCH=macintel OS_VERS=highsierra MACOSX_DEPLOYMENT_TARGET=10.5 TARFILE=iraf.macintel.tar.gz
     - os: osx
       osx_image: xcode6.4
       env: IRAFARCH=macintel OS_VERS=yosemite

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
       addons:
         apt:
           packages:
+            - libcurl4-openssl-dev
+            - libexpat-dev
             - libreadline-dev
     - os: linux
       dist: precise
@@ -22,7 +24,7 @@ matrix:
           packages:
             - gcc-multilib
             - libcurl4-openssl-dev:i386
-            - libexpat1-dev:i386
+            - libexpat-dev:i386
             - libreadline-dev:i386
     - os: linux
       dist: precise
@@ -32,7 +34,7 @@ matrix:
           packages:
             - gcc-multilib
             - libcurl4-openssl-dev:i386
-            - libexpat1-dev:i386
+            - libexpat-dev:i386
             - libreadline-dev:i386
     - os: osx
       osx_image: xcode10

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,27 +13,58 @@ and in the file name.
 ## System Requirements and Dependencies
 
 The distributed binaries require the readline or libedit, curl, and
-expat libraries to be installed.
+expat libraries to be installed. For full functionality and for
+installation from source, additionally the C compiler, the make
+program, flex, and the development versions are required.
 
 On Debian and its derivatives (Ubuntu, Mint, Devuan, Raspbian etc.):
 
-    $ sudo apt install gcc make flex
     $ sudo apt install libcurl4-openssl-dev libexpat-dev libreadline-dev
+    $ sudo apt install gcc make flex
 
 On Fedora and its derivatives (Redhat, Scientific Linux etc.)
 
-    $ sudo dnf install gcc make perl flex
     $ sudo dnf install libcurl-devel expat-devel readline-devel
+    $ sudo dnf install gcc make perl flex
 
-On MacOS X, you need to have the XCode tools installed. If you
-haven't, you can install them with:
+On MacOS X, you need to have the XCode tools installed to build from
+source. If you haven't, you can install them with:
 
     $ xcode-select --install
 
 Click "Install" to download and install Xcode Command Line Tools.
 
 
-## Unpack the IRAF Distribution
+## Install a Binary Distribution
+
+The binary distribution file is built as a tarball of the toplevel
+IRAF directory, i.e. they should be unpacked in a directory the user
+creates. Thus, distribution files can be unpacked with the command
+
+    $ mkdir iraf.v2161
+    $ cd iraf.v2161
+    $ tar xzf /<path>/iraf.<arch>.tar.gz
+
+To install IRAF for personal use, execute the install script:
+
+    $ ./install
+
+Answer the prompts, in most cases simply accepting the defaults will
+be all that is needed.
+
+To install IRAF as root for system wide use, execute the install
+script with root permissions:
+
+    $ sudo ./install --system
+
+This will create a system installation of IRAF for all users of the
+machine.  Root permissions are required in order to write to system
+directories.
+
+IRAF is then immediately available by typing `cl`.
+
+
+## Build from Sources
 
 The source distribution file is built as a tarball with the package
 name and version as base directory. Thus, distribution files can be
@@ -41,9 +72,6 @@ unpacked with the command
 
     $ tar zxf /<path>/iraf-2.16.1-2018.06.15.tar.gz
     $ cd iraf-2.16.1-2018.06.15/
-
-
-## Build from Sources
 
 In the source directory, execute the install script to create needed
 links:
@@ -60,7 +88,7 @@ and build:
 For `<arch>`, use the proper IRAF architecture name:
 
 `<arch>`   | Operating system | CPU
------------|------------------|--------------------
+-----------|------------------|---------------------------------------
 `linux64`  | Linux 64 bit     | x86_64, arm64, mips64, ppc64, riscv64
 `linux`    | Linux 32 bit     | i386, x32, arm, mips
 `macintel` | Mac OS X 64 bit  | x86_64

--- a/unix/hlib/irafuser.sh
+++ b/unix/hlib/irafuser.sh
@@ -30,10 +30,6 @@ export HSI_F77LIBS=""
 export HSI_LFLAGS=""
 export HSI_OSLIBS=""
 
-if [ "$MACH" = "macosx" ] ; then
-    export MACOSX_DEPLOYMENT_TARGET=10.5
-fi
-
 # The following determines whether or not the VOS is used for filename mapping.
 if [ -f "${iraf}lib/libsys.a" ]; then
 	export	HSI_LIBS="${hlib}libboot.a ${iraf}lib/libsys.a ${iraf}lib/libvops.a ${hlib}libos.a ${hbin}libf2c.a -lm"

--- a/vendor/mklibs
+++ b/vendor/mklibs
@@ -29,7 +29,7 @@ if [ $build_cfitsio = 1 ] ; then
     printf "    Building CFITSIO libs ...."
     opts="$gopts --bindir=$top/bin --libdir=$top/bin"
     (cd cfitsio	&& ./configure $opts && \
-     make clean all install distclean )
+     make clean all install && make distclean )
     echo "done"
 
 fi


### PR DESCRIPTION
When a new release is created, it is useful to have the compiled packages available for direct use, as on the [IRAF home page](http://iraf.noao.edu).
This PR deploys the created packages for MacOS X High Sierra (XCode 10) 64 bit.

For Linux, the binaries are not so universal and will be deployed manually.