### PR TITLE
Fix irafuser.csh

### DIFF
--- a/unix/hlib/irafuser.csh
+++ b/unix/hlib/irafuser.csh
@@ -4,8 +4,8 @@
 # home$ should be defined in the user's .login file.
 
 
-setenv MACH 	 `$iraf/unix/hlib/irafarch.sh`
-setenv IRAFARCH  `$iraf/unix/hlib/irafarch.sh`
+setenv MACH 	 `${iraf}unix/hlib/irafarch.sh`
+setenv IRAFARCH  `${iraf}unix/hlib/irafarch.sh`
 
 
 
@@ -17,8 +17,8 @@ setenv	tmp	/tmp/
 
 # Default to GCC for compilation.
 setenv	CC	gcc
-setenv	F77	$hlib/f77.sh
-setenv	F2C	$hbin/f2c.e
+setenv	F77	${hlib}f77.sh
+setenv	F2C	${hbin}f2c.e
 setenv	RANLIB	ranlib
 if ( ! ${?CPPFLAGS} ) then
     set CPPFLAGS

--- a/unix/hlib/irafuser.csh
+++ b/unix/hlib/irafuser.csh
@@ -20,6 +20,15 @@ setenv	CC	gcc
 setenv	F77	$hlib/f77.sh
 setenv	F2C	$hbin/f2c.e
 setenv	RANLIB	ranlib
+if ( ! ${?CPPFLAGS} ) then
+    set CPPFLAGS
+endif
+if (! ${?CFLAGS} ) then
+    set CFLAGS
+endif
+if (! ${?LDFLAGS} ) then
+    set LDFLAGS
+endif
 
 setenv XC_CFLAGS "${CPPFLAGS} ${CFLAGS} -I${iraf}include"
 setenv HSI_CF "${XC_CFLAGS}"


### PR DESCRIPTION
Tcsh aborts sourcing the script if it tries to access an undefined variable. This change makes it sure that the variables (except $iraf) are defined before accessing them.

Also, we make sure that no double slashes are in the defined variables.
