### PR TITLE
add note about the path to iraf bin dir to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,9 +50,19 @@ links:
 
     $ ./install 		# execute the install script
 
-Usually, you can everywhere use the default settings when asked from
-the install script.  Configure the system for the proper architecture
-and build:
+The script will prompt you for the path to the default image 
+directory, the cache directory and the binary files directory.
+Usually, you can everywhere use the default settings when asked from 
+the install script. You will need to include the binary files 
+directory in your PATH before proceeding to the `<make>` step.
+In BASH this can be done with the command:
+
+    $ export PATH=/path/to/iraf/bin/:$PATH
+
+where `</path/to/iraf/bin/>` is the binary files path specified to 
+the install script.
+
+Now you can configure the system for the proper architecture and build:
 
     $ make <arch>
     $ make sysgen 2>&1 | tee build.log


### PR DESCRIPTION
I propose a small addition to the instructions in INSTALL.md It may be helpful to inform the user that the IRAF bin directory specified by the user to the install script should be added to PATH variable. If it is not done, the following `make` step fails not finding the `xc` command. The solution to this problem is kind of obvious, but still mentioning it in the installation instructions will save some minutes and nerve cells for the new users.