### PR TITLE
Add macOS arm64 support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,8 +39,8 @@ The source distribution file is built as a tarball with the package
 name and version as base directory. Thus, distribution files can be
 unpacked with the command
 
-    $ tar zxf /<path>/iraf-2.16.1-2018.06.15.tar.gz
-    $ cd iraf-2.16.1-2018.06.15/
+    $ tar zxf /<path>/iraf-2.16.1-2018.11.01.tar.gz
+    $ cd iraf-2.16.1-2018.11.01/
 
 
 ## Build from Sources
@@ -69,12 +69,13 @@ Now you can configure the system for the proper architecture and build:
 
 For `<arch>`, use the proper IRAF architecture name:
 
-`<arch>`   | Operating system | CPU
------------|------------------|--------------------
+`<arch>`   | Operating system | Supported CPU types
+-----------|------------------|---------------------------------------
 `linux64`  | Linux 64 bit     | x86_64, arm64, mips64, ppc64, riscv64, alpha
 `linux`    | Linux 32 bit     | i386, x32, arm, mips
-`macintel` | Mac OS X 64 bit  | x86_64
-`macosx`   | Mac OS X 32 bit  | i386
+`macos64`  | macOS 64 bit     | arm64
+`macintel` | macOS 64 bit     | x86_64
+`macosx`   | macOS 32 bit     | i386
 `freebsd64`| FreeBSD 64 bit   | x86_64
 `freebsd`  | FreeBSD 32 bit   | i386, arm
 `hurd`     | GNU HURD 32 bit  | i386

--- a/Makefile
+++ b/Makefile
@@ -101,23 +101,13 @@ macosx::
 	(util/mkarch macosx)
 macintel::
 	(util/mkarch macintel)
-redhat::
-	(util/mkarch redhat)
+macos64::
+	(util/mkarch macos64)
 linux::
 	(util/mkarch linux)
 linux64::
 	(util/mkarch linux64)
 freebsd::
-	(util/mkarch freebsd)
-cygwin::
-	(util/mkarch cygwin)
-sunos::
-	(util/mkarch sunos)
-sparc::
-	(util/mkarch sparc)
-ssun::
-	(util/mkarch ssun)
-
 
 
 # ----------------------------------------------------------------------

--- a/mkpkg
+++ b/mkpkg
@@ -129,11 +129,6 @@ generic:				# make architecture indep. (no bins)
 	!(cd ./unix; export MACH=generic; sh setarch.sh)
 	;
 
-cygwin:					# install WinXP/Cygwin binaries
-        $verbose off
-        !$(hlib)/mkfloat cygwin
-        !(cd ./unix; export MACH=cygwin; sh setarch.sh)
-        ;
 freebsd:				# install freebsd binaries
         $verbose off
         !$(hlib)/mkfloat freebsd
@@ -160,28 +155,8 @@ macosx:					# install MacOS X (Unix 32-bit) binaries
         !$(hlib)/mkfloat macosx
         !(cd ./unix; export MACH=macosx; sh setarch.sh)
         ;
-ipad:					# install Mac iPad binaries
+macos64:				# install MacOS X (x86_64) binaries
         $verbose off
-        !$(hlib)/mkfloat ipad
-        !(cd ./unix; export MACH=ipad; sh setarch.sh)
+        !$(hlib)/mkfloat macos64
+        !(cd ./unix; export MACH=macos64; sh setarch.sh)
         ;
-redhat:					# install redhat binaries
-        $verbose off
-        !$(hlib)/mkfloat redhat
-        !(cd ./unix; export MACH=redhat; sh setarch.sh)
-        ;
-sparc:					# install sparc binaries
-	$verbose off
-	!$(hlib)/mkfloat sparc
-	!(cd ./unix; export MACH=sparc; sh setarch.sh)
-	;
-sunos:					# install sunos binaries
-        $verbose off
-        !$(hlib)/mkfloat sunos
-        !(cd ./unix; export MACH=sunos; sh setarch.sh)
-        ;
-ssun:					# install ssun binaries
-	$verbose off
-	!$(hlib)/mkfloat ssun
-	!(cd ./unix; export MACH=ssol; sh setarch.sh)
-	;

--- a/noao/mkpkg
+++ b/noao/mkpkg
@@ -115,115 +115,6 @@ generic:				# make architecture indep. (no bins)
 	             nproto nobsolete rv surfphot twodspec obsutil"
 	!$(hlib)/mkfloat generic -d $(DIRS)
 	;
-sparc:					# install sparc binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat sparc -d $(DIRS)
-	;
-ssun:					# install ssun binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat ssun -d $(DIRS)
-	;
-sf2c:					# install sf2c binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat sf2c -d $(DIRS)
-	;
-i386:					# install i386 binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat i386 -d $(DIRS)
-	;
-f68881:					# install f68881 binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat f68881 -d $(DIRS)
-	;
-ffpa:					# install ffpa binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat ffpa -d $(DIRS)
-	;
-fswitch:				# install fswitch binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat fswitch -d $(DIRS)
-	;
-fsoft:					# install fsoft binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat fsoft -d $(DIRS)
-	;
-pg:					# install -pg -f68881 binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat pg -d $(DIRS)
-	;
-f2c:					# install Macintosh A/UX f2c binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat f2c -d $(DIRS)
-	;
-alpha:					# install DEC Alpha/OSF binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat alpha -d $(DIRS)
-	;
-ddec:					# install DECstation DEC-Fortran bins
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat ddec -d $(DIRS)
-	;
-dmip:					# install DECstation MIPS-Fortran bins
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat dmip -d $(DIRS)
-	;
-irix:					# install SGI IRIX binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat irix -d $(DIRS)
-	;
-rs6000:					# install IBM AIX binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat rs6000 -d $(DIRS)
-	;
-mips:					# install MIPS workstation binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat mips -d $(DIRS)
-	;
-hp300:                                  # install HPUX series 300 binaries
-        $verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-        !$(hlib)/mkfloat hp300 -d $(DIRS)
-        ;
-hp700:                                  # install HPUX series 700 binaries
-hp800:					# install HPUX series 800/700 binaries
-        $verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-        !$(hlib)/mkfloat hp700 -d $(DIRS)
-        ;
 freebsd:				# install FREEBSD binaries
 	$verbose off
 	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
@@ -242,17 +133,11 @@ macintel:				# install MACOSX (x86) binaries
 	             nproto nobsolete rv surfphot twodspec obsutil"
 	!$(hlib)/mkfloat macintel -d $(DIRS)
 	;
-ipad:					# install Mac iPad  binaries
+macos64:				# install MACOSX (arm64) binaries
 	$verbose off
 	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
 	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat ipad -d $(DIRS)
-	;
-cygwin:					# install WinXP/Cygwin binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat cygwin -d $(DIRS)
+	!$(hlib)/mkfloat macos64 -d $(DIRS)
 	;
 linux:					# install Linux binaries
 	$verbose off
@@ -261,42 +146,6 @@ linux:					# install Linux binaries
 	!$(hlib)/mkfloat linux -d $(DIRS)
 	;
 linux64:				# install Linux x86_64 binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat linux64 -d $(DIRS)
-	;
-redhat:					# install Redhat Linux binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat redhat -d $(DIRS)
-	;
-suse:					# install SUSE Linux binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-		     nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat suse -d $(DIRS)
-	;
-linuz:					# install LINUZ binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat linuz -d $(DIRS)
-	;
-sunos:					# install SUNOS (Solaris x86) binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat sunos -d $(DIRS)
-	;
-linuxppc:				# install Linux (PPC) binaries
-	$verbose off
-	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
-	             nproto nobsolete rv surfphot twodspec obsutil"
-	!$(hlib)/mkfloat linuxppc -d $(DIRS)
-	;
-linux64:				# install Linux (64-bit) binaries
 	$verbose off
 	$set DIRS = "lib artdata astcat astutil digiphot imred mtlocal onedspec\
 	             nproto nobsolete rv surfphot twodspec obsutil"

--- a/pkg/cl/exec.c
+++ b/pkg/cl/exec.c
@@ -746,6 +746,13 @@ findexe (
 		if (c_access (bin_path, 0, 0) == YES)
 	    	    return (bin_path);
 
+	    } else if (strcmp (arch, ".macos64") == 0) {
+		/*  On 64-bit Mac systems, check for older 'macintel' binaries.
+		 */
+		sprintf (bin_path, "%s.macintel/%s.e", bin_root, root);
+		if (c_access (bin_path, 0, 0) == YES)
+		    return (bin_path);
+
 	    } else if (strcmp (arch, ".macintel") == 0) {
 		/*  On 64-bit Mac systems, check for older 32-bin binaries.
 		 */

--- a/pkg/ecl/exec.c
+++ b/pkg/ecl/exec.c
@@ -791,6 +791,13 @@ findexe (
 		if (c_access (bin_path, 0, 0) == YES)
 	    	    return (bin_path);
 
+	    } else if (strcmp (arch, ".macos64") == 0) {
+		/*  On 64-bit Mac systems, check for older 'macintel' binaries.
+		 */
+		sprintf (bin_path, "%s.macintel/%s.e", bin_root, root);
+		if (c_access (bin_path, 0, 0) == YES)
+		    return (bin_path);
+
 	    } else if (strcmp (arch, ".macintel") == 0) {
 		/*  On 64-bit Mac systems, check for older 32-bin binaries.
 		 */

--- a/pkg/ecl/grammar.y
+++ b/pkg/ecl/grammar.y
@@ -16,6 +16,7 @@
 #include "task.h"
 #include "construct.h"
 #include "errs.h"
+#include "proto.h"
 
 
 /* CL parser, written as a yacc grammar:

--- a/pkg/ecl/mkpkg
+++ b/pkg/ecl/mkpkg
@@ -46,7 +46,7 @@ relink:
 		param.h task.h
 link:
 	$set	LIBS = "-lc -lcur -lds -lstg"
-	$ifeq (MACH, macosx, macintel) then
+	$ifeq (MACH, macosx, macintel, macos64) then
 	  $set	LIBS2 = "-ledit"
 	$else
 	  $set	LIBS2 = "-lreadline"

--- a/pkg/ecl/ytab.c
+++ b/pkg/ecl/ytab.c
@@ -207,6 +207,7 @@
 #include "task.h"
 #include "construct.h"
 #include "errs.h"
+#include "proto.h"
 
 
 /* CL parser, written as a yacc grammar:

--- a/test/run_tests
+++ b/test/run_tests
@@ -265,7 +265,7 @@ for CL in $IRAF_SHELLS ; do
 done
 
 if [ -s "$summary_file" ] ; then
-    printf "Test summary: %s\\n" "$(sort "$summary_file" | uniq -c | sed ':a;N;$!ba;s/\\n */, /g')"
+    printf "Test summary: %s\\n" "$(sort "$summary_file" | uniq -c | sed ':a;N;$!ba;s/\\n */, /g' 2> /dev/null)"
 fi
 
 if [ -s "$failure_file" ] ; then

--- a/unix/hlib/cl.sh
+++ b/unix/hlib/cl.sh
@@ -105,12 +105,14 @@ else
         fi
     elif [ "$os_mach" = "darwin" ]; then	# handle Mac systems
         if [ "$(uname -m)" = "x86_64" ]; then
-            export mach="macintel"
+	     if [ "$(uname -m)" = "x86_64" ] ; then
+	         export mach="macintel"
+             else
+                 export mach="macos64"
+	     fi
         else
             export mach="macosx"
         fi
-    elif [ "$os_mach" = "cygwin" ]; then
-        export mach="cygwin"
     else
         mach=$(uname -s | tr '[:upper:]' '[:lower:]')
     fi

--- a/unix/hlib/ecl.sh
+++ b/unix/hlib/ecl.sh
@@ -105,12 +105,14 @@ else
         fi
     elif [ "$os_mach" = "darwin" ]; then	# handle Mac systems
         if [ "$(uname -m)" = "x86_64" ]; then
-            export mach="macintel"
+	     if [ "$(uname -m)" = "x86_64" ] ; then
+	         export mach="macintel"
+             else
+                 export mach="macos64"
+	     fi
         else
             export mach="macosx"
         fi
-    elif [ "$os_mach" = "cygwin" ]; then
-        export mach="cygwin"
     else
         mach=$(uname -s | tr '[:upper:]' '[:lower:]')
     fi

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -77,7 +77,7 @@ fi
 # Determine parameters for each architecture.
 if [ -n "$IRAFARCH" ]; then
     mach="$IRAFARCH"
-    if [ "$mach" = "macintel" ] || [ "$mach" = "freebsd64" ] || [ "$mach" = "linux64" ]; then
+    if [ "$mach" = "macintel" ] || [ "$mach" = "macos64" ] || [ "$mach" = "freebsd64" ] || [ "$mach" = "linux64" ]; then
 	nbits=64
     else
 	nbits=32
@@ -87,7 +87,11 @@ else
     case "$MNAME" in
      "darwin")		# Mac OS X
 	 if [ "$nbits" = 64 ] ; then
-             mach="macintel"
+	     if [ "$(uname -m)" = "x86_64" ] ; then
+	         mach="macintel"
+             else
+                 mach="macos64"
+	     fi
 	 else
              mach="macosx"
          fi

--- a/unix/hlib/strip.iraf
+++ b/unix/hlib/strip.iraf
@@ -31,4 +31,5 @@
 -file bin.linux64/OBJS.arc.Z
 -file bin.macosx/OBJS.arc.Z
 -file bin.macintel/OBJS.arc.Z
+-file bin.macos64/OBJS.arc.Z
 

--- a/unix/os/zsvjmp.S
+++ b/unix/os/zsvjmp.S
@@ -81,7 +81,11 @@ zsvjmp_:
 	str	x1, [x0], 8		// ((long **)buf)[0] = status
 	// also post-increment x0 by 8: 1st arg for sigsetjmp
 	mov	w1, 0			// 0 --> 2nd arg for sigsetjmp
+#if defined(__APPLE__)
+	b      _sigsetjmp		// call sigsetjmp
+#else
 	b      __sigsetjmp		// call sigsetjmp
+#endif
 
 #elif defined(__mips__) && (_MIPS_SIM == _ABI64)
 


### PR DESCRIPTION
This needs some changes:

 * [x] `zsvjmp.S` needs to be extended for arm64 at macOS. This is basically the same as for Linux on arm64, except that the sigsetjmp jump is `_sigsetjmp` on macOS. This is implemented now, but untested, due to the lack of Mac@arm64 hardware.

 * [x] We need a new architecture name for this. We could do either
 
     - **`macos64`**, which would be the logical analogon to `linux64`. We also could rename `macintel` at some point.
 
     - `macarm`, which would be the logical analogon to `macintel`.

     I now committed a change to `macos64`, because it is much clearer.