### PR TITLE
Fix buffer length in urlget.x

### DIFF
--- a/pkg/system/chkupdate.x
+++ b/pkg/system/chkupdate.x
@@ -19,7 +19,6 @@ char	version[SZ_FNAME], baseurl[SZ_FNAME], chkfile[SZ_LINE]
 char	netpath[SZ_LINE], arch[SZ_FNAME], tmpfile[SZ_FNAME]
 char	host[SZ_LINE], ref_file[SZ_LINE], release[SZ_LINE]
 char	buf[SZ_LINE]
-pointer	reply
 bool	verbose
 long	last, reldate, ndays, info[LEN_FINFO]
 int	ip, op, fd, nread, interval, tm[LEN_TMSTRUCT]
@@ -111,9 +110,7 @@ begin
 
 
 	# Access the URL and get the reply.
-	call calloc (reply, SZ_LINE, TY_CHAR)
-
-	if (url_get (netpath, tmpfile, reply) > 0) {
+	if (url_get (netpath, tmpfile, NULL) > 0) {
 	    call aclrc (buf, SZ_LINE)
 	    fd = open (tmpfile, READ_ONLY, TEXT_FILE)
 	    if (getline (fd, buf) != EOF) {
@@ -172,7 +169,6 @@ begin
 	call close (fd)
 
 	# Clean up.
-done_ 	call mfree (reply, TY_CHAR)
-	if (access (tmpfile, 0, 0) == YES) 
+done_ 	if (access (tmpfile, 0, 0) == YES) 
 	    call delete (tmpfile)
 end

--- a/pkg/system/t_urlget.x
+++ b/pkg/system/t_urlget.x
@@ -12,7 +12,6 @@ include <mach.h>
 
 procedure t_urlget ()
 
-pointer	reply
 char	url[SZ_PATHNAME], fname[SZ_PATHNAME], extn[SZ_PATHNAME]
 char	cache[SZ_PATHNAME], lfname[SZ_PATHNAME]
 int	nread
@@ -63,9 +62,7 @@ begin
 
 	} else {
 	    # Not in cache, or not using the cache, so force the download.
-	    call calloc (reply, SZ_LINE, TY_CHAR)
-	    nread = url_get (url, fname, reply)
-	    call mfree (reply, TY_CHAR)
+	    nread = url_get (url, fname, NULL)
 	}
 end
 

--- a/sys/etc/zzdebug.x
+++ b/sys/etc/zzdebug.x
@@ -35,6 +35,7 @@ define	INC_ENVBUF	500		# increment if overflow occurs
 define	MAX_SZKEY	32		# max chars in a key
 define	MAX_SZVALUE	80		# max chars in value string
 define	MAX_LENLISTELEM	(3+(MAX_SZKEY+1+MAX_SZVALUE+1+SZ_SHORT-1)/SZ_SHORT)
+define 	SZ_BUF		8192			# http response buffer
 
 # List element structure, stored in ENVBUF, which is allocated as an array of
 # type SHORT integer.  Each list element is aligned on a short integer boundary
@@ -390,7 +391,7 @@ begin
 	call clgstr ("fname", fname, SZ_FNAME)
 	hdr = clgetb ("hdr")
 
-	call calloc (reply, SZ_LINE, TY_CHAR)
+	call calloc (reply, SZ_BUF, TY_CHAR)
 
 	nread = url_get (url, fname, reply)
 

--- a/sys/imio/imt/t_urlget.x
+++ b/sys/imio/imt/t_urlget.x
@@ -14,7 +14,6 @@ task urlget	= t_urlget
 
 procedure t_urlget ()
 
-pointer	reply
 char	url[SZ_PATHNAME], fname[SZ_PATHNAME], extn[SZ_PATHNAME]
 char	cache[SZ_PATHNAME], lfname[SZ_PATHNAME]
 int	nread
@@ -61,9 +60,7 @@ begin
 
 	} else {
 	    # Not in cache, or not using the cache, so force the download.
-	    call calloc (reply, SZ_LINE, TY_CHAR)
-	    nread = url_get (url, fname, reply)
-	    call mfree (reply, TY_CHAR)
+	    nread = url_get (url, fname, NULL)
 	}
 end
 


### PR DESCRIPTION
Sometimes, the HTTP response header is larger than `SZ_PATHNAME` (512 chars). This may happen especially when the URL redirects to a content delivery service. In this case, the end of the redirected URL was cut (resulting in a failing download), or the program even segfaulted.

This patch increases the size of the reply buffer to `SZ_BUF` (8192 chars), and also takes care that the program does not crash when the header is larger. The response URL however is still limited to `SZ_LINE` (1023 chars).

Note that these limits are still arbitrary and may be too short: the maximum *recommended* size for an URL is 2048, and the HTTP response header has no size limit at all. `SZ_LINE` is however builtin in many places of string processing, so it is probably not easy to increase the max URL size to the recommended one (except increasing `SZ_LINE` itself).

This at fixes #69. The reason that is did not handle the extension+slicing was that we disabled `use_new_imt`.
@iraf: FYI, this fixes [iraf.net#1469909](http://iraf.net/forum/viewtopic.php?showtopic=1469909). See #69 for further explanation and debugging.