### PR TITLE
Remove old architectures from Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,25 +8,8 @@ matrix:
           packages:
             - libreadline-dev
     - os: linux
-      dist: precise
-      env: IRAFARCH=linux64 OS_VERS=precise
-      addons:
-        apt:
-          packages:
-            - libreadline-dev
-    - os: linux
       dist: trusty
       env: IRAFARCH=linux OS_VERS=trusty CARCH="-m32"
-      addons:
-        apt:
-          packages:
-            - gcc-multilib
-            - libcurl4-openssl-dev:i386
-            - libexpat1-dev:i386
-            - libreadline-dev:i386
-    - os: linux
-      dist: precise
-      env: IRAFARCH=linux OS_VERS=precise CARCH="-m32"
       addons:
         apt:
           packages:
@@ -38,14 +21,8 @@ matrix:
       osx_image: xcode10
       env: IRAFARCH=macintel OS_VERS=highsierra
     - os: osx
-      osx_image: xcode6.4
-      env: IRAFARCH=macintel OS_VERS=yosemite
-    - os: osx
       osx_image: xcode9.4
       env: IRAFARCH=macosx OS_VERS=highsierra CARCH="-m32"
-    - os: osx
-      osx_image: xcode7.3
-      env: IRAFARCH=macosx OS_VERS=elcapitan CARCH="-m32"
 
 install:
   - if [ $TRAVIS_OS_NAME = osx ]; then brew install ccache; PATH=/usr/local/opt/ccache/libexec:$PATH ; fi


### PR DESCRIPTION
The old archs are outdated and subject of removal from Travis. And we had no problems ever for them when built from source. We should concentrate here on newer systems. This will speed up the tests by a factor of 2.

Occasional tests will run locally however on older systems is an incompatibility is suspected (remembering that @iraf still has a RHEL-7 system).

We could think of dropping OS-X 32 bit tests, as 32 bit is going less and less supported by the OS.