### PR TITLE
Update host commands documentation

### DIFF
--- a/unix/boot/mkpkg/extern.h
+++ b/unix/boot/mkpkg/extern.h
@@ -14,4 +14,3 @@ extern	int	verbose;		/* print informative messages	*/
 extern	int	ignore;			/* ignore warns			*/
 extern	int	execute;		/* think but don't act?		*/
 extern	int	exit_status;		/* exit status of last syscall	*/
-extern	int	forceupdate;		/* foribly update libmod dates	*/

--- a/unix/boot/mkpkg/extern.h
+++ b/unix/boot/mkpkg/extern.h
@@ -5,7 +5,6 @@ extern	struct	symbol symtab[];	/* symbol table (macros)	*/
 extern	struct	context *topcx;		/* currently active context	*/
 extern	char	*cp;			/* pointer into sbuf		*/
 extern	char	*ctop;			/* top of sbuf			*/
-extern	char	irafdir[];		/* iraf root directory		*/
 extern	int	nsymbols;		/* number of defined symbols	*/
 extern	int	ifstate[];		/* $IF stack			*/
 extern	int	iflev;			/* $IF stack pointer		*/

--- a/unix/boot/mkpkg/host.c
+++ b/unix/boot/mkpkg/host.c
@@ -44,7 +44,7 @@ char	*resolvefname(char *fname);
 char	*mkpath(char *module, char *directory, char *outstr);
 
 int   h_updatelibrary (char *library, char *flist[], int totfiles, 
-                char *xflags, char *irafdir);
+                char *xflags);
 int   h_rebuildlibrary (char *library);
 int   h_incheck (char *file, char *dir);
 int   h_outcheck (char *file, char *dir, int clobber);
@@ -82,8 +82,7 @@ h_updatelibrary (
     char   *library,		/* pathname of library		*/
     char   *flist[],		/* pointers to filename strings	*/
     int	    totfiles,		/* number of files in list	*/
-    char   *xflags,		/* XC compiler flags		*/
-    char   *irafdir 		/* iraf root directory		*/
+    char   *xflags		/* XC compiler flags		*/
 )
 {
 	char	cmd[SZ_CMD+1], *args;
@@ -105,10 +104,7 @@ h_updatelibrary (
 	 * Compile the files.
 	 * -------------------
 	 */
-	if (irafdir[0])
-	    sprintf (cmd, "%s -r %s %s", xc_path, irafdir, xflags);
-	else
-	    sprintf (cmd, "%s %s", xc_path, xflags);
+	sprintf (cmd, "%s %s", xc_path, xflags);
 
 	if (debug)
 	    strcat (cmd, " -d");

--- a/unix/boot/mkpkg/main.c
+++ b/unix/boot/mkpkg/main.c
@@ -44,7 +44,6 @@ char	*ctop = &sbuf[SZ_SBUF];		/* top of sbuf			*/
 int	npkg = 0;			/* number of packages		*/
 char	*pkgenv[MAX_PKGENV];		/* package environments		*/
 char	v_pkgenv[SZ_PKGENV+1];		/* buffer for pkgenv names	*/
-char	irafdir[SZ_PATHNAME+1];		/* iraf root directory		*/
 int	nsymbols = 0;			/* number of defined symbols	*/
 int	ifstate[SZ_IFSTACK];		/* $IF stack			*/
 int	iflev;				/* $IF stack pointer		*/
@@ -67,11 +66,6 @@ extern  int  ZZSTOP (void);
 extern  int  do_mkpkg (struct context *cx, int islib);
 
 
-
-void 
-zzpause (void) { printf ("ready ...."); (void) getc(stdin); }
-
-
 /* MAIN -- Entry point of mkpkg.e
  */
 int
@@ -87,7 +81,6 @@ main (int argc, char *argv[])
 
 	/* Initialize the MKPKG context.
 	 */
-	irafdir[0] = EOS;
 	topcx = cx = (struct context *) calloc (1, sizeof (struct context));
 	if (cx == NULL)
 	    fatals ("out of memory (%s)", "mkpkg.e");
@@ -151,15 +144,6 @@ main (int argc, char *argv[])
 			break;
 		    case 'v':
 			verbose = YES;
-			break;
-		    case 'w':
-			zzpause();
-			break;
-		    case 'r':
-			if (*argp == NULL)
-			    warns ("missing argument to switch `-r'", NULL);
-			else
-			    strcpy (irafdir, *argp++);
 			break;
 		    default:
 addflag:		for (op=flags;  *op;  op++)

--- a/unix/boot/mkpkg/main.c
+++ b/unix/boot/mkpkg/main.c
@@ -53,7 +53,6 @@ int	verbose = NO;			/* print informative messages	*/
 int	ignore = YES;			/* ignore warns			*/
 int	execute = YES;			/* think but don't act?		*/
 int	exit_status;			/* exit status of last syscall	*/
-int	forceupdate = NO;		/* forcibly update libmod dates	*/
 extern	char *os_getenv(char *);
 
 
@@ -138,9 +137,6 @@ main (int argc, char *argv[])
 			    if (npkg++ >= MAX_PKGENV)
 				fatals ("too many -p package arguments", NULL);
 			}
-			break;
-		    case 'u':
-			forceupdate = YES;
 			break;
 		    case 'v':
 			verbose = YES;

--- a/unix/boot/mkpkg/mkpkg.h
+++ b/unix/boot/mkpkg/mkpkg.h
@@ -158,7 +158,7 @@ int   fn_strncpy (char *out, char *in, int maxch);
 
 /*  host.c  */ 
 int   h_updatelibrary (char *library, char *flist[], int totfiles, 
-		char *xflags, char *irafdir);
+		char *xflags);
 int   h_rebuildlibrary (char *library);
 int   h_incheck (char *file, char *dir);
 int   h_outcheck (char *file, char *dir, int clobber);

--- a/unix/boot/mkpkg/mkpkg.hlp
+++ b/unix/boot/mkpkg/mkpkg.hlp
@@ -14,7 +14,7 @@ character in the switch, e.g., "-d" is level one, "-dd" is level two, and
 so on.  The debug messages get progressively more detailed as the debug level
 increases.  Debug mode automatically enables the verbose mode messages.
 .le
-.ls 10 \fB-f file\fR
+.ls 10 \fB-f \fIfile\fR
 Set the name of the file to be interpreted (default: "mkpkg").
 The special value "stdin" (lower case) allows commands to be entered
 interactively from the standard input, e.g., for debugging \fImkpkg\fR.
@@ -36,23 +36,12 @@ host level to accomplish the same thing.  The package name \fImust\fR
 be specified when doing software development in an external or layered
 package.
 .le
-.ls 10 \fB-u\fR    [AOSVS/IRAF only]
-Forcibly update the dates of improperly dated library modules.  This option
-is used when a binary archive is restored on a machine which cannot restore
-the file modify dates.  In this case, all source file dates would appear to
-have been modified since the libraries were updated, causing all sources to
-be recompiled.  By running \fImkpkg\fR with the \fI-u\fR flag, one can update
-the library module dates without recompiling the associated files.  This is
-done by setting the date of each library module to be no older than the
-file \fIhlib$iraf.h\fR, which should be "touched" after the system has fully
-been restored to disk to mark the installation time.  Note that files which
-have been modified \fIsince\fR the system was restored to disk will still
-cause the affected library modules to be updated, even when the \fI-u\fR flag
-is specfied.
-.le
 .ls 10 \fB-v\fR
 Verbose mode.  A message is printed whenever a file is touched.
 Recommended when running large mkpkg jobs in batch mode.
+.le
+.ls 10 \fB-x\fR, \fB-g\fR
+Define the symbol "DEBUG" to build for debugging.
 .le
 .ls 10 \fBmodule\fR
 The names of the module or modules (named entries in the "mkpkg" file) to be
@@ -133,7 +122,6 @@ directory or a logical directory.
 
 .ks
 .nf
-	as$		where .s files go		host$as/
 	bin$		installed executables		iraf$bin/
 	dev$		device tables			iraf$dev/
 	hlib$		machdep header files		host$hlib/
@@ -470,13 +458,12 @@ Delete the named file or files.
 .ls \fB$generic\fR [-k] [-p prefix] [-t types] [-o root] files
 .sp
 Run the generic preprocessor on the named files.  The generic preprocessor
-is an IRAF bootstrap utility and may not be available on non-UNIX hosts.
+is an IRAF bootstrap utility.
 .le
 .ls \fB$xyacc\fR [options] file
 .sp
 Run the xyacc parser generator on the named files.  The yacc parser
-generator is an IRAF bootstrap utility and may not be available on
-non-UNIX hosts.
+generator is an IRAF bootstrap utility.
 .le
 .ls \fB$link\fR [switches] file1 file2 ... fileN [-o file.e]
 .sp

--- a/unix/boot/mkpkg/mkpkg.man
+++ b/unix/boot/mkpkg/mkpkg.man
@@ -44,21 +44,6 @@ host level to accomplish the same thing.  The package name \fImust\fR
 be specified when doing software development in an external or layered
 package.
 .TP
-.B \-u  [AOSVS/IRAF only]
-Forcibly update the dates of improperly dated library modules.  This
-option is used when a binary archive is restored on a machine which
-cannot restore the file modify dates.  In this case, all source file
-dates would appear to have been modified since the libraries were
-updated, causing all sources to be recompiled.  By running \fBmkpkg\fP
-with the \fB-u\fP flag, one can update the library module dates
-without recompiling the associated files.  This is done by setting the
-date of each library module to be no older than the file
-\fBhlib$iraf.h\fP, which should be "touched" after the system has
-fully been restored to disk to mark the installation time.  Note that
-files which have been modified \fIsince\fR the system was restored to
-disk will still cause the affected library modules to be updated, even
-when the \fB-u\fP flag is specified.
-.TP
 .B \-v
 Verbose mode.  A message is printed whenever a file is touched.
 Recommended when running large mkpkg jobs in batch mode.
@@ -137,7 +122,6 @@ logical directories; these are summarized in the list below.  The IRAF
 the current directory or a logical directory.
 
 .nf
-        as$         where .s files go             host$as/
         bin$        installed executables         iraf$bin/
         dev$        device tables                 iraf$dev/
         hlib$       machdep header files          host$hlib/
@@ -453,13 +437,12 @@ Delete the named file or files.
 .B $generic \fP[\fI-k\fP] [\fI-p prefix\fP] [\fI-t types\fP] [\fI-o root\fP] \fIfiles\fP
 .sp
 Run the generic preprocessor on the named files.  The generic preprocessor
-is an IRAF bootstrap utility and may not be available on non-UNIX hosts.
+is an IRAF bootstrap utility.
 .TP
 .B $xyacc \fP[\fIoptions\fP] \fIfile\fP
 .sp
 Run the xyacc parser generator on the named files.  The yacc parser
-generator is an IRAF bootstrap utility and may not be available on
-non-UNIX hosts.
+generator is an IRAF bootstrap utility.
 .TP
 .B $link \fP[\fIswitches\fP] \fIfile1 file2 ... fileN \fP[\fI-o file.e\fP]
 .sp

--- a/unix/boot/mkpkg/pkg.c
+++ b/unix/boot/mkpkg/pkg.c
@@ -364,7 +364,7 @@ next_:	    tok = gettok (cx, token, SZ_FNAME);
 	 * been reached (but only if the module being processed is a library
 	 * list).
 	 */
-	if (cx->totfiles == 0 && !forceupdate) {
+	if (cx->totfiles == 0) {
 	    printf ("Library %s is up to date\n", cx->library);
 	    fflush (stdout);
 	} else if (exit_status == OK || ignore) {

--- a/unix/boot/mkpkg/pkg.c
+++ b/unix/boot/mkpkg/pkg.c
@@ -328,7 +328,7 @@ next_:	    tok = gettok (cx, token, SZ_FNAME);
 		    /* Compile the modules and update the library.
 		     */
 		    exit_status = h_updatelibrary (cx->libpath,
-			cx->flist, cx->nfiles, getsym(XFLAGS), irafdir);
+			cx->flist, cx->nfiles, getsym(XFLAGS));
 		    if (exit_status == INTERRUPT)
 			fatals ("<ctrl/c> interrupt %s", cx->library);
 		    cx->totfiles += cx->nfiles;

--- a/unix/boot/mkpkg/scanlib.c
+++ b/unix/boot/mkpkg/scanlib.c
@@ -30,7 +30,6 @@
  */
 
 #define	SZ_KEY		128		/* arbitrary			*/
-extern	int forceupdate;		/* NOT IMPLEMENTED for UNIX	*/
 
 char	mlb_sbuf[SZ_SBUF];		/* string buffer		*/
 int	mlb_op = 0;			/* index into string buffer	*/

--- a/unix/boot/mkpkg/tok.c
+++ b/unix/boot/mkpkg/tok.c
@@ -789,10 +789,7 @@ do_omake (
 		strcat (xflags, "-x ");
 	    strcat (xflags, s_xflags);
 
-	    if (irafdir[0])
-		sprintf (cmd, "%s %s -r %s %s", xc_path, xflags, irafdir, fname);
-	    else
-		sprintf (cmd, "%s %s %s", xc_path, xflags, fname);
+	    sprintf (cmd, "%s %s %s", xc_path, xflags, fname);
 
 	    if (verbose) {
 		printf ("%s\n", cmd);
@@ -830,10 +827,7 @@ do_xc (struct context *cx)
 	    fflush (stdout);
 	}
 
-	if (irafdir[0])
-	    sprintf (cmd, "%s -r %s", xc_path, irafdir);
-	else
-	    sprintf (cmd, "%s", xc_path);
+	sprintf (cmd, "%s", xc_path);
 
 	if (debug)
 	    strcat (cmd, " -d");
@@ -908,10 +902,7 @@ do_link (struct context *cx)
 	} else
 	    lflags = getsym (LFLAGS);
 
-	if (irafdir[0])
-	    sprintf (cmd, "%s %s -r %s", xc_path, lflags, irafdir);
-	else
-	    sprintf (cmd, "%s %s", xc_path, lflags);
+	sprintf (cmd, "%s %s", xc_path, lflags);
 
 	if (debug)
 	    strcat (cmd, " -d");

--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -25,7 +25,7 @@
  * system.
  */
 
-#define VERSION		"IRAFNET XC V2.4 Jan 21 2010"
+#define VERSION		"IRAF community XC V2.5 Mar 15 2023"
 
 #define	ERR		(-1)
 #define	EOS		'\0'
@@ -128,7 +128,6 @@ int	nolibc 		= NO;
 int	usef2c 		= YES;
 int	useg95 		= NO;
 int	userincs	= NO;
-int	useg2c 		= NO;
 int	host_c_main 	= NO;
 
 char	ccomp[SZ_FNAME] 	= CCOMP;
@@ -200,9 +199,9 @@ static void  fatal (char *s);
  *	f77		UNIX fortran compiler
  *	cc		compile other sources, link if desired
  *
- *  The Fortran source is left behind if the -F flag is given.  The IRAF root
- *  directory must either be given on the command line as "-r pathname" or in
- *  the environment as the variable "irafdir".
+ *  The Fortran source is left behind if the -F flag is given.  The
+ *  IRAF root directory must be given in the environment as the
+ *  variable "iraf".
  */
 int
 main (int argc, char *argv[])
@@ -394,12 +393,6 @@ main (int argc, char *argv[])
 		    i++;
 		    break;
 
-		case 'r':
-		    /* Not used anymore */
-		    if ((arg = argv[++i]) == NULL)
-			i--;
-		    break;
-
 		case 'h':
 		    /* Host program: do not link in IRAF main or search
 		     * standard IRAF libraries unless explicitly referenced
@@ -414,12 +407,6 @@ main (int argc, char *argv[])
 		    hostprog++;
 		    noedsym++;
 		    nolibc++;
-		    break;
-
-		case 'G':
-		    /* Force a program to link w/ libg2c.a instead of libf2c.a
-		     */
-		    useg2c++;
 		    break;
 
 		case 'A':
@@ -617,16 +604,6 @@ passflag:		    mkobject = YES;
 		    ip++;
 	    }
 	}
-
-	/* Now check for any alternative compiler definitions or commandline
-	 * flags which will affect out link line.  Some systems like LinuxPPC
-	 * will require use of -lg2c even though we can continue to use the
-	 * hlib$f77.sh the fortran compiler script on that system.
-	 */
-	if (useg2c || strncmp (f77comp, "g77", 3) == 0) {
-	    fortlib[0] = fortlib[1] = "-lg2c";
-	}
-
 
 	/* Compile all F77 source files with F77 to produce object code.
 	 * This compilation is separate from that used for the '.x' files,

--- a/unix/boot/spp/xc.hlp
+++ b/unix/boot/spp/xc.hlp
@@ -7,17 +7,6 @@ USAGE
 xc [flags] files
 .ih
 FLAGS
-.ls 10 -a
-To support VMS link options file.  Next file is taken to be the VMS name
-of a link options file.  This is primarily for using long lists of files
-or libraries and not for actual VMS Linker options, since XC adds continuation
-characters where it believes it is appropriate.
-.le
-.ls 10 -C
-Tells fortran to do array bound and other checking.
-By default no checking is done.  From DCL fortran usually
-does array and overflow checking which is not used here.
-.le
 .ls 10 -c
 Tells \fIxc\fR not to link, i.e., not to create an executable.
 .le
@@ -28,7 +17,7 @@ Causes debug messages to be printed during execution.
 Do not delete the Fortran translation of an SPP source file.
 .le
 .ls 10 -g
-Generates debugging information and (for VMS), links in the debugger.
+Generates debugging information.
 .le
 .ls 10 -h
 Causes the executable to be linked as a host program, i.e., without the
@@ -36,33 +25,43 @@ IRAF main and without searching the IRAF libraries, unless explicitly
 referenced on the command line.  Used to compile and link host (e.g., Fortran)
 programs which may or may not reference the IRAF libraries.
 .le
-.ls 10 -i2
-Tells fortran to use I*2 by default.
+.ls 10 -H
+Link a host program as with "-h", but include the VOS libraries.
 .le
-.ls 10 -i4
-Tells fortran to use I*4 by default.
+.ls 10 -A
+Force architecture specific include files.
 .le
-.ls 10 -l\fIlib\fR
-This tells the linker which libraries besides the standard
-ones to include.  These must be either on the current
+.ls 10 -C
+Link a host program which has a C main.  We may need to tweak the
+command line as a special case here since we normally assume Fortran
+sources.
+.le
+.ls 10 -/\fIflag\fR, -//\fIfoo\fR
+Pass \fIflag\fR to host compiler without further
+interpretation. "-/\fIflag\fR" becomes "-\fIfoo\fR", "-//\fIfoo\fR"
+becomes "\fIfoo\fR".
+.le
+.ls 10 -D\fIdefine\fR
+Pass a -D\fIdefine\fR flag on to the host compiler.
+.le
+.ls 10 -I\fIdir\fR
+Pass a -I\fIdir\fR flag on to the host compiler.  A special case is
+"-Inolibc" which disables automatic inclusion of the IRAF LIBC
+includes (hlib$libc).
+.le
+.ls 10 -l\fIlib\fR, -L\fIdir\fR
+This tells the linker which library files or library directories
+besides the standard ones to include.  These must be either on the current
 directory, or in an IRAF system library (lib$ or hlib$).
 The library specification must be immediately after the option as in
 "-lxtools".  No other option may follow the 'l' option in the same
-argument as in -lxtoolsO.	
-.le
-.ls 10 -L
-Creates a list file. VMS specific.
-.le
-.ls 10 -M, -m
-Tells the linker to create a link map.
-.le
-.ls 10 -n
-Not really supported under VMS since "normal" users
-cannot install images.  In Unix this is just a link
-option to make a shareable image.
+argument as in -lxtoolsO.
 .le
 .ls 10 -N
-Same as -z for VMS.
+Generates the output temp file in /tmp during the link, then moves it
+to the output directory in one operation when done.  For cases such as
+linking in an NFS-mounted directory, where all the NFS i/o may slow
+the link down excessively.
 .le
 .ls 10 -Nh [filename]
 This tells xpp that the foreign definitions in the
@@ -88,23 +87,12 @@ host level to accomplish the same thing.  The package name \fImust\fR
 be specified when doing software development in an external or layered
 package.
 .le
-.ls 10 -P
-Check portability.  This should be used all of the time in IRAF,
-but the VMS C compiler forces the use of non-standard
-constructs in some cases.  Also <stdio.h> and <ctype.h> get
-complaints for the above reason.  This may be used and probably
-should when working with Fortran due to Dec non-standard
-extension.
-.le
 .ls 10 -q
 Disable optimization.  Opposite of -O.  Object code will be optimized
 by default.
 .le
 .ls 10 -s
 Strips all symbols and debugging information.
-.le
-.ls 10 -S
-Same as -s for VMS.
 .le
 .ls 10 -v
 Verbose mode.  Causes messages to be printed during execution telling
@@ -113,52 +101,46 @@ what the \fIxc\fR program is doing.
 .ls 10 -w
 Suppress warnings.				
 .le
-.ls 10 -X, -x
-Compile and link for debugging.  In VMS/IRAF, links in the VMS debugger
-and symbols.
+.ls 10 -x
+Compile and link for debugging.
 .le
 .ls 10 -z
 Create a non-shareable image (default).
 .le
+.ls 10 -V
+Print XC version identification.
+.le
 .ih
 DESCRIPTION
 XC is a machine independent utility for compiling and linking IRAF
-tasks or files.  The XC utility may also be used to compile and/or link
-non-IRAF files and tasks.  The VMS version of XC supports all of the
-important flags except -D which VMS C doesn't support in any way.
-It can be used to generate fortran from xpp or ratfor code, to compile any
-number of files, and then link them if desired.  XC accepts and maps IRAF
-virtual filenames, but since it is a standalone bootstrap utility the
-environment is not passed, hence logical directories cannot be used.
+tasks or files.  The XC utility may also be used to compile and/or
+link non-IRAF files and tasks. It can be used to generate fortran from
+xpp or ratfor code, to compile any number of files, and then link them
+if desired.  XC accepts and maps IRAF virtual filenames, but since it
+is a standalone bootstrap utility the environment is not passed, hence
+logical directories cannot be used.
 
-The following extensions are supported by the VMS version of xc:
-.x, .r, .f, .ftn, .for, .c, .mar, .s, .o, .obj, .a, .olb, .e, .exe.
 It is suggested that everyone stick with the iraf virtual file name extensions.
-These are : .x, .r, .f, .c, .s, .o, .a, .e. The mapping of these to their
-VMS counterparts is:
+These are : .x, .r, .f, .c, .s, .o, .a, .e.
+The meaning of these is:
 
 .ks
 .nf
-     .x -> .x    SPP code
-     .r -> .r    Ratfor code
-     .f -> .for  Fortran code
-     .c -> .c    C code
-     .s -> .mar  Macro assembler code
-     .o -> .obj  Object module
-     .a -> .olb  Library file
-     .e -> .exe  Executable Image
+     .x  SPP code
+     .r  Ratfor code
+     .f  Fortran code
+     .c  C code
+     .s  Macro assembler code
+     .o  Object module
+     .a  Library file
+     .e  Executable Image
 .fi
 .ke
 
-XC is available both in the CL, via the foreign task interface, and as
-a standalone DCL callable task.  Usage is equivalent in either case.  Upper
-case flags must be quoted to be recognized (the upper case flags will be
-done away with at some point).
+XC is available both in the CL and as a standalone task.
+Usage is equivalent in either case.
 .ih
 EXAMPLES
-Any upper case flags in the following examples must be doubly quoted in
-the CL, singly quoted in VMS, to make it to XC without VMS mapping
-everything to one case.  Omit the "-x" flag on a UNIX system.
 
 1. Compile and link the source file "mytask.x" to produce the executable
 "mytask.e".
@@ -194,12 +176,6 @@ everything to one case.  Omit the "-x" flag on a UNIX system.
 
 XC is often combined with \fImkpkg\fR to automatically maintain large packages
 or libraries.
-.ih
-BUGS
-The -S flag should generate assembler
-output but does not presently do so in the VMS version.  All case sensitive
-switches should be done away with in both the UNIX and VMS versions of the
-utility.
 .ih
 SEE ALSO
 mkpkg, generic

--- a/unix/boot/spp/xc.man
+++ b/unix/boot/spp/xc.man
@@ -9,48 +9,31 @@ xc \- portable IRAF compile/link utility
 .SH DESCRIPTION
 \fBXC\fP is a machine independent utility for compiling and linking
 IRAF tasks or files.  The XC utility may also be used to compile
-and/or link non-IRAF files and tasks.  The VMS version of XC supports
-all of the important flags except \-D which VMS C doesn't support in
-any way.  It can be used to generate fortran from xpp or ratfor code,
-to compile any number of files, and then link them if desired.  XC
-accepts and maps IRAF virtual filenames, but since it is a standalone
-bootstrap utility the environment is not passed, hence logical
-directories cannot be used.
+and/or link non-IRAF files and tasks. It can be used to generate
+fortran from xpp or ratfor code, to compile any number of files, and
+then link them if desired.  XC accepts and maps IRAF virtual
+filenames, but since it is a standalone bootstrap utility the
+environment is not passed, hence logical directories cannot be used.
 
-The following extensions are supported by the VMS version of 
-xc: .x, .r, .f, .ftn, .for, .c, .mar, .s, .o, .obj, .a, .olb, .e, .exe.
 It is suggested that everyone stick with the iraf virtual file name
-extensions.  These are : .x, .r, .f, .c, .s, .o, .a, .e. The mapping
-of these to their VMS counterparts is:
+extensions.  These are : .x, .r, .f, .c, .s, .o, .a, .e. The meaning
+of these is:
 
 .nf
-     .x -> .x    SPP code
-     .r -> .r    Ratfor code
-     .f -> .for  Fortran code
-     .c -> .c    C code
-     .s -> .mar  Macro assembler code
-     .o -> .obj  Object module
-     .a -> .olb  Library file
-     .e -> .exe  Executable Image
+     .x   SPP code
+     .r   Ratfor code
+     .f   Fortran code
+     .c   C code
+     .s   Macro assembler code
+     .o   Object module
+     .a   Library file
+     .e   Executable Image
 .fi
 
-XC is available both in the CL, via the foreign task interface, and as
-a standalone DCL callable task.  Usage is equivalent in either case.
-Upper case flags must be quoted to be recognized (the upper case flags
-will be done away with at some point).
+XC is available both in the CL and as
+a standalone task.  Usage is equivalent in either case.
 
 .SH FLAGS
-.TP
-.B -a
-To support VMS link options file.  Next file is taken to be the VMS
-name of a link options file.  This is primarily for using long lists
-of files or libraries and not for actual VMS Linker options, since XC
-adds continuation characters where it believes it is appropriate.
-.TP
-.B -C
-Tells fortran to do array bound and other checking.  By default no
-checking is done.  From DCL fortran usually does array and overflow
-checking which is not used here.
 .TP
 .B -c
 Tells \fBxc\fR not to link, i.e., not to create an executable.
@@ -62,7 +45,7 @@ Causes debug messages to be printed during execution.
 Do not delete the Fortran translation of an SPP source file.
 .TP
 .B -g
-Generates debugging information and (for VMS), links in the debugger.
+Generates debugging information .
 .TP
 .B -h
 Causes the executable to be linked as a host program, i.e., without
@@ -71,31 +54,43 @@ explicitly referenced on the command line.  Used to compile and link
 host (e.g., Fortran) programs which may or may not reference the IRAF
 libraries.
 .TP
-.B -i2
-Tells fortran to use I*2 by default.
+.B -H
+Link a host program as with "-h", but include the VOS libraries.
 .TP
-.B -i4
-Tells fortran to use I*4 by default.
+.B -A
+Force architecture specific include files.
 .TP
-.B -l\fIlib\fR
-This tells the linker which libraries besides the standard ones to
-include.  These must be either on the current directory, or in an IRAF
-system library (lib$ or hlib$).  The library specification must be
-immediately after the option as in "\-lxtools".  No other option may
-follow the 'l' option in the same argument as in \-lxtoolsO.
+.B -C
+Link a host program which has a C main.  We may need to tweak the
+command line as a special case here since we normally assume Fortran
+sources.
 .TP
-.B -L
-Creates a list file. VMS specific.
+.B -/\fIflag\fR, \fB-//\fIfoo
+Pass \fIflag\fR to host compiler without further
+interpretation. "-/\fIflag\fR" becomes "-\fIfoo\fR", "-//\fIfoo\fR"
+becomes "\fIfoo\fR".
 .TP
-.B -M\fR,\fB -m
-Tells the linker to create a link map.
+.B -D\fIdefine
+Pass a -D\fIdefine\fR flag on to the host compiler.
 .TP
-.B -n
-Not really supported under VMS since "normal" users cannot install
-images.  In Unix this is just a link option to make a shareable image.
+.B -I\fIdir
+Pass a -I\fIdir\fR flag on to the host compiler.  A special case is
+"-Inolibc" which disables automatic inclusion of the IRAF LIBC
+includes (hlib$libc).
+.TP
+.B -l\fIlib\fR, \fB-L\fIdir\fR
+This tells the linker which library files or library directories
+besides the standard ones to include.  These must be either on the current
+directory, or in an IRAF system library (lib$ or hlib$).
+The library specification must be immediately after the option as in
+"-lxtools".  No other option may follow the 'l' option in the same
+argument as in -lxtoolsO.	
 .TP
 .B -N
-Same as \-z for VMS.
+Generates the output temp file in /tmp during the link, then moves it
+to the output directory in one operation when done.  For cases such as
+linking in an NFS-mounted directory, where all the NFS i/o may slow
+the link down excessively.
 .TP
 .B -Nh \fR[\fIfilename\fR]
 This tells xpp that the foreign definitions in the file specified
@@ -119,13 +114,6 @@ level to accomplish the same thing.  The package name \fImust\fR be
 specified when doing software development in an external or layered
 package.
 .TP
-.B -P
-Check portability.  This should be used all of the time in IRAF, but
-the VMS C compiler forces the use of non-standard constructs in some
-cases.  Also <stdio.h> and <ctype.h> get complaints for the above
-reason.  This may be used and probably should when working with
-Fortran due to Dec non-standard extension.
-.TP
 .B -q
 Disable optimization.  Opposite of \-O.  Object code will be optimized
 by default.
@@ -143,12 +131,11 @@ what the \fBxc\fR program is doing.
 .B -w
 Suppress warnings.                              
 .TP
-.B -X\fR,\fB -x
-Compile and link for debugging.  In VMS/IRAF, links in the VMS
-debugger and symbols.
-.TP
 .B -z
 Create a non-shareable image (default).
+.TP
+.B V
+Print XC version identification.
 
 .SH SEE ALSO
 .BR mkpkg (1),


### PR DESCRIPTION
This PR syncs the online documentation and manpages and the source code for xc and mkpkg: 

* remove documentation of options that are not available (either removed, or not available on Unix hosts)
* Remove few options from the sources that are not implemented:
  - xc **-G** (force a program to link w/ libg2c.a instead of libf2c.a)
  - xc **-r** (dummy; set irafdir before)
  - mkpkg **-r** (set irafdir)
  - mkpkg **-u** (forcibly update libmod dates)

Also, VMS specifics were removed.