### PR TITLE
Fix usage irafarch.sh in (e)cl.sh

### DIFF
--- a/unix/hlib/cl.sh
+++ b/unix/hlib/cl.sh
@@ -91,8 +91,8 @@ if [ -n "$IRAFARCH" ]; then
 else
     os_mach=$(uname -s | tr '[:upper:]' '[:lower:]' | cut -c1-6)
  
-    if [ -e $iraf/unix/hlib/irafarch.csh ]; then
-        MACH=$($iraf/unix/hlib/irafarch.csh)
+    if [ -e $iraf/unix/hlib/irafarch.sh ]; then
+        MACH=$($iraf/unix/hlib/irafarch.sh)
     else
         MACH=$os_mach
     fi

--- a/unix/hlib/ecl.sh
+++ b/unix/hlib/ecl.sh
@@ -91,8 +91,8 @@ if [ -n "$IRAFARCH" ]; then
 else
     os_mach=$(uname -s | tr '[:upper:]' '[:lower:]' | cut -c1-6)
  
-    if [ -e $iraf/unix/hlib/irafarch.csh ]; then
-        MACH=$($iraf/unix/hlib/irafarch.csh)
+    if [ -e $iraf/unix/hlib/irafarch.sh ]; then
+        MACH=$($iraf/unix/hlib/irafarch.sh)
     else
         MACH=$os_mach
     fi

--- a/unix/hlib/mkiraf.sh
+++ b/unix/hlib/mkiraf.sh
@@ -95,7 +95,7 @@ if [ "$def" = 1 ]; then
     if [ ! -e cache ]; then
         mkdir cache
     fi
-    cp "$iraf/unix/hlib/setup.*sh" .
+    cp $iraf/unix/hlib/setup.*sh .
 fi
 
 


### PR DESCRIPTION
irafarch is now a `/bin/sh` script, and has the suffix `.sh`. This was forgotten to change in #54, and also another small glitch was introduced there.
Should have tested it more carefully... :-(