### PR TITLE
Adjust calling of nttools subdir in pkg/utilities/mkpkg

### DIFF
--- a/pkg/utilities/mkpkg
+++ b/pkg/utilities/mkpkg
@@ -4,8 +4,6 @@ $call	relink
 $exit
 
 update:
-	@nttools
-
 	$call	relink
 	$call	install
 	;
@@ -21,6 +19,7 @@ relink:
 	;
 
 install:
+	@nttools
 	$move	xx_utilities.e bin$x_utilities.e
 	;
 


### PR DESCRIPTION
Otherwise, the `x_nttools.e` task is built twice, but the second built is not moved and kept in `pkg/utilities/nttools/`. This will unnecessarily increase the size of the binary packages.