### PR TITLE
Update OS versions for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
             - libexpat1-dev:i386
             - libreadline-dev:i386
     - os: osx
-      osx_image: xcode10
-      env: IRAFARCH=macintel OS_VERS=highsierra
+      osx_image: xcode10.2
+      env: IRAFARCH=macintel OS_VERS=mojave
     - os: osx
       osx_image: xcode9.4
       env: IRAFARCH=macosx OS_VERS=highsierra CARCH="-m32"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 matrix:
   include:
     - os: linux
-      dist: trusty
-      env: IRAFARCH=linux64 OS_VERS=trusty
+      dist: xenial
+      env: IRAFARCH=linux64 OS_VERS=xenial
       addons:
         apt:
           packages:
             - libreadline-dev
     - os: linux
-      dist: trusty
-      env: IRAFARCH=linux OS_VERS=trusty CARCH="-m32"
+      dist: xenial
+      env: IRAFARCH=linux OS_VERS=xenial CARCH="-m32"
       addons:
         apt:
           packages:


### PR DESCRIPTION
This PR updates the tests to the latest OS versions available on travis:

* MacOS Mojave 10.14 (64 bit); xcode 10.2
* Ubuntu 16.04 Xenial (32 and 64 bit)

The 32-bit version remains on xcode 9.4 (macOS 10.13 High Sierra) 