### PR TITLE
Update travis build environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
             - libexpat1-dev:i386
             - libreadline-dev:i386
     - os: osx
-      osx_image: xcode10.2
-      env: IRAFARCH=macintel OS_VERS=mojave
+      osx_image: xcode11.2
+      env: IRAFARCH=macintel OS_VERS=catalina
     - os: osx
       osx_image: xcode9.4
       env: IRAFARCH=macosx OS_VERS=highsierra CARCH="-m32"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,28 @@
 matrix:
   include:
     - os: linux
-      dist: xenial
-      env: IRAFARCH=linux64 OS_VERS=xenial
+      dist: bionic
+      arch: amd64
+      env: IRAFARCH=linux64 OS_VERS=bionic
       addons:
         apt:
           packages:
+            - libcurl4-openssl-dev
+            - libexpat1-dev
             - libreadline-dev
     - os: linux
-      dist: xenial
-      env: IRAFARCH=linux OS_VERS=xenial CARCH="-m32"
+      dist: bionic
+      arch: arm64
+      env: IRAFARCH=linux64 OS_VERS=bionic
+      addons:
+        apt:
+          packages:
+            - libcurl4-openssl-dev
+            - libexpat1-dev
+            - libreadline-dev
+    - os: linux
+      dist: bionic
+      env: IRAFARCH=linux OS_VERS=bionic CARCH="-m32"
       addons:
         apt:
           packages:


### PR DESCRIPTION
The PR updates the Travis build environments to Ubuntu 18.04 "Bionic" and macOS 10.15 "Catalina" (XCode 11.2, 64 bit). The macOS 32-bit environment stays at 10.13 "High Sierra" (XCode 9.4), since this is the last version that works well.
Additionally, the 64-bit ARM architecture is built (also Ubuntu 18.04 "Bionic").
