### PR TITLE
Update remaining version numbers to 2.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 # Compiler Flags.
 
-RELEASE		= v2.16
+RELEASE		= v2.17
 export CFLAGS	= -g -Wall -O2 $(CARCH)
 export LDFLAGS	= $(CARCH)
 export  iraf     = $(shell pwd)/

--- a/install
+++ b/install
@@ -39,7 +39,7 @@ if [ -z "$IRAFARCH" ]; then
     IRAFARCH=$mach
 fi
 
-VERSION="v2.16"                         # current IRAF version
+VERSION="v2.17"                         # current IRAF version
 
 defterm="xgterm"			# default terminal type
 do_system=0				# system or personal install?

--- a/pkg/cl/cl.par
+++ b/pkg/cl/cl.par
@@ -20,10 +20,10 @@ menus,b,h,yes,,,Display menu when changing packages?
 showtype,b,h,no,,,Add task-type suffix in menus?
 notify,b,h,yes,,,Send done message when bkgrnd task finishes?
 szprcache,i,h,4,1,10,Size of the process cache
-version,s,h,"IRAF V2.17 2021",,,IRAF version
+version,s,h,"IRAF V2.17 2022",,,IRAF version
 logver,s,h,"",,,login.cl version
 logregen,b,h,no,,,Updating of login.cl to current version is advised
-release,s,h,"2.16",,,IRAF release
+release,s,h,"2.17",,,IRAF release
 mode,s,h,ql,,,CL mode of execution (query or query+learn)
 
 auto,s,h,a,,,The next 4 params are read-only.

--- a/pkg/ecl/cl.par
+++ b/pkg/ecl/cl.par
@@ -20,10 +20,10 @@ menus,b,h,yes,,,Display menu when changing packages?
 showtype,b,h,no,,,Add task-type suffix in menus?
 notify,b,h,yes,,,Send done message when bkgrnd task finishes?
 szprcache,i,h,4,1,10,Size of the process cache
-version,s,h,"IRAF V2.17 2021",,,IRAF version
+version,s,h,"IRAF V2.17 2022",,,IRAF version
 logver,s,h,"",,,login.cl version
 logregen,b,h,no,,,Updating of login.cl to current version is advised
-release,s,h,"2.16",,,IRAF release
+release,s,h,"2.17",,,IRAF release
 mode,s,h,ql,,,CL mode of execution (query or query+learn)
 
 auto,s,h,a,,,The next 4 params are read-only.


### PR DESCRIPTION
These have been forgotten in #170 (616fe81332e3ca4eeb734ddfc805f11b6d332bd9) before the release.

Closes: #220 