### PR TITLE
SLALIB bug

### DIFF
--- a/math/slalib/eqeqx.f
+++ b/math/slalib/eqeqx.f
@@ -21,9 +21,7 @@
 *
 *  Called:  slNUTC
 *
-*  Patrick Wallace   Starlink   23 August 1996
-*
-*  Copyright (C) 1996 Rutherford Appleton Laboratory
+*  Patrick Wallace   Starlink   23 August 1996, amended 22 May 2021
 *
 *  License:
 *    This program is free software; you can redistribute it and/or modify
@@ -41,7 +39,6 @@
 *    Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 *    Boston, MA  02110-1301  USA
 *
-*  Copyright (C) 1995 Association of Universities for Research in Astronomy Inc.
 *-
 
       IMPLICIT NONE
@@ -66,7 +63,7 @@
      :         +(7.455D0+0.008D0*T)*T)*T)
 
 *  Nutation
-      CALL slNUTC(DATE,DPSI,DEPS,EPS0)
+      CALL slNUTC80(DATE,DPSI,DEPS,EPS0)
 
 *  Equation of the equinoxes
       slEQEX=DPSI*COS(EPS0)+AS2R*(0.00264D0*SIN(OM)+


### PR DESCRIPTION
This is taken from a mail from Patrick Wallace <patrick.wallace@STFC.AC.UK> to the starlink-users mailing list:

> To whom it may concern...
> 
> I have discovered a decades-old bug in the SLALIB routine `sla_EQEQX`:
> 
> https://github.com/Starlink/starlink/blob/master/libraries/sla/eqeqx.f
> 
> It causes observed places (the direction of the incoming radiation from a celestial source) to be wrong by an amount that was zero at J2000.0 but grows steadily and at the present time has reached almost 0.1 arcseconds.
> 
> Corrected code (including the test program) is attached.  For anyone interested, the story is as follows.
> 
> * Using the classical pre IAU 2000 equinox based methods, hour angles are obtained by subtracting apparent right ascension from the local apparent sidereal time.
> 
> * The local apparent sidereal time involves the quantity "equation of the equinoxes", which is the difference between mean and
>   apparent sidereal time.
> 
> * Most of the equation of the equinoxes comes from the nutation in longitude.
> 
> * The previous, incorrect, `sla_EQEQX` obtained the nutation components by calling the routine `sla_NUTC`.
> 
> * `sla_NUTC` implements the nutation model of Shirai & Fukushima (2001).
> 
> * Shirai & Fukushima included in their nutation model a secular term that compensated for the imperfect precession model in use  at that time.  Thus the combination of IAU 1976 precession and the Shirai & Fukushima delivered milliarcsecond accuracy  aparent places, which is good.
> 
> * However, this secular term has no place in the computation of the nutation per se, and has been polluting SLALIB's computation of sidereal time.
> 
> * The cure is simply to fall back on the nutation model that predates Shirai & Fukushima (2001), namely the IAU 1980 model.
> 
> * The fix to `sla_EQEQX` has been simply to call `sla_NUTC80` instead of `sla_NUTC`.
> 
> * The corrected `sla_EQEQX` delivers equation of the equinoxes values that agree to better than 1 mas with more recent algorithms.
> 
> I doubt there are any applications out there where this bug has had any practical effect.  The pollution has been smooth and gradual, and is at least an order of magnitude below the level important for telescope pointing;  in any case, pointing models have probably been fudging it out.  The most critical would probably be interferometer delays, and such applications really ought to be using modern post IAU 2000 CIO based algorithms.
> 
> Patrick Wallace
> 
> _____________________________________________________________________________________________
> RAL Space                                            +44-1235-531198
> STFC Rutherford Appleton Laboratory
> Harwell Oxford
> Didcot, Oxfordshire, OX11 0QX, UK         Patrick.Wallace@stfc.ac.uk
> _____________________________________________________________________________________________
