### PR TITLE
Replace vfork() with fork()

### DIFF
--- a/unix/os/zfiopr.c
+++ b/unix/os/zfiopr.c
@@ -16,7 +16,6 @@
 #include <iraf.h>
 
 extern	int errno;		/* error code returned by the kernel	*/
-/* #define	vfork	fork */
 
 extern void pr_enter (int pid, int inchan, int outchan);
 
@@ -98,13 +97,11 @@ err:	    close (pin[0]);  close (pin[1]);
 	pr_ionbytes[pout[0]] = 0;
 	pr_ionbytes[pout[1]] = 0;
 
-	/* Create child process.  Vfork is used to avoid necessity to copy
-	 * the full address space of the parent, since we are going to overlay
-	 * a new process immediately with Execl anyhow.  The child inherits
-	 * the open stdio files.  The fork can fail if swap space is full or
-	 * if we have too many processes.
+	/* Create child process.  The child inherits the open stdio
+	 * files.  The fork can fail if swap space is full or if we
+	 * have too many processes.
 	 */
-	while ((*pid = vfork()) == ERR) {
+	while ((*pid = fork()) == ERR) {
 	    if (--maxforks == 0) {
 		close (pin[0]);  close (pin[1]);
 		close (pout[0]); close (pout[1]);

--- a/unix/os/zopdpr.c
+++ b/unix/os/zopdpr.c
@@ -16,7 +16,6 @@
 #include <iraf.h>
 
 #define	QUANTUM		6
-/* #define	vfork	fork */
 
 extern void pr_enter (int pid, int inchan, int outchan);
 extern int  pr_wait (int pid);
@@ -86,13 +85,11 @@ ZOPDPR (
 	else
 	    priority = sum;
 
-	/* Create child process.  Vfork is used to avoid necessity to copy
-	 * the full address space of the parent, since we are going to overlay
-	 * a new process immediately with Execl anyhow.  The child inherits
-	 * the open stdio files.  The fork can fail if swap space is full or
-	 * if we have too many processes.
+	/* Create child process.  The child inherits the open stdio
+	 * files.  The fork can fail if swap space is full or if we
+	 * have too many processes.
 	 */
-	while ((pid = vfork()) == ERR) {
+	while ((pid = fork()) == ERR) {
 	    if (--maxforks == 0) {
 		*jobcode = XERR;
 		return (XERR);
@@ -120,10 +117,7 @@ ZOPDPR (
 
 	    setpriority (PRIO_PROCESS, 0, priority);
 
-	    /* Since we used vfork we share memory with the parent until the
-	     * call to execl(), hence we must not close any files or do
-	     * anything else which would corrupt the parent's data structures.
-	     * Instead, immediately exec the new process (will not return if
+	    /* Immediately exec the new process (will not return if
 	     * successful).  The "-d" flag tells the subprocess that it is a
 	     * detached process.  The background file name is passed to the
 	     * child, which reads the file to learn what to do, and deletes

--- a/unix/os/zoscmd.c
+++ b/unix/os/zoscmd.c
@@ -17,8 +17,6 @@
 static	int lastsig;
 extern	int pr_onint(int usig, int *hwcode, int *scp);
 
-/* #define	vfork	fork */
-
 extern void pr_enter (int pid, int inchan, int outchan);
 extern int  pr_wait (int pid);
 
@@ -63,15 +61,8 @@ ZOSCMD (
 
 	sigaction (SIGINT, NULL, &oldact);
 
-	/* Vfork is faster if we can use it.
-	 */
-	if (*sin == EOS && *sout == EOS && *serr == EOS) {
-	    while ((pid = vfork()) == ERR)
-		sleep (2);
-	} else {
-	    while ((pid =  fork()) == ERR)
-		sleep (2);
-	}
+	while ((pid =  fork()) == ERR)
+	  sleep (2);
 
 	if (pid == 0) {
 	    /* Child.


### PR DESCRIPTION
`vfork()` is marked obsolete in POSIX.1-2001 and was removed from Posix in POSIX.1-2008. Newer macOS compilers warn about this, so we remove it. `vfork()` was used in Debian only for speed improvements by avoiding copying the address space; however modern systems use copy-on-write, this argument is not actual anymore.