### PR TITLE
Mention Chisato Yamauchi as copyright owner of the x86_64 zsvjmp.s code

### DIFF
--- a/unix/as.linux64/zsvjmp.S
+++ b/unix/as.linux64/zsvjmp.S
@@ -1,5 +1,6 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy
- * Inc. (amd64),
+ * Inc. (comment block)
+ * Copyright(c) 2008 Chisato Yamauchi (C-SODA/ISAS/JAXA) (amd64),
  * Copyright(c) 2018 Peter Green (arm64)
  * Copyright(c) 2018 James Cowgill <jcowgill AT debian TOD org> (mips64)
  * Copyright(c) 2018 Gustavo Romero, Rogerio Cardoso, Breno Leitao,

--- a/unix/as.macintel/zsvjmp.s
+++ b/unix/as.macintel/zsvjmp.s
@@ -1,3 +1,7 @@
+# Copyright(c) 1986 Association of Universities for Research in Astronomy
+# Inc. (comment block)
+# Copyright(c) 2008 Chisato Yamauchi (C-SODA/ISAS/JAXA) (amd64 code)
+
 	.file	"zsvjmp.s"
 
 # ZSVJMP, ZDOJMP -- Set up a jump (non-local goto) by saving the processor


### PR DESCRIPTION
The iraf64 web page [states]( https://www.ir.isas.jaxa.jp/~cyamauch/iraf64/index.html) for their own code (which is there at least since **Jan 2008**)
> Updates for x86_64
>     Wrote an assembler code for Linux x86_64 architecture.

https://github.com/iraf-community/iraf/blob/6687c734978c66909648cdb4b899942da147d65f/iraf/unix/as.x86_64-linux-generic/zsvjmp.s#L38-L44

The code here is identical, except for white spaces, and appeared only **Nov 2010**:
https://github.com/iraf-community/iraf/blob/b499169fe25dee4410cac1c27b239562df98f0ce/unix/as.linux64/zsvjmp.s#L41-L47

So, I am quite sure that the IRAF code for amd64 zsvjmp was "taken over" from the iraf64 project, and therefore should get the proper copyright assignment. Interestingly, this file is not mentioned in the `notes.v214` or `notes.64bit` which usually provide a description of what was done during development.

@iraf please correct me if I am wrong.