### PR TITLE
[skip ci] Add IRAF authors list

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,49 @@
+# Authors of NOAO IRAF
+
+This list was compiled from the IRAF newsletter, web page, and the
+revision notes:
+
+ * Ed Anderson
+ * Jeanette Barnes
+ * David Bell
+ * Chris Biemesderfer
+ * Todd Boroson
+ * Matt Cheselka
+ * Mike Cobb
+ * Dennis Crabtree
+ * Lindsey Davis
+ * Michele De La Peña
+ * Elwood Downey
+ * Jonathan Eisenhamer
+ * Mike Fitzpatrick
+ * Pedro Gigoux
+ * Rick Hill
+ * George Jacoby
+ * Suzanne Jacoby
+ * Dyer Lytle
+ * Eric Mandel
+ * Phil Massey
+ * Tom McGlynn
+ * Drew Phillips
+ * Fred Romelfanger
+ * Steve Rooke
+ * Jim Rose
+ * Skip Schaller
+ * Rob Seaman
+ * Peter Shames
+ * Richard Shaw
+ * Peter Stetson
+ * Cliff Stoll
+ * Doug Tody
+ * Jay Travisano
+ * Frank Valdes
+ * Phillip Warner
+ * Richard Wolff
+ * Nelson Zarate
+
+# Contributors from the IRAF community
+
+ * Christian Dersch
+ * Ole Streicher
+ * Chisato Yamauchi
+ * Josef Wang


### PR DESCRIPTION
The basic idea is to keep the names of those who contributed to IRAF.