### PR TITLE
Replace hard-coded host$bin paths by IRAFPATH

### DIFF
--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -68,36 +68,14 @@ irafpath (char *fname)
 	    return (fname);
 
 	/* Look first in HBIN.
+	 * Use IRAFARCH if defined.
 	 */
 	strcpy (pathname, (char *)hostdir);
 	strcat (pathname, "bin");
-
-#if defined( __APPLE__) /* These have special rules */
-
-#if defined (__x86_64__)
-	strcat (pathname, ".macintel");
-#elif defined (__i386__)
-	strcat (pathname, ".macosx");
-#endif
-
-#else /* ! __APPLE__ */
-
-#if defined (__linux__)
-	strcat (pathname, ".linux");
-#elif defined( __freebsd__)
-	strcat (pathname, ".freebsd");
-#elif defined( __hurd__)
-	strcat (pathname, ".hurd");
-#else
-	strcat (pathname, ".unknown");
-#endif
-
-#if (__SIZEOF_LONG__ == 8 && __SIZEOF_POINTER__ == 8) /* ILP64 */
-	strcat (pathname, "64");
-#endif
-
-#endif /* ! __APPLE__ */
-
+	if ( (irafarch = getenv("IRAFARCH")) ) {
+	    strcat (pathname, ".");
+	    strcat (pathname, irafarch);
+	}
 	strcat (pathname, "/");
 	strcat (pathname, fname);
 	if (access (pathname, 0) == 0)
@@ -111,15 +89,13 @@ irafpath (char *fname)
 	    return (pathname);
 
 	/* Try BIN - use IRAFARCH if defined. */
+	strcpy (pathname, (char *)irafdir);
+	strcat (pathname, "bin");
 	if ( (irafarch = getenv("IRAFARCH")) ) {
-	    strcpy (pathname, (char *)irafdir);
-	    strcat (pathname, "bin.");
+	    strcat (pathname, ".");
 	    strcat (pathname, irafarch);
-	    strcat (pathname, "/");
-	} else {
-	    strcpy (pathname, (char *)irafdir);
-	    strcat (pathname, "bin/");
 	}
+	strcat (pathname, "/");
 	strcat (pathname, fname);
 	if (access (pathname, 0) == 0)
 	    return (pathname);


### PR DESCRIPTION
The function `irafpath()` resolves the full path for a given IRAF file. The file is searched in the following directories:

 * `host$bin(arch)`: system build executables and libraries

 * `host$hlib`: include files and shell scripts

 * `iraf$bin(arch)`:  IRAF executables and libraries

 * `iraf$lib`: IRAF include files and libraries (links)

While `iraf$bin(arch)` is created from IRAFARCH, `host$bin(arch)` is hardcoded by defines like `#ifdef __x86_64__`. This has two disadvantages: First, it fixes the architecture names in the executable, and second it requires a source change for every new arch. And it does not allow to have only arch-independent directory names, as it is used f.e. in Debian.

 This patch unifies the handling architectures in `irafpath()`. This continues the path started with #117.

The code in question goes back to the first recorded IRAF version 2.8: https://github.com/iraf-community/iraf/blob/155505b5d94811bdda50d14e0aefaa30d2fe94d0/unix/os/irafpath.c#L68-L101

