### PR TITLE
Fix fits times

### DIFF
--- a/test/os.md
+++ b/test/os.md
@@ -90,7 +90,7 @@ procedure t_gmtcotest ()
 int corr
 begin
     call zgmtco(corr)
-	if ((corr < 315532800 - 86400) || (corr < 315532800 - 86400)) {
+	if ((corr < - 86400) || (corr > 86400)) {
 	    call printf("Unreasonable correction %d\n")
 		    call pargi(corr)
 	} else {

--- a/unix/os/zgmtco.c
+++ b/unix/os/zgmtco.c
@@ -1,11 +1,15 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
+
 #include <stdio.h>
+#include <time.h>
+
 #define	import_kernel
 #define	import_knames
 #define import_spp
 #include <iraf.h>
 
+#define SECONDS_1970_TO_1980    315532800L
 
 /* ZGMTCO -- Return the correction, in seconds, from local standard time
  * (clock time) to GMT.   GMT = LST + gmtco (seconds), or gmtco = GMT-LST.
@@ -15,8 +19,18 @@ ZGMTCO (
   XINT	*gmtcor				/* seconds */
 )
 {
-    time_t gmt_to_lst(time_t);
-    time_t gmt = 315532800; /* The value doesn't matter here; we take 1980-01-01 */
-    *gmtcor = gmt - gmt_to_lst(gmt);
-    return (XOK);
+	time_t gmt_to_lst(), ltime;
+
+	/* Given an input value of zero (biased by SECONDS_1970_TO_1980)
+	 * gmt_to_lst will return a negative value in seconds for a location
+	 * in the US (as an limiting test case).  We want to return the
+	 * correction to LST to get GMT, a positive value for the US, so
+	 * we need to negate this value.  gmt_to_lst will already have taken
+	 * daylight savings time into account.  Although we talk about the
+	 * US (as a test case) this relation will hold both east and west
+	 * of Greenwich.
+	 */
+
+	*gmtcor = -((XINT) gmt_to_lst ((time_t) SECONDS_1970_TO_1980));
+	return (XOK);
 }


### PR DESCRIPTION
Revert part of #118, where we assumed that gmtco converts GMT (Unix) time into LST. In fact this is not the case (so, I think the name is a bit misleading, as it assumes the same as `gmt_to_lst`), but it just gives the current local correction in time.

`zgmtco` gives the time difference for the following numbers:

 * Seconds since 1980-01-01 local time ("LST")
 * Seconds since 1980-01-01 UTC ("GMT")
    
Both are (should be) monotone, so the difference is just the start. Therefore, we calculate the difference on the base of the begin of the epoch, and revert (almost) to the original version from IRAF 2.11. Adding the current (!) summer time (as done in version 2.12) seems to  be a wrong idea here.

This fixes #135 