### PR TITLE
Update Xcode version to 10.0 in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
             - libexpat1-dev:i386
             - libreadline-dev:i386
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10
       env: IRAFARCH=macintel OS_VERS=highsierra
     - os: osx
       osx_image: xcode6.4


### PR DESCRIPTION
Only for the 64-bit version.

In the 32-bit version, the compilation output is messed up with deprecation warnings, therefore some tests (which require compilation) fail. So we stay with 9.4 there.

