### PR TITLE
Appended `ZTTYSZ()` function to get width and height of terminal

### DIFF
--- a/sys/tty/ttygsize.x
+++ b/sys/tty/ttygsize.x
@@ -4,8 +4,6 @@ include	<ttyset.h>
 include	<ttset.h>
 include	<fset.h>
 
-define	TIMEOUT  2000		# timeout interval, msec, for size query
-
 
 # TTYGSIZE -- Get the width and height of the terminal screen in characters.
 # For a conventional terminal these values are given as constants in the
@@ -20,88 +18,16 @@ pointer	tty			# terminal descriptor
 int	width			# ncols on screen (out)
 int	height			# nlines on screen (out)
 
-pointer	sp, patbuf, buf, qs, wh, ip, op
-int	index, len_qs, len_wh, w_index, h_index, sv_iomode, nchars, junk
-
-int	patmake(), patindex(), gstrcpy(), ctoi()
-int	ttygets(), ttyread(), ttystati(), ttstati(), fstati()
-define	noquery_ 91
-errchk	ttyread
+int	ttystati(), ttstati()
 
 begin
-	call smark (sp)
-	call salloc (patbuf, SZ_LINE, TY_CHAR)
-	call salloc (buf, SZ_LINE, TY_CHAR)
-	call salloc (qs, SZ_FNAME, TY_CHAR)
-	call salloc (wh, SZ_FNAME, TY_CHAR)
-
 	width = 0
 	height = 0
-	index = 0
 
-	# Just use the termcap values if in stty playback or record mode.
-	if (ttstati(in,TT_LOGIN) == YES || ttstati(in,TT_PLAYBACK) == YES)
-	    goto noquery_
+	# Retrieve actual values when not in stty playback or record mode.
+	if (ttstati(in,TT_LOGIN) != YES && ttstati(in,TT_PLAYBACK) != YES)
+	    call zttysz (out, width, height)
 
-	len_qs = ttygets (tty, "qs", Memc[qs], SZ_FNAME)
-	len_wh = ttygets (tty, "wh", Memc[wh], SZ_FNAME)
-
-	# Process the string DS (decode size string) to map the %W %H fields
-	# into the pattern strings "%[0-9]*", noting the index positions of
-	# the W and H fields.
-
-	if (len_wh > 0) {
-	    op = buf
-	    for (ip=wh;  Memc[ip] != EOS;  ip=ip+1) {
-		if ((Memc[ip] == '%') && ip > wh && Memc[ip-1] != '\\' &&
-		    (Memc[ip+1] == 'W' || Memc[ip+1] == 'H')) {
-
-		    index = index + 1
-		    op = op + gstrcpy ("%[0-9]*", Memc[op], ARB)
-		    ip = ip + 1
-
-		    if (Memc[ip] == 'W')
-			w_index = index
-		    else
-			h_index = index
-		} else {
-		    Memc[op] = Memc[ip]
-		    op = op + 1
-		}
-	    }
-	    Memc[op] = EOS
-	    junk = patmake (Memc[buf], Memc[patbuf], SZ_LINE)
-	}
-
-	# Query the terminal for the screen size, read back and decode the
-	# encoded screen size string.
-
-	if (len_qs > 0 && len_wh > 0) {
-	    sv_iomode = fstati (in, F_IOMODE)
-	    if (sv_iomode != IO_RAW)
-		call fseti (in, F_IOMODE, IO_RAW)
-
-	    call ttywrite (out, tty, Memc[qs], len_qs, 0)
-	    call flush (out)
-
-	    nchars = ttyread (in, tty, Memc[buf],SZ_LINE,Memc[patbuf], TIMEOUT)
-	    if (nchars > 0) {
-		if (ctoi (Memc[buf],patindex(Memc[patbuf],w_index),width) <= 0)
-		    width = 0
-		if (ctoi (Memc[buf],patindex(Memc[patbuf],h_index),height) <= 0)
-		    height = 0
-	    }
-
-	    if (sv_iomode != IO_RAW)
-		call fseti (in, F_IOMODE, sv_iomode)
-
-	    if (width == 0 && nchars == 0) {
-		call eprintf ("timeout - terminal type set wrong? ")
-		call eprintf ("(`stty termtype' to reset)\n")
-	    }
-	}
-
-noquery_
 	# If we still do not know the screen width or height, use the values
 	# given in the user environment, else in the termcap entry for the
 	# device.
@@ -111,5 +37,4 @@ noquery_
 	if (height <= 0)
 	    height = ttystati (tty, TTY_NLINES)
 
-	call sfree (sp)
 end

--- a/sys/tty/ttyodes.x
+++ b/sys/tty/ttyodes.x
@@ -151,23 +151,27 @@ begin
 
 	istty = (streq (Memc[devname], terminal))
 
-	# Get nlines.
+	# Get nlines and ncols
 	if (istty)
 	    iferr (T_NLINES(tty) = envgeti ("ttynlines"))
 		T_NLINES(tty) = 0
-	if (T_NLINES(tty) <= 0)
-	    iferr (T_NLINES(tty) = ttygeti (tty, "li"))
-		T_NLINES(tty) = 0
-	if (T_NLINES(tty) <= 0)
-	    T_NLINES(tty) = DEF_TTYNLINES
-
-	# Get ncols.
 	if (istty)
 	    iferr (T_NCOLS(tty) = envgeti ("ttyncols"))
 		T_NCOLS(tty) = 0
+
+	if (T_NLINES(tty) <= 0 || T_NCOLS(tty) <= 0) {
+	    call zttysz (1,T_NCOLS(tty),T_NLINES(tty))
+	}
+
+	if (T_NLINES(tty) <= 0)
+	    iferr (T_NLINES(tty) = ttygeti (tty, "li"))
+		T_NLINES(tty) = 0
 	if (T_NCOLS(tty) <= 0)
 	    iferr (T_NCOLS(tty) = ttygeti (tty, "co"))
 		T_NCOLS(tty) = 0
+
+	if (T_NLINES(tty) <= 0)
+	    T_NLINES(tty) = DEF_TTYNLINES
 	if (T_NCOLS(tty) <= 0)
 	    T_NCOLS(tty) = DEF_TTYNCOLS
 

--- a/unix/hlib/libc/knames.h
+++ b/unix/hlib/libc/knames.h
@@ -155,6 +155,7 @@
 #define ZTSDPR		ztsdpr_
 #define	ZSVJMP		zsvjmp_
 #define	ZTSLEE		ztslee_
+#define	ZTTYSZ		zttysz_
 #define	ZWMSEC		zwmsec_
 #define	ZXGMES		zxgmes_
 #define	ZXWHEN		zxwhen_

--- a/unix/os/mkpkg
+++ b/unix/os/mkpkg
@@ -82,6 +82,7 @@ libos.a:
 	zpanic.c	<libc/kernel.h> <libc/spp.h>
 	zraloc.c	<libc/kernel.h> <libc/spp.h>
 	zshlib.c
+	zttyio.c	<libc/kernel.h>	<libc/spp.h>
 	zwmsec.c	<libc/kernel.h> <libc/spp.h>
 	zxwhen.c	<libc/kernel.h> <libc/spp.h>
 	zzepro.c	<libc/spp.h>

--- a/unix/os/zttyio.c
+++ b/unix/os/zttyio.c
@@ -1,0 +1,25 @@
+/* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
+ */
+
+#include <unistd.h>
+#include <termios.h>
+#include <sys/ioctl.h>
+
+#define import_knames
+#define import_spp
+#include <iraf.h>
+
+int ZTTYSZ ( XINT *dev, XINT *width, XINT *height )
+{
+    struct winsize buf;
+    int ret;
+    ret = ioctl( *dev, TIOCGWINSZ, &buf );
+    if ( ret == 0 ) {
+	*width = buf.ws_col;
+	*height = buf.ws_row;
+	return XOK;
+    }
+    *width = 0;
+    *height = 0;
+    return XERR;
+}


### PR DESCRIPTION
This is a nice [cherry-pick](https://sourceforge.net/p/iraf64/code/276/) from the [iraf64](https://www.ir.isas.jaxa.jp/~cyamauch/iraf64/index.html) project by @cyamauch .

This makes terminal resizing working again, and so fixes the issue iraf/iraf-v216#118.
```
$ echo $TERM
xterm
$ resize
COLUMNS=80;
LINES=24;
export COLUMNS LINES;
$ cl
[...]
ecl> stty 
xterm ncols=80 nlines=24 
```
Without this PR, it shows the wrong `nlines=65` here.  Nice side effect is that one does not get a timeout anymore when the wrong terminal was set.

See also [iraf.net](http://iraf.net/forum/viewtopic.php?showtopic=1467258). I am wondering why this did not make the way into the NOAO code base 10 years ago?