### PR TITLE
Push XCode version to 11.4 (64bit/Catalina)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
             - libexpat1-dev:i386
             - libreadline-dev:i386
     - os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.4
       env: IRAFARCH=macintel OS_VERS=catalina
     - os: osx
       osx_image: xcode9.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,6 @@ matrix:
             - libreadline-dev
     - os: linux
       dist: bionic
-      arch: arm64
-      env: IRAFARCH=linux64 OS_VERS=bionic
-      addons:
-        apt:
-          packages:
-            - libcurl4-openssl-dev
-            - libexpat1-dev
-            - libreadline-dev
-    - os: linux
-      dist: bionic
       env: IRAFARCH=linux OS_VERS=bionic CARCH="-m32"
       addons:
         apt:


### PR DESCRIPTION
... to keep the MacOS build test up to date with the latest code of the development tools

Unfortunately, we have to disable the ARM64 build since it takes too long on Travis.