### PR TITLE
Support freeBSD variants

### DIFF
--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -105,7 +105,7 @@ else
          fi
          ;;
 
-     "freebsd")
+     "*freebsd")
 	 if [ "$nbits" = 64 ] ; then
              mach="freebsd64"
          else


### PR DESCRIPTION
This patch makes the test for freebsd more generic, as there exist some exotic variants: kfreeBSD is a Debian on top of a freeBSD kernel. The architecture string then is "gnu/kfreebsd".

So, we enable wildcard prefixes to `freebsd` to check it..
