### PR TITLE
Avoid multiple definition of errflag

### DIFF
--- a/unix/boot/spp/xpp/xppcode.c
+++ b/unix/boot/spp/xpp/xppcode.c
@@ -106,7 +106,7 @@ int	ntasks = 0;			/* number of tasks in interpreter     */
 int	str_idnum = 0;			/* for generating unique string names */
 int	nbrace = 0;			/* must be zero when "end" is reached */
 int	nswitch = 0;			/* number switch stmts in procedure   */
-int	errflag;
+extern int	errflag;
 int	errhand = NO;			/* set if proc employs error handler  */
 int	errchk = NO;			/* set if proc employs error checking */
 

--- a/unix/hlib/f77.sh
+++ b/unix/hlib/f77.sh
@@ -42,7 +42,7 @@
 
 s=/tmp/stderr_$$
 CC=${CC_f2c:-'gcc'}
-CFLAGS="-I${iraf}include -I${iraf}unix/f2c/libf2c ${XC_CFLAGS} -Wno-maybe-uninitialized -Wno-strict-aliasing -Wno-unknown-warning-option"
+CFLAGS="-I${iraf}include -I${iraf}unix/f2c/libf2c ${XC_CFLAGS} -Wno-maybe-uninitialized -Wno-strict-aliasing -Wno-unknown-warning-option -fcommon"
 EFL=${EFL:-/v/bin/efl}
 EFLFLAGS=${EFLFLAGS:-'system=portable deltastno=10'}
 F2C=${F2C:-${iraf}unix/bin/f2c.e}


### PR DESCRIPTION
GCC 10 defaults to `-fno-common`, where it is an error when the same global variable is defined twice; see https://gcc.gnu.org/gcc-10/porting_to.html.

This PR resolves this (for xpp), and closes #110.