### PR TITLE
Remove some C compiler warnings

### DIFF
--- a/unix/boot/bootlib/osfcopy.c
+++ b/unix/boot/bootlib/osfcopy.c
@@ -19,7 +19,7 @@ os_fcopy (
 )
 {
 	XCHAR	buf[SZ_FBUF];
-	XINT	status,	junk, maxch = SZ_FBUF, mode = 0, in, out, n, nw;
+	XINT	status,	junk, maxch = SZ_FBUF, mode = 0, in, out, n;
 
 	extern  int ZOPNTX(PKCHAR *osfn, XINT *mode, XINT *chan);
 	extern  int ZGETTX(XINT *fd, XCHAR *buf, XINT *maxchars, XINT *status);
@@ -75,7 +75,7 @@ os_fcopy (
 	    }
 
 	    while ((n = read (in, (char *)buf, SZ_FBUF)) > 0)
-		nw = write (out, (char *)buf, n);
+		write (out, (char *)buf, n);
 
 	    close (in);
 	    close (out);

--- a/unix/boot/mkpkg/host.c
+++ b/unix/boot/mkpkg/host.c
@@ -91,11 +91,10 @@ h_updatelibrary (
 	int	nsources, nfiles, ndone, nleft;
 	int	hostnames, status;
 	char	libfname[SZ_PATHNAME+1];
-	char   *lname = NULL;
 
 	/* Get the library file name. */
 	h_getlibname (library, libfname);
-	lname = resolvefname(libfname);
+	resolvefname(libfname);
 
 	/*
 	 * Compile the files.

--- a/unix/boot/mkpkg/scanlib.c
+++ b/unix/boot/mkpkg/scanlib.c
@@ -193,11 +193,11 @@ h_scanlibrary (char *library)
 		        char p[SZ_PATHNAME];
 
 		        len = atoi(&arf.ar_name[3]);
-	                bzero (p, SZ_PATHNAME);
+	                memset (p, 0, SZ_PATHNAME);
 		        if (fread(p, len, 1, fp) != 1) {
 		            fprintf (stderr, "%s: premature EOF", libfname);
 		        }
-	                bzero (modname, SZ_KEY+1);
+	                memset (modname, 0, SZ_KEY+1);
 		        sprintf (modname, "%s", p);
 	        } else 
 		    len = 0;

--- a/unix/boot/mkpkg/scanlib.c
+++ b/unix/boot/mkpkg/scanlib.c
@@ -78,7 +78,6 @@ h_scanlibrary (char *library)
 	mlb_op = 1;
 	nmodules = 0;
 
-	len = 0;
 	for (i=0;  i < MAX_LIBFILES;  i++)
 	    mlb_index[i] = 0;
 

--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -192,10 +192,6 @@ static void  rmfiles (void);
 static void  fatalstr (char *s1, char *s2);
 static void  fatal (char *s);
 
-static char *findexe (char *prog, char *dir);
-
-
-
 
 /**
  *  MAIN -- Execution begins here.  Interpret command line arguments and
@@ -1403,69 +1399,4 @@ fatal (char *s)
 	fprintf (stderr, "Fatal compiler error: %s\n", s);
 	fflush (stderr);
 	done (1);
-}
-
-
-/* FINDEXE -- Search for the named file and return the path if found, else
- * NULL.  If "dir" is non-NULL the directory in which the file resides is
- * returned in the string buffer pointed to.  The user's PATH is searched,
- * followed by SYSBINDIR, then LOCALBINDIR.
- */
-static char *
-findexe (
-    char  *prog,		/* file to search for */
-    char  *dir			/* pointer to output string buf, or NULL */
-)
-{
-	register char *ip, *op;
-	static	char path[SZ_PATHNAME];
-	char	dirpath[SZ_PATHNAME];
-	char	*dp = dir ? dir : dirpath;
-	char	*pathp;
-
-	/* Look for the program in the directories in the user's path.
-	 */
-	ip = pathp = os_getenv ("PATH");
-	while (*ip) {
-	    for (op=dp;  *ip && (*op = *ip++) != ':';  op++)
-		;
-	    *op++ = '/';
-	    *op++ = EOS;
-	    strcpy (path, dp);
-	    strcat (path, prog);
-	    if (access (path, 0) != -1)
-		return (path);
-	}
-
-	/* Look in SYSBINDIR. */
-	strcpy (dp, SYSBINDIR);
-	strcpy (path, dp);
-	strcat (path, prog);
-
-	if (access (path, 0) != -1) {
-	    static  char envpath[8192];
-	    char    *oldpath;
-
-	    /* Add SYSBINDIR to the user's path.  This is required to
-	     * use the V1.3 compiler.  Note that this code should only be
-	     * executed once, since the next time findexe is called the
-	     * SYSBINDIR directory will be in the default path, above.
-	     */
-	    if ((oldpath = pathp)) {
-		sprintf (envpath, "PATH=%s:%s", SYSBINDIR, oldpath);
-		putenv (envpath);
-	    }
-
-	    return (path);
-	}
-
-	/* Look in LOCALBINDIR. */
-	strcpy (dp, LOCALBINDIR);
-	strcpy (path, dp);
-	strcat (path, prog);
-	if (access (path, 0) != -1)
-	    return (path);
-
-	/* Not found. */
-	return (NULL);
 }

--- a/unix/os/prwait.c
+++ b/unix/os/prwait.c
@@ -45,7 +45,7 @@ pr_enter (int pid, int inchan, int outchan)
 	extern  int kernel_panic (char *msg);
 
 
-	if ((pr = pr_findpid (NULL)) == NULL)
+	if ((pr = pr_findpid (0)) == NULL)
 	    kernel_panic ("iraf process table overflow");
 	else {
 	    pr->pr_pid = pid;

--- a/unix/os/zfiobf.c
+++ b/unix/os/zfiobf.c
@@ -777,7 +777,7 @@ vm_connect (void)
 	} else {
 	    vm_server = fd;
 	    if (vm_debug)
-		fprintf (stderr, "fd=%d\n", fd);
+		fprintf (stderr, "fd=%d\n", (int)fd);
 	    vm_identify();
 	}
 

--- a/unix/os/zfioks.c
+++ b/unix/os/zfioks.c
@@ -320,7 +320,7 @@ ZOPNKS (
             client_host = ip + 1;
 
 	    dbgmsgf ("S:callback client %s on port %d\n", client_host, port);
-	    if ((s = ks_socket (client_host, NULL, port, "connect")) < 0)
+	    if ((s = ks_socket (client_host, 0, port, "connect")) < 0)
 		*chan = ERR;
 	    else
 		*chan = s;
@@ -686,7 +686,7 @@ again:
 	     * to start up a new irafks daemon on the port just created.  If
 	     * the connection fails, fork an rsh and start up the in.irafksd.
 	     */
-	    if (!port || (t = ks_socket (host, NULL, port, "connect")) < 0) {
+	    if (!port || (t = ks_socket (host, 0, port, "connect")) < 0) {
 		dbgmsg ("C:no server, fork rsh to start in.irafksd\n");
 
 		if (pipe(pin) < 0 || pipe(pout) < 0) {
@@ -734,7 +734,7 @@ retry:
 		     * the daemon.
 		     */
 		    if (status ||
-			(t = ks_socket (host, NULL, port, "connect")) < 0) {
+			(t = ks_socket (host, 0, port, "connect")) < 0) {
 
 			/* The KS_RETRY environment variable may be set to 
 			 * the number of times we wish to try to reconnect.

--- a/unix/os/zfioks.c
+++ b/unix/os/zfioks.c
@@ -1126,7 +1126,7 @@ ks_socket (char *host, u_long addr, int port, char *mode)
 	    return (ERR);
 
 	/* Set socket address. */
-	bzero ((char *)&sockaddr, sizeof(sockaddr));
+	memset ((char *)&sockaddr, 0, sizeof(sockaddr));
 	sockaddr.sin_family = AF_INET;
 	sockaddr.sin_port = htons((short)port);
 
@@ -1136,7 +1136,7 @@ ks_socket (char *host, u_long addr, int port, char *mode)
 	} else if (*host) {
 	    if ((hp = gethostbyname (host)) == NULL)
 		goto failed;
-	    bcopy((char *)hp->h_addr,(char *)&sockaddr.sin_addr, hp->h_length);
+	    memcpy((char *)&sockaddr.sin_addr,(char *)hp->h_addr, hp->h_length);
 	} else
 	    sockaddr.sin_addr.s_addr = INADDR_ANY;
 

--- a/unix/os/zfiomt.c
+++ b/unix/os/zfiomt.c
@@ -1712,8 +1712,8 @@ static void zmtdbgopen (struct mtdesc *mp)
 	    if ((s = socket (AF_INET, SOCK_STREAM, 0)) < 0)
 		return;
 
-	    bzero ((char *)&sockaddr, sizeof(sockaddr));
-	    bcopy ((char *)hp->h_addr,(char *)&sockaddr.sin_addr, hp->h_length);
+	    memset ((char *)&sockaddr, 0, sizeof(sockaddr));
+	    memcpy ((char *)&sockaddr.sin_addr,(char *)hp->h_addr, hp->h_length);
 	    sockaddr.sin_family = AF_INET;
 	    sockaddr.sin_port = htons((short)port);
 	    if (connect (s,(struct sockaddr *)&sockaddr,sizeof(sockaddr)) < 0) {

--- a/unix/os/zfiond.c
+++ b/unix/os/zfiond.c
@@ -172,7 +172,7 @@ ZOPNND (
 	register int fd;
 	    register struct portal *np, *s_np = (struct portal *) NULL;
 	    unsigned short host_port = 0;
-	    unsigned long host_addr = 0;
+	    in_addr_t host_addr = 0;
 	    char osfn[SZ_NAME*2];
 	    char flag[SZ_NAME];
 	    char *ip;
@@ -220,7 +220,7 @@ ZOPNND (
 		    strcpy (host_str, "localhost");
 		if (isdigit (host_str[0])) {
 		    host_addr = inet_addr (host_str);
-		    if ((int)host_addr == -1)
+		    if (host_addr == INADDR_NONE)
 			goto err;
 		} else if ((hp = gethostbyname(host_str))) {
   		    memcpy (&host_addr, hp->h_addr, sizeof(host_addr));

--- a/unix/os/zfiond.c
+++ b/unix/os/zfiond.c
@@ -223,7 +223,7 @@ ZOPNND (
 		    if ((int)host_addr == -1)
 			goto err;
 		} else if ((hp = gethostbyname(host_str))) {
-		    bcopy (hp->h_addr, (char *)&host_addr, sizeof(host_addr));
+  		    memcpy (&host_addr, hp->h_addr, sizeof(host_addr));
 		} else
 		    goto err;
 
@@ -340,11 +340,10 @@ ZOPNND (
 		    goto err;
 
 		/* Compose network address. */
-		bzero ((char *)&sockaddr, sizeof(sockaddr));
+		memset (&sockaddr, 0, sizeof(sockaddr));
 		sockaddr.sin_family = AF_INET;
 		sockaddr.sin_port = host_port;
-		bcopy ((char *)&host_addr, (char *)&sockaddr.sin_addr,
-		    sizeof(host_addr));
+		memcpy (&sockaddr.sin_addr, &host_addr, sizeof(host_addr));
 
 		/* Connect to server. */
 		if (fd >= MAXOFILES || (connect (fd,
@@ -365,7 +364,7 @@ ZOPNND (
 		    goto err;
 
 		/* Compose network address. */
-		bzero ((char *)&sockaddr, sizeof(sockaddr));
+		memset ((char *)&sockaddr, 0, sizeof(sockaddr));
 		sockaddr.sun_family = AF_UNIX;
 		strncpy (sockaddr.sun_path,
 		    np->path1, sizeof(sockaddr.sun_path));
@@ -420,7 +419,7 @@ ZOPNND (
 		    goto err;
 
 		/* Bind server port to socket. */
-		bzero ((char *)&sockaddr, sizeof(sockaddr));
+		memset ((char *)&sockaddr, 0, sizeof(sockaddr));
 		sockaddr.sin_family = AF_INET;
 		sockaddr.sin_port = host_port;
 		sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -469,7 +468,7 @@ ZOPNND (
 		    goto err;
 
 		/* Bind server port to socket. */
-		bzero ((char *)&sockaddr, sizeof(sockaddr));
+		memset ((char *)&sockaddr, 0, sizeof(sockaddr));
 		sockaddr.sun_family = AF_UNIX;
 		strncpy (sockaddr.sun_path,np->path1,sizeof(sockaddr.sun_path));
 		addrlen = sizeof(sockaddr) - sizeof(sockaddr.sun_path)

--- a/unix/os/zzstrt.c
+++ b/unix/os/zzstrt.c
@@ -90,7 +90,7 @@ ZZSTRT (void)
 
 	/* Pass the values of the kernel parameters into the kernel. */
 	ZZSETK (os_process_name, osfn_bkgfile, prtype, ipc_isatty,
-	    &ipc_in, &ipc_out);
+	    ipc_in, ipc_out);
 
 	return (XOK);
 }

--- a/vendor/libvotable/votParse.c
+++ b/vendor/libvotable/votParse.c
@@ -213,8 +213,8 @@ vot_openVOTABLE (char *arg)
     FILE    *fd = (FILE *) NULL;
     Element *my_element;
     char     buf[BUFSIZE], *ip, urlFname[BUFSIZE];
-    size_t   len, nleft = 0, fsize = -1, nread = 0;
-    int      done, ret_handle, nerrs;
+    size_t   len = 0, nleft = 0, fsize = -1, nread = 0;
+    int      done, ret_handle;
     XML_Parser parser;
 
     struct   stat st;
@@ -260,7 +260,7 @@ vot_openVOTABLE (char *arg)
 	    strcpy (urlFname, "/tmp/votquery");
 	close (tfd);
 
-	nerrs = vot_simpleGetURL (arg, urlFname);
+	vot_simpleGetURL (arg, urlFname);
         if ( !(fd = fopen (urlFname, "r")) ) {
             fprintf (stderr, "Unable to open url '%s'\n", arg);
             return (0);			/* cannot open file error	*/
@@ -3392,7 +3392,7 @@ static void
 vot_htmlTableData (FILE *fd, handle_t res, char *ifname)
 {
     handle_t  tab, data, tdata, field, tr, td;
-    register  int i, nrows, ncols;
+    register  int i;
     char     *name, *id, *ucd, *s;
 
 
@@ -3411,8 +3411,6 @@ vot_htmlTableData (FILE *fd, handle_t res, char *ifname)
 	return;
     if ((tdata = vot_getTABLEDATA (data)) <= 0)
 	return;
-    nrows = vot_getNRows (tdata);
-    ncols = vot_getNCols (tdata);
 
 
     fprintf (fd, "<table border='%d'>\n", tborder);


### PR DESCRIPTION
This PR removes a few compiler warnings:

  * unused static function `findexe()` from `xc.c` (the code of this function is removed)
  * use of `NULL` as an integer parameter
  * unused local variables
  * deprecated `bcopy()` and `bzero()` functions (replaced by `memcopy()` and `memset()`)
  * wrong (generic integer) data type instead of `in_addr_t` in `zfiond.c`
  * call-by-value parameters of `ZZSETK()` in `zzstrt.c`
