### PR TITLE
Force using POSIX shell in extpkg.cl script

### DIFF
--- a/unix/hlib/extpkg.cl
+++ b/unix/hlib/extpkg.cl
@@ -15,15 +15,15 @@ extdir = osfn ("iraf$extern")
 # Go to the dynamic package directory, but save the current directory so
 # we can return when we're done.  At this stage of the login we need to 
 # use host commands since the system package isn't available.
-printf ("!/bin/pwd\n") | cl () | scan (curdir)
+printf ("!!/bin/pwd\n") | cl () | scan (curdir)
 chdir (extdir)
 
 #  Create a file list to process.
 dpkg = mktemp ("tmp$dpkg")
 if (access (dpkg) == yes)
-  printf ("!/bin/rm -f %s\n", osfn(dpkg))                              	| cl ()
+  printf ("!!/bin/rm -f %s\n", osfn(dpkg))                             	| cl ()
 ;
-printf ("!/bin/ls -1ad [a-y]* 2> /dev/null\n") | cl (,> dpkg)
+printf ("!!/bin/ls -1ad [a-y]* 2> /dev/null\n") | cl (,> dpkg)
 
 list = dpkg
 while (fscan (list, s1) != EOF) {
@@ -52,7 +52,7 @@ while (fscan (list, s1) != EOF) {
 }
 
 # Clean up and go back to the login directory.
-printf  ("!/bin/rm -f %s\n", osfn(dpkg))                               	| cl ()
+printf  ("!!/bin/rm -f %s\n", osfn(dpkg))                               | cl ()
 if (curdir != "") {
     chdir (curdir)
 } else {

--- a/unix/os/zoscmd.c
+++ b/unix/os/zoscmd.c
@@ -51,7 +51,7 @@ ZOSCMD (
 	sout = (char *)stdout_file;
 	serr = (char *)stderr_file;
 
-	/* The Bourne shell SH is used if the first character of the cmd
+	/* The POSIX shell SH is used if the first character of the cmd
 	 * is '!' or if the user does not have SHELL defined in their
 	 * environment.
 	 */


### PR DESCRIPTION
Some shells behave differently; namely zsh prints a warning itself when a glob doesn't match.  This is f.e. the case when one tries to get the list of external packages from an empty dir with https://github.com/iraf-community/iraf/blob/bcb80b314cbd8c4ee253abec1e2ca64645428579/unix/hlib/extpkg.cl#L26

With zsh, this leads to a message "no matches found" which disturbs f.e. the tests. See f.e. https://github.com/iraf-community/iraf/discussions/178#discussioncomment-882244 for such a failure.

The solution is to use `!!`  in the cl script so that `/bin/sh` is forced to be used. Generally, the scripts provided by IRAF should be independent of the user's shell (just checked that this is the only place where this happens).