### PR TITLE
Use PLT when calling sigsetjmp on i386

### DIFF
--- a/unix/as.linux/zsvjmp.S
+++ b/unix/as.linux/zsvjmp.S
@@ -47,7 +47,7 @@ zsvjmp_:
 	addl	$4, %ecx		// change stack to point to &jmpbuf[1]
 	movl	%ecx, 4(%esp)		// 	...
 	movl	$0, 8(%esp)		// change arg2 to zero
-	jmp	__sigsetjmp		// let sigsetjmp do the rest
+	jmp	__sigsetjmp@PLT		// let sigsetjmp do the rest
 
 #elif defined(__x86_64__)		// linux x32 ABI
 


### PR DESCRIPTION
With gcc-10, the linkes issues a warning when trying to call sigsetjmp directly on i386:
```
…/libos.a(zsvjmp.o): warning: relocation against `__sigsetjmp@@GLIBC_2.0' in read-only section `.text'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
```
This can be avoided to use the Procedure Linkage Table for this function. Note that other architectures still use direct calls:

 * ARM 32/64 bit
 * MIPS 32/64 bit
 * PowerPC 64 bit