### PR TITLE
Update travis CI to latest macOS and Ubuntu versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 matrix:
   include:
     - os: linux
-      dist: bionic
+      dist: focal
       arch: amd64
-      env: IRAFARCH=linux64 OS_VERS=bionic RATFOR=ratfor
+      env: IRAFARCH=linux64 OS_VERS=focal RATFOR=ratfor
       addons:
         apt:
           update: true
-          sources:
-            - sourceline: 'ppa:olebole/astro-bionic'
           packages:
             - libcurl4-openssl-dev
             - libexpat1-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
             - libexpat1-dev:i386
             - libreadline-dev:i386
     - os: osx
-      osx_image: xcode11.4
+      osx_image: xcode12.2
       env: IRAFARCH=macintel OS_VERS=catalina
     - os: osx
       osx_image: xcode9.4

--- a/unix/os/zgmtco.c
+++ b/unix/os/zgmtco.c
@@ -15,6 +15,7 @@ ZGMTCO (
   XINT	*gmtcor				/* seconds */
 )
 {
+    time_t gmt_to_lst(time_t);
     time_t gmt = 315532800; /* The value doesn't matter here; we take 1980-01-01 */
     *gmtcor = gmt - gmt_to_lst(gmt);
     return (XOK);


### PR DESCRIPTION
This PR updates

 * the macOS build to xCode 12.2 (still on Catalina)
 * the Linux build to Ubuntu 20.04 "focal"

A minor issue was found with the macOS build: `gmt_to_lst()` needs to be declared before use.