### PR TITLE
Remove duplicate argument in call

### DIFF
--- a/noao/imred/src/fibers/fibresponse.cl
+++ b/noao/imred/src/fibers/fibresponse.cl
@@ -116,7 +116,7 @@ begin
 			clean=clean, extras=no)
 		else
 		    apscript (flat2d, output=resp, ansrecenter="NO",
-			ansrecenter="NO", ansresize="NO", ansedit="NO",
+			ansresize="NO", ansedit="NO",
 			anstrace="NO", background="none",
 			clean=clean, extras=no)
 	    } else
@@ -207,7 +207,7 @@ begin
 		print ("Set aperture throughput using ", skyflat2d) | tee (log1)
 		if (!access (apref // mstype)) {
 		    apscript (apref, output=resp, ansrecenter="NO",
-			ansrecenter="NO", ansresize="NO", ansedit="NO",
+			ansresize="NO", ansedit="NO",
 			anstrace="NO", background="none",
 			clean=no, extras=no)
 		    sarith (resp, "replace", "0", resp, w1=INDEF,


### PR DESCRIPTION
Duplicate arguments are not needed, and they confuse PyRAF (as discovered when test-compiling all IRAF CL procedures with PyRAF)
The other problem is the `default` argument in https://github.com/iraf-community/iraf/blob/6ba125dfa9da44704e345b695b159985720ce2b0/noao/imred/crutil/src/credit.cl#L6-L12

which converts to illegal Python code. This is unresolved now.
