### PR TITLE
Set ecl as the default shell

### DIFF
--- a/unix/hlib/cl.sh
+++ b/unix/hlib/cl.sh
@@ -12,7 +12,7 @@
 
 
 nm=${0##*/}
-cl_binary="vocl.e"
+cl_binary="ecl.e"
 
 case "$nm" in
     "cl" | "cl.sh")

--- a/unix/hlib/ecl.sh
+++ b/unix/hlib/ecl.sh
@@ -11,7 +11,7 @@
 # Determine CL binary to run based on how we were called.
 
 nm=${0##*/}
-cl_binary="vocl.e"
+cl_binary="ecl.e"
 
 case "$nm" in
     "cl" | "cl.sh")


### PR DESCRIPTION
With the removal of vocl (iraf/iraf-v216#93), this can't be used as the default shell anymore; so we set the default shell to ecl.e.