### PR TITLE
Check for the existence of the "arch" variable before using it

### DIFF
--- a/pkg/cl/exec.c
+++ b/pkg/cl/exec.c
@@ -705,7 +705,7 @@ findexe (
 
 	if (c_access (bin_path, 0, 0) == YES) {
 	    return (bin_path);
-	} else {
+	} else if (arch != NULL) {
 	    /*  The binary wasn't found in the expected bin directory, but
 	     *  on certain platforms look for alternate binaries that may
 	     *  work.  This supports backward compatability with older

--- a/pkg/ecl/exec.c
+++ b/pkg/ecl/exec.c
@@ -750,7 +750,7 @@ findexe (
 
 	if (c_access (bin_path, 0, 0) == YES) {
 	    return (bin_path);
-	} else {
+	} else if (arch != NULL) {
 	    /*  The binary wasn't found in the expected bin directory, but
 	     *  on certain platforms look for alternate binaries that may
 	     *  work.  This supports backward compatability with older


### PR DESCRIPTION
From [iraf.net](http://iraf.net/forum/viewtopic.php?showtopic=1469897) (user mcba):

> Hi guys,
> 
> I'm trying to use an IRAF command in a bash script, so I am creating a file like this:
>```
>#!/home/mcba/miniconda3/envs/iraf27/iraf/bin.linux/ecl.e -f
>task $hello=/home/mcba/iraf/hello.e
>imhead g.fits
>hello
>logout
>```
> When I run this, the "imhead" command works fine, but the "hello" command results in:
>```
>ERROR: segmentation violation
>called as: `cl ()'
>Error while reading login.cl file - may need to rebuild with mkiraf
>Fatal startup error. CL dies.
>```
> Interestingly, the cl doesn't get as far as even looking at `hello.e`. I can replace the above task line with
>```
>task $hello=dummy
>```
> and I get exactly the same error message. But if I use `$dummy`, then hello gets passed straight to bash.
>
> Presumably there is some problem with an environment variable somewhere, but I can't find it. The fact that the imhead comand works OK indicated that my environment can't be too wrong.
>
> Thanks in advance for any help,
> Michael

where he found the problem himself:

> OK, I found the problem.
> 
> The environment variable "arch" wasn't defined (and isn't apparently used by the miniconda version of IRAF). When IRAF tries to execute a task it first checks various locations for the binary, even if you specify exactly where it is with a task statement. In `ecl/exec.c` there is a line
> ```
> arch = envget ("arch");
> ```
> and if the environment variable "arch" isn't defined, the internal variable "arch" will be NULL, which then causes a segmentation violation at line 764 when it is used in a `strstr` copy.
> 
> The workaround is to call your routine at the bash command prompt with
> ```
> arch= routine_name
> ```
> This will ensure that "arch" is defined immediately before running `routine_name` (and then returned to its previous definition, or lack thereof, afterwards).
> 
> Note: I debugged this using
> ```
> gdb ecl.e
> task $hello=/home/mcba/iraf/hello.e
> hello
> ```
> and then using "where" to find out where the segvio occurred.
> 
> Regards, Michael
> 

It looks like the lines dealing with `arch` were a quick hack introduced during the 64-bit porting; they appear in 2.15 first: 

https://github.com/iraf-community/iraf/blob/ae1b06a2bf989a78f176e259a3fc9c93a454f82d/pkg/ecl/exec.c#L748-L808

We should just check for a `NULL` pointer before accessing it.

Thanks Michael, for the great bug search!

Cheers

Ole
