### PR TITLE
Fix cpu_time calculation in unix/os/zgtime.c

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -10,6 +10,7 @@ The following tests are available:
    mainly from the test procedure document written by Jeanette Barnes and 
    her "Beginner's Guide to Using IRAF",
  * [Programming interface](programming.md) for basic CL and SPP functionality,
+ * [OS specific subroutines](os.md),
  * Test from the examples in several packages:
     - [`lists`](lists.md),
     - [`images.imcoords`](images.imcoords.md)
@@ -20,6 +21,7 @@ The following tests are available:
     - [`utilities.nttools`](utilities.nttools.md)
     - [`noao.digiphot.photcal`](noao.digiphot.photcal.md)
     - [`noao.astutil`](noao.astutil.md)
+	- [`sys.vops`](sys.vops.md)
  * [Regression test](numerical-recipes.md) for the replacement of Numerical
    Recipes code
  * [A self-test](test-syntax.md) for the basic unit test functionality,

--- a/test/os.md
+++ b/test/os.md
@@ -1,0 +1,165 @@
+# OS specific function is host$os
+
+## ZGTIME
+
+ZGTIME returns a local clock  time in seconds and the
+used cpu time in milliseconds.
+	
+File: `timetest.x`
+```
+task timetest = t_timetest
+procedure t_timetest ()
+long clktime0, cputime0
+long clktime1, cputime1
+int errs
+begin
+    call zgtime(clktime0, cputime0)
+    if (clktime0 < 1280000000) {
+        call printf("Unreasonable clktime %d (cputime is %d)\n")
+            call pargl(clktime0)
+            call pargl(cputime0)
+	return
+    }
+    clktime1 = clktime0
+    cputime1 = cputime0
+    errs = 0
+    # Busy loop until wall clock increases by one second
+    while (clktime1 == clktime0) {
+        call zgtime(clktime1, cputime1)
+    }
+    if (clktime1 < clktime0) {
+        call printf("ERROR: Backward clktime %d --> %d\n")
+            call pargl(clktime0)
+            call pargl(clktime1)
+	errs = errs + 1
+    }
+    if (clktime1 > clktime0 + 2) {
+        call printf("ERROR: Clktime is too fast %d --> %d\n")
+            call pargl(clktime0)
+            call pargl(clktime1)
+	errs = errs + 1
+    }
+    if (clktime1 > clktime0 + 2) {
+        call printf("ERROR: Clktime is too fast %d --> %d\n")
+            call pargl(clktime0)
+            call pargl(clktime1)
+	errs = errs + 1
+    }
+    if (cputime1 < cputime0) {
+        call printf("ERROR: Backward cputime %d --> %d\n")
+            call pargl(cputime0)
+            call pargl(cputime1)
+	errs = errs + 1
+    }
+    if (cputime1 == cputime0) {
+        call printf("ERROR: Constant cputime %d --> %d\n")
+            call pargl(cputime0)
+            call pargl(cputime1)
+	errs = errs + 1
+    }
+    if (cputime1 > cputime0 + 1000 * (clktime1 - clktime0)) {
+        call printf("ERROR: Cputime faster that clktime: %d --> %d\n")
+            call pargl(cputime0)
+            call pargl(cputime1)
+	errs = errs + 1
+    }
+    call printf("%d errors\n")
+        call pargi(errs)
+end
+```
+
+The test program should just return zero errors:
+
+```
+cl> softools
+cl> xc -w timetest.x
+cl> task $timetest = timetest.e
+cl> timetest
+0 errors
+```
+
+## ZGMTCO
+
+ZGMTCO returns the correction, in seconds, from local standard
+time. This may have some issues with daylight saving time.
+
+File: `gmtcotest.x`
+```
+task gmtcotest = t_gmtcotest
+procedure t_gmtcotest ()
+int corr
+begin
+    call zgmtco(corr)
+	if ((corr < 315532800 - 86400) || (corr < 315532800 - 86400)) {
+	    call printf("Unreasonable correction %d\n")
+		    call pargi(corr)
+	} else {
+	    call printf("OK")
+	}
+end
+```
+
+The test program should just return OK:
+
+```
+cl> softools
+cl> xc -w gmtcotest.x
+cl> task $gmtcotest = gmtcotest.e
+cl> gmtcotest
+OK
+```
+
+## Non-local goto
+
+IRAF uses its own version of a "long jump" (non-local goto), which needs a
+small piece of code to be written in assembler (`zsvjmp.s`). This is highly
+CPU and OS specific. Here is some test code:
+
+File: `jmptest.x`
+```
+include <config.h>
+task jmptest = t_jmptest
+procedure t_jmptest ()
+int jmp_buf[LEN_JUMPBUF]
+int status, step
+begin
+    status = 0
+    step = 0
+
+    call zsvjmp(jmp_buf, status)
+    call printf("status = %d, step = %d\n")
+    call pargi(status)
+    call pargi(step)
+    if (status == 0) {
+        if (step == 1) {
+	    call printf("Error: Called zsvjmp a second time\n")
+            return
+	 }
+         step = 1
+         call printf("Calling zdojmp\n")
+         call zdojmp(jmp_buf, status)
+         call printf("Error: return from ZDOJMP\n")
+         return
+      }
+      if (step == 0) {
+         call printf("Error: ZSVJMP was not called successfully\n")
+         return
+      }
+      call printf("All OK\n")
+end
+```
+
+`ZSVJMP` saves the processor registers in a buffer, while a following `ZDOJMP`
+restores them (and therefore goes back to the place where `ZSVJMP was called).
+
+```
+cl> softools
+cl> xc -w jmptest.x
+cl> task $jmptest = jmptest.e
+cl> jmptest
+status = 0, step = 0
+Calling zdojmp
+status = 1, step = 1
+All OK
+```
+

--- a/test/programming.md
+++ b/test/programming.md
@@ -276,60 +276,6 @@ cl> otest
 
 See issue #73 for the bug report.
 
-## Non-local goto
-
-IRAF uses its own version of a "long jump" (non-local goto), which needs a
-small piece of code to be written in assembler (`zsvjmp.s`). This is highly
-CPU and OS specific. Here is some test code:
-
-File: `jmptest.x`
-```
-include <config.h>
-task jmptest = t_jmptest
-procedure t_jmptest ()
-int jmp_buf[LEN_JUMPBUF]
-int status, step
-begin
-    status = 0
-    step = 0
-
-    call zsvjmp(jmp_buf, status)
-    call printf("status = %d, step = %d\n")
-    call pargi(status)
-    call pargi(step)
-    if (status == 0) {
-        if (step == 1) {
-	    call printf("Error: Called zsvjmp a second time\n")
-            return
-	 }
-         step = 1
-         call printf("Calling zdojmp\n")
-         call zdojmp(jmp_buf, status)
-         call printf("Error: return from ZDOJMP\n")
-         return
-      }
-      if (step == 0) {
-         call printf("Error: ZSVJMP was not called successfully\n")
-         return
-      }
-      call printf("All OK\n")
-end
-```
-
-`ZSVJMP` saves the processor registers in a buffer, while a following `ZDOJMP`
-restores them (and therefore goes back to the place where `ZSVJMP was called).
-
-```
-cl> softools
-cl> xc -w jmptest.x
-cl> task $jmptest = jmptest.e
-cl> jmptest
-status = 0, step = 0
-Calling zdojmp
-status = 1, step = 1
-All OK
-```
-
 ## The `generic` preprocessor
 
 The `generic` preprocessor is used to translate generic source code (code

--- a/unix/os/zgmtco.c
+++ b/unix/os/zgmtco.c
@@ -1,9 +1,6 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
-
 #include <stdio.h>
-#include <time.h>
-
 #define	import_kernel
 #define	import_knames
 #define import_spp
@@ -18,9 +15,7 @@ ZGMTCO (
   XINT	*gmtcor				/* seconds */
 )
 {
-	time_t now = time(NULL);
-	struct tm ptm;
-	localtime_r(&now, &ptm);
-	*gmtcor = -ptm.tm_gmtoff;
-	return (XOK);
+    time_t gmt = 315532800; /* The value doesn't matter here; we take 1980-01-01 */
+    *gmtcor = gmt - gmt_to_lst(gmt);
+    return (XOK);
 }

--- a/unix/os/zgtime.c
+++ b/unix/os/zgtime.c
@@ -6,6 +6,7 @@
 #include <sys/times.h>
 #include <sys/time.h>
 #include <time.h>
+#include <unistd.h>
 
 #define	import_kernel
 #define	import_knames
@@ -27,7 +28,7 @@ ZGTIME (
 	long	cpu, clkfreq;
 
 
-	clkfreq = CLOCKS_PER_SEC;
+	clkfreq = sysconf(_SC_CLK_TCK);
 
 	times (&t);
 	*clock_time = gmt_to_lst (time(0));
@@ -39,11 +40,9 @@ ZGTIME (
 	cpu = (t.tms_utime + t.tms_cutime);
 
 	if (cpu > MAX_LONG/1000)
-	    /* *cpu_time = cpu / clkfreq * 1000;*/
-	    *cpu_time = cpu / 10;
+	  *cpu_time = cpu / clkfreq * 1000;
 	else
-	    /* *cpu_time = cpu * 1000 / clkfreq;*/
-	    *cpu_time = cpu * 10;
+	  *cpu_time = cpu * 1000 / clkfreq;
 
 	return (XOK);
 }


### PR DESCRIPTION
This should return the CPU time in milliseconds. In early versions, this was calculated as floating point `cpu*1000./clkfreq` with `clkfreq` being the clock ticks per second. At some point, floating point was tried to be avoided in the kernel, and so this got an (all integer)

    cpu * 1000 / clkfreq

To prevent (undiscovered) overflow for large values of `cpu` (namely when `cpu > MAX_LONG/1000)`, the order is reversed:

     cpu / clkfreq * 1000

Note that this is still the same operation, just a different order.
In version 2.15, determination of `clkfreq` seemed to be complicated as noticed in https://github.com/iraf-community/iraf/blob/216ab7d6bc20411d0dad16bde61902eee74fecd4/doc/notes.v214#L1511-L1513

It was then changed to the buggy

    if (cpu > MAX_LONG/1000)
        *cpu_time = cpu / 10;
    else
        *cpu_time = cpu * 10;

which is wrong, because is assumes `clkfreq=100`, and it also does the wrong thing for `cpu > MAX_LONG/1000`.

In POSIX, the clock frequency can be determined with `sysconf(_SC_CLK_TCK)`, which is used here now.