### PR TITLE
Fail on error when running build scripts

### DIFF
--- a/unix/boot/bootlib/mkpkg.sh
+++ b/unix/boot/bootlib/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Make the bootstrap utilities library (bootlib).
+
+# Exit on error
+set -e
 
 # $CC -c $HSI_CF [a-z]*.c
 for i in [a-z]*.c ;\

--- a/unix/boot/generic/mkpkg.sh
+++ b/unix/boot/generic/mkpkg.sh
@@ -3,6 +3,9 @@
 # the enternal dependency.  The filename lex.yy.c is changed to lexyy.c
 # for portability reasons.
 
+# Exit on error
+set -e
+
 #if [ ! -f lexyy.c -o tok.l -nt lexyy.c ] ; then
     lex -o lexyy.c tok.l
 #fi

--- a/unix/boot/mkpkg.sh
+++ b/unix/boot/mkpkg.sh
@@ -1,5 +1,9 @@
+#!/bin/sh
 # Bootstrap the bootstrap utilities.  The logical directory hlib$ should be
 # defined for the cshell when this is run.
+
+# Exit on error
+set -e
 
 echo "----------------------- BOOTLIB ------------------------"
 (cd bootlib; sh -x mkpkg.sh)

--- a/unix/boot/mkpkg/mkpkg.sh
+++ b/unix/boot/mkpkg/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Bootstrap MKPKG.
+
+# Exit on error
+set -e
 
 $CC -c $HSI_CF	char.c fdcache.c fncache.c host.c main.c pkg.c scanlib.c\
 		    sflist.c tok.c

--- a/unix/boot/rmbin/mkpkg.sh
+++ b/unix/boot/rmbin/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Make and install the RMBIN utility.
+
+# Exit on error
+set -e
 
 $CC -c $HSI_CF	rmbin.c
 $CC $HSI_LF	rmbin.o $HSI_LIBS -o rmbin.e

--- a/unix/boot/rmfiles/mkpkg.sh
+++ b/unix/boot/rmfiles/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Make and install the RMFILES utility.
+
+# Exit on error
+set -e
 
 $CC -c $HSI_CF	rmfiles.c
 $CC $HSI_LF	rmfiles.o $HSI_LIBS -o rmfiles.e

--- a/unix/boot/rtar/mkpkg.sh
+++ b/unix/boot/rtar/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Bootstrap RTAR.
+
+# Exit on error
+set -e
 
 $CC -c $HSI_CF	rtar.c
 $CC $HSI_LF	rtar.o $HSI_LIBS -o rtar.e

--- a/unix/boot/spp/mkpkg.sh
+++ b/unix/boot/spp/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Make the Subset Preprocessor language (SPP) compiler.
+
+# Exit on error
+set -e
 
 echo "----------------------- XC  ----------------------------"
 $CC -c $HSI_CF	xc.c

--- a/unix/boot/spp/rpp/mkpkg.sh
+++ b/unix/boot/spp/rpp/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Make the second pass (RPP) of the SPP language compiler.
+
+# Exit on error
+set -e
 
 echo "----------------------- RPPFOR -------------------------"
 (cd rppfor;	sh -x mkpkg.sh)

--- a/unix/boot/spp/rpp/ratlibc/mkpkg.sh
+++ b/unix/boot/spp/rpp/ratlibc/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Host system interface for the RPP program.
+
+# Exit on error
+set -e
 
 $CC -c -g $HSI_CF	cant.c close.c endst.c getarg.c getlin.c initst.c open.c\
 		putch.c putlin.c r4tocstr.c remark.c

--- a/unix/boot/spp/rpp/ratlibf/mkpkg.sh
+++ b/unix/boot/spp/rpp/ratlibf/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Utility library subroutines for RPP.
+
+# Exit on error
+set -e
 
 $F77 -c $HSI_FF	addset.f addstr.f amatch.f catsub.f clower.f concat.f
 $F77 -c $HSI_FF	ctoc.f ctoi.f ctomn.f cupper.f delete.f docant.f dodash.f

--- a/unix/boot/spp/rpp/rppfor/mkpkg.sh
+++ b/unix/boot/spp/rpp/rppfor/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Fortran source for RPP preprocessor.
+
+# Exit on error
+set -e
 
 $F77 -c $HSI_FF	addchr.f allblk.f alldig.f baderr.f balpar.f beginc.f
 $F77 -c $HSI_FF	brknxt.f cascod.f caslab.f declco.f deftok.f doarth.f

--- a/unix/boot/spp/xpp/mkpkg.sh
+++ b/unix/boot/spp/xpp/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Make the first pass (XPP) of the SPP language compiler.
+
+# Exit on error
+set -e
 
 if [ ! -f lexyy.c -o xpp.l -nt lexyy.c ] ; then
     lex	-o lexyy.c -t xpp.l

--- a/unix/boot/wtar/mkpkg.sh
+++ b/unix/boot/wtar/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Bootstrap WTAR.
+
+# Exit on error
+set -e
 
 $CC -c $HSI_CF	wtar.c
 $CC $HSI_LF	wtar.o $HSI_LIBS -o wtar.e

--- a/unix/boot/xyacc/mkpkg.sh
+++ b/unix/boot/xyacc/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # XYACC -- Yacc parser generator for SPP.
+
+# Exit on error
+set -e
 
 $CC -c $HSI_CF	y[1-4].c
 $CC $HSI_LF	y[1-4].o $HSI_LIBS -o xyacc.e

--- a/unix/f2c/libf2c/mkpkg.sh
+++ b/unix/f2c/libf2c/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Bootstrap the F2C compiler and libraries.
+
+# Exit on error
+set -e
 
 make -f makefile.u
 mv libf2c.a ../../bin/

--- a/unix/f2c/mkpkg.sh
+++ b/unix/f2c/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Bootstrap the F2C compiler and libraries.
+
+# Exit on error
+set -e
 
 echo "----------------------- F2C ---------------------------"
 (cd src;    sh -x mkpkg.sh)

--- a/unix/f2c/src/mkpkg.sh
+++ b/unix/f2c/src/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Bootstrap the F2C compiler and libraries.
+
+# Exit on error
+set -e
 
 make -f makefile.u
 mv f2c ../../bin/f2c.e

--- a/unix/gdev/mkpkg.sh
+++ b/unix/gdev/mkpkg.sh
@@ -1,3 +1,7 @@
+#!/bin/sh
 # GDEV -- Host dependent graphics device drivers.
+
+# Exit on error
+set -e
 
 (cd sgidev;  sh -x mkpkg.sh)

--- a/unix/gdev/sgidev/mkpkg.sh
+++ b/unix/gdev/sgidev/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Make the SGI translators and install them in hlib.
+
+# Exit on error
+set -e
 
 $CC -c $HSI_CF	sgiUtil.c
 

--- a/unix/mkpkg.sh
+++ b/unix/mkpkg.sh
@@ -1,8 +1,12 @@
+#!/bin/sh
 # Bootstrap the UNIX bootstrap utilities and host system interface.
 # Note - the environment variables HSI_CF and HSI_FF (compile/link flags)
 # are required for the bootstrap; these are defined in hlib$irafuser.csh.
 #
 # USAGE:  `sh -x mkpkg.sh >& spool'  to bootstrap the IRAF HSI.
+
+# Exit on error
+set -e
 
 # Set the HSI architecture.
 sh -x setarch.sh

--- a/unix/os/mkpkg.sh
+++ b/unix/os/mkpkg.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 # Bootstrap the LIBOS.A library.
+
+# Exit on error
+set -e
 
 echo		"--------------------- OS ----------------------"
 

--- a/util/mksysgen
+++ b/util/mksysgen
@@ -1,6 +1,9 @@
 #!/bin/sh
 #
 
+# Exit on error
+set -e
+
 # Initialize the $iraf and environment.
 if [ -z "$iraf" ]; then
   if [ -e "$HOME/.iraf/setup.sh" ]; then
@@ -31,33 +34,19 @@ if [ -e "$HOME/.iraf/arch" ]; then
 fi
 
 c_start=$(date)
-rm -f spool */spool
 
 
 "$iraf/util/mkclean"				# clean old binaries
 
-cd "$iraf/unix"					# NOVOS bootstrap
-. hlib/irafuser.sh
-sh -x mkpkg.sh 2>&1 | tee -a spool
+. "$iraf/unix/hlib/irafuser.sh"			# NOVOS bootstrap
+(cd "$iraf/unix" && sh -x mkpkg.sh)
+(cd "$iraf/sys"	&& mkpkg)			# build NOVOS
 
-cd "$iraf/sys"					# build NOVOS
-mkpkg 2>&1 | tee -a spool
-
-cd "$iraf/unix/boot"				# VOS bootstrap
-. ../hlib/irafuser.sh
-sh -x mkpkg.sh 2>&1 | tee -a spool
-mv -v "$hlib"/*.e "$hbin"
-
-cd "$iraf/vendor"                               # build vendor libs
-make all 2>&1 | tee -a ../spool.final
-cd ../
-
-cd "$iraf/"					# build core system
-mkpkg 2>&1 | tee -a spool
-
-cd "$iraf/noao"					# build NOAO package
-export noao=$(pwd)/
-mkpkg -p noao 2>&1 | tee -a ../spool.final
+. "$iraf/unix/hlib/irafuser.sh"			# VOS bootstrap
+(cd "$iraf/unix/boot" && sh -x mkpkg.sh && mv -v "$hlib"/*.e "$hbin")
+(cd "$iraf/vendor" && make all)			# build vendor libs
+(cd "$iraf/" && mkpkg)				# build core system
+(cd "$iraf/noao" && noao=$(pwd)/ mkpkg -p noao)	# build NOAO package
 
 rm -rf bin*/pkgconfig			# misc clean up
 

--- a/vendor/cfitsio/mklibs
+++ b/vendor/cfitsio/mklibs
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 top=$(pwd)
 
 export CC=gcc
@@ -15,9 +17,9 @@ echo "  (Using toplevel directory $top ....)"
 # Global options.
 gopts="--prefix=$top --exec-prefix=$top --disable-shared"
 
-./configure $gopts  			       | tee _spool 2>&1
-make clean 				       | tee -a _spool 2>&1
-make 					       | tee -a _spool 2>&1
+./configure $gopts
+make clean
+make
 
 cp   libcfitsio.a ../voclient/lib
 mv   libcfitsio.a ../../lib

--- a/vendor/mklibs
+++ b/vendor/mklibs
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 top=$(cd .. && pwd)
 
 export CC=gcc
@@ -27,7 +29,7 @@ if [ $build_cfitsio = 1 ] ; then
     printf "    Building CFITSIO libs ...."
     opts="$gopts --bindir=$top/bin --libdir=$top/bin"
     (cd cfitsio	&& ./configure $opts && \
-     make clean all install distclean ) 2>&1 | tee -a _spool
+     make clean all install distclean )
     echo "done"
 
 fi
@@ -40,7 +42,7 @@ fi
 if [ $build_libvotable = 1 ] ; then
 
     printf "    Building VOTABLE lib ...."
-    (cd libvotable && make all clean ) 2>&1 | tee -a _spool
+    (cd libvotable && make all clean )
     echo "done"
 
 fi

--- a/vendor/trim_cfitsio.sh
+++ b/vendor/trim_cfitsio.sh
@@ -62,6 +62,8 @@ EOF
 cat <<EOF >cfitsio/mklibs
 #!/bin/sh
 
+set -e
+
 top=\$(pwd)
 
 export CC=gcc
@@ -77,9 +79,9 @@ echo "  (Using toplevel directory \$top ....)"
 # Global options.
 gopts="--prefix=\$top --exec-prefix=\$top --disable-shared"
 
-./configure \$gopts  			       | tee _spool 2>&1
-make clean 				       | tee -a _spool 2>&1
-make 					       | tee -a _spool 2>&1
+./configure \$gopts
+make clean
+make
 
 cp   libcfitsio.a ../voclient/lib
 mv   libcfitsio.a ../../lib


### PR DESCRIPTION
This requires the removal ot the build log redirection in `util/mksysgen`. 
Also, the shebang is added to the `mkpkg.sh` scripts.

I am not very sure about this: it may be better to just replace all the `mkpkg.sh` scripts by proper Makefiles (they are simple anyway), and to merge `util/mksysgen` into the toplevel Makefile. This would bring the IRAF build system closer to the standard, and also has the effect to properly fail on build errors. @iraf, any opinion on this?