### PR TITLE
Fix test for RATFOR variable

### DIFF
--- a/unix/boot/spp/rpp/mkpkg.sh
+++ b/unix/boot/spp/rpp/mkpkg.sh
@@ -4,11 +4,11 @@
 # Exit on error
 set -e
 
-if [ "$(RATFOR)" ] ; then
+if [ "${RATFOR}" ] ; then
     echo "------------------- Ratfor preprocessing ---------------"
     rm -f rppfor/*.f ratlibf/*.f rpprat/fort ratlibr/fort
-    make -C rpprat RATFOR=$(RATFOR)
-    make -C ratlibr RATFOR=$(RATFOR)
+    make -C rpprat RATFOR=${RATFOR}
+    make -C ratlibr RATFOR=${RATFOR}
 fi
 
 echo "----------------------- RPPFOR -------------------------"


### PR DESCRIPTION
The `RATFOR` variable is used to determine whether we want Ratfor preprocessing (see #103); however it was references by `$(RATFOR)` instead of `${RATFOR}` in the shell script. This patch fixes this (used in the Debian build, as Debian builds completely from sources).