### PR TITLE
Add .note.GNU-stack section to zsvjmp.S

### DIFF
--- a/unix/os/zsvjmp.S
+++ b/unix/os/zsvjmp.S
@@ -225,3 +225,7 @@ zsvjmp_:
 #else
 #error "Unsupported CPU type"
 #endif
+
+#if defined(__ELF__)
+	.section        .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Modern gcc on ELF systems require an explicit mark of whether the stack is executable or not. This one marks the stack as *not* executable.