### PR TITLE
Fix a bug in the parsing of directory arguments of mkfloat

### DIFF
--- a/unix/hlib/mkfloat
+++ b/unix/hlib/mkfloat
@@ -63,7 +63,7 @@ DIRS=""
 if [ "$1" = "-d" ]; then
     DIRS=""
     shift
-    while : ; do
+    while "$1" ; do
 	DIRS="$DIRS $1"
 	shift
     done


### PR DESCRIPTION
This is required to use mkfloat (when building an external package) with the "-d" option.