### PR TITLE
Improve prototyping in bootlib

### DIFF
--- a/unix/boot/bootlib/bytmov.c
+++ b/unix/boot/bootlib/bytmov.c
@@ -1,6 +1,7 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
 #define	import_spp
 #define import_knames
 #include <iraf.h>
@@ -11,6 +12,7 @@
  * to determine if they overlap.
  * [Specially optimized version for Sun/IRAF].
  */
+void
 BYTMOV (
   XCHAR	*a,			/* input byte array			*/
   XINT	*aoff,			/* first byte in A to be moved		*/

--- a/unix/boot/bootlib/oschdir.c
+++ b/unix/boot/bootlib/oschdir.c
@@ -17,7 +17,7 @@ os_chdir (char *dir)
 {
 	XCHAR	dpath[SZ_PATHNAME+1];
 	XCHAR	osdir[SZ_PATHNAME+1];
-	XINT	sz_dpath, sz_osdir, status, x_maxch=SZ_PATHNAME;
+	XINT	sz_osdir, status, x_maxch=SZ_PATHNAME;
 
 	extern  int ZFXDIR(XCHAR *osfn, XCHAR  *osdir, XINT *maxch, XINT   *nchars);
 	extern	int ZFGCWD(PKCHAR  *outstr, XINT *maxch, XINT *status);
@@ -25,7 +25,7 @@ os_chdir (char *dir)
 	extern	int ZFCHDR(PKCHAR  *newdir, XINT *status);
 
 
-	sz_dpath = os_fpathname (dir, (char *)dpath, SZ_PATHNAME);
+	os_fpathname (dir, (char *)dpath, SZ_PATHNAME);
 	os_strupk ((char *)dpath, osdir, SZ_PATHNAME);
 	ZFXDIR (osdir, osdir, &x_maxch, &sz_osdir);
 

--- a/unix/boot/bootlib/osgetenv.c
+++ b/unix/boot/bootlib/osgetenv.c
@@ -5,8 +5,7 @@
 #define	import_xnames
 #include "bootlib.h"
 
-
-char *_os_getenv(char *envvar, char *outstr, int maxch);
+extern char *_os_getenv(char *envvar, char *outstr, int maxch);
 
 
 /* OS_GETENV -- Return the value of the named environment variable.  Null is
@@ -82,6 +81,7 @@ _os_getenv (
 	PKCHAR	symbol[SZ_FNAME+1];
 	PKCHAR	value[SZ_COMMAND+1];
 	XINT	x_maxch = SZ_COMMAND, status=1;
+	extern int ZGTENV(PKCHAR *envvar, PKCHAR *outstr, XINT *maxch, XINT *status);
 
 	strcpy ((char *)symbol, envvar);
 	ZGTENV (symbol, value, &x_maxch, &status);


### PR DESCRIPTION

 * add missing return type to `BYTMOV`
 * declare memmove via `#include <string.h>`
 * declare `ZGTENV()` in `os_getenv.c`