### PR TITLE
Add riscv64 support

### DIFF
--- a/unix/as.linux64/zsvjmp.S
+++ b/unix/as.linux64/zsvjmp.S
@@ -5,6 +5,7 @@
  * Copyright(c) 2018 James Cowgill <jcowgill AT debian TOD org> (mips64)
  * Copyright(c) 2018 Gustavo Romero, Rogerio Cardoso, Breno Leitao,
  * IBM Corporation (ppc64)
+ * Copyright(c) 2018 Manuel A. Fernandez Montecelo (riscv64)
  * Copyright(c) 2014 John Long <codeblue@inbox.lv> (s390x)
  */
 
@@ -109,6 +110,14 @@ zsvjmp_:
 	mtvrsave %r11
 
 	blr
+
+#elif defined (__riscv)
+
+        sd      zero,0(a1)
+        sd      a1,0(a0)
+        li      a1,0
+        addi    a0,a0,8
+        tail    __sigsetjmp@plt
 
 #elif defined (__s390x__)
 


### PR DESCRIPTION
[RISC-V](https://riscv.org/) (pronounced "risk-five") is an open instruction set architecture (ISA) based on established reduced instruction set computing (RISC) principles. While there are still no real hardware CPUs available, there is already Linux support with it, and it exists an (unofficial) [Debian port](https://wiki.debian.org/RISC-V).

This patch provides the assembler code in `zsvjmp.S` to support riscv64. It is based on

https://lists.debian.org/debian-riscv/2018/10/msg00012.html

and the code was written and tested by Manuel A. Fernandez Montecelo and Stefan O'Rear.
