### PR TITLE
Stop mkpkg execution if an error was discovered

### DIFF
--- a/mkpkg
+++ b/mkpkg
@@ -54,13 +54,6 @@ mathlibs:
 packages:
 	$echo "====================== PACKAGES ========================="
 	$echo "+" $echo "+"
-
-	# On the UNIX distribution, the BIN directory is excluded from the
-	# tar tape in a "you relink" distribution.  Lets make sure we have
-	# the directory before proceeding to relink all the packages.
-
-	$ifeq (hostid, unix)  !(mkdir $(iraf)bin >& /dev/null)  $endif
-
 	$call update@pkg
 	$echo "+" $echo "+"
 	;

--- a/unix/boot/mkpkg/char.c
+++ b/unix/boot/mkpkg/char.c
@@ -71,7 +71,7 @@ m_getc (register struct context *cx)
 	     */
 	    if (name[0] == '?') {
 		/* Interactive query. */
-		if ((cx->fp == stdin)) {
+		if (cx->fp == stdin) {
 		    warns ("`$(%s)': cannot query in -f stdin mode", name);
 		    val = &name[1];
 		} else {

--- a/unix/boot/mkpkg/host.c
+++ b/unix/boot/mkpkg/host.c
@@ -148,6 +148,8 @@ h_updatelibrary (
 		if ((status = os_cmd (cmd)) != OK) {
 		    if (status == INTERRUPT)
 			fatals ("<ctrl/c> interrupt %s", library);
+		    if (status != OK)
+		        errors ("Command '%s' returned error", cmd);
 		    if (!ignore)
 			baderr++;
 		    exit_status += status;
@@ -213,8 +215,11 @@ h_updatelibrary (
 
 		    for (i=0;  i < nfiles;  i++)
 			os_delete (makeobj (flist[ndone+i]));
-		} else if (exit_status == INTERRUPT)
+		} else if (exit_status == INTERRUPT) {
 		    fatals ("<ctrl/c> interrupt %s", library);
+		} else {
+	            errors ("Command '%s' returned error", cmd);
+		}
 	    }
 
 	    /* Truncate command and repeat with the next few files.

--- a/unix/boot/mkpkg/main.c
+++ b/unix/boot/mkpkg/main.c
@@ -306,8 +306,8 @@ warns (char *fmt, char *arg)
 	char	errmsg[SZ_LINE+1];
 
 	sprintf (errmsg, fmt, arg);
-	printf ("Warning, %s line %d: %s\n", topcx->mkpkgfile, topcx->lineno,
-	    errmsg);
+	printf ("%s%s:%d: warning: %s\n", topcx->curdir, topcx->mkpkgfile,
+		topcx->lineno, errmsg);
 	fflush (stdout);
 }
 
@@ -321,8 +321,8 @@ errors (char *fmt, char *arg)
 	char	errmsg[SZ_LINE+1];
 
 	sprintf (errmsg, fmt, arg);
-	printf ("Error, %s line %d: %s\n", topcx->mkpkgfile, topcx->lineno,
-	    errmsg);
+	printf ("%s%s:%d: error: %s\n", topcx->curdir, topcx->mkpkgfile,
+		topcx->lineno, errmsg);
 	fflush (stdout);
 	if (ignore == NO)
 	  exit (OSOK+1);
@@ -338,8 +338,8 @@ fatals (char *fmt, char	*arg)
 	char	errmsg[SZ_LINE+1];
 
 	sprintf (errmsg, fmt, arg);
-	printf ("Fatal error, %s line %d: %s\n", topcx->mkpkgfile,
-	    topcx->lineno, errmsg);
+	printf ("%s%s:%d: fatal: %s\n", topcx->curdir,
+		topcx->mkpkgfile, topcx->lineno, errmsg);
 	fflush (stdout);
 	exit (OSOK+1);
 }

--- a/unix/boot/mkpkg/main.c
+++ b/unix/boot/mkpkg/main.c
@@ -50,7 +50,7 @@ int	iflev;				/* $IF stack pointer		*/
 int	debug = 0;			/* print debug messages		*/
 int	dbgout = 0;			/* compile for debugging	*/
 int	verbose = NO;			/* print informative messages	*/
-int	ignore = YES;			/* ignore warns			*/
+int	ignore = NO;			/* ignore warns			*/
 int	execute = YES;			/* think but don't act?		*/
 int	exit_status;			/* exit status of last syscall	*/
 extern	char *os_getenv(char *);
@@ -297,7 +297,7 @@ addflag:		for (op=flags;  *op;  op++)
 }
 
 
-/* WARNS -- Print error message with one string argument but do not terminate
+/* WARNS -- Print warning message with one string argument but do not terminate
  * program execution.
  */
 void
@@ -309,6 +309,23 @@ warns (char *fmt, char *arg)
 	printf ("Warning, %s line %d: %s\n", topcx->mkpkgfile, topcx->lineno,
 	    errmsg);
 	fflush (stdout);
+}
+
+
+/* ERRORS -- Print error message with one string argument and terminate
+ * program execution if -i flag is not given.
+ */
+void
+errors (char *fmt, char *arg)
+{
+	char	errmsg[SZ_LINE+1];
+
+	sprintf (errmsg, fmt, arg);
+	printf ("Error, %s line %d: %s\n", topcx->mkpkgfile, topcx->lineno,
+	    errmsg);
+	fflush (stdout);
+	if (ignore == NO)
+	  exit (OSOK+1);
 }
 
 

--- a/unix/boot/mkpkg/mkpkg.h
+++ b/unix/boot/mkpkg/mkpkg.h
@@ -125,6 +125,7 @@ char	*k_fgets(char *op, int maxch, register struct context *cx);
 
 /*  main.c  */
 void warns (char *fmt, char *arg);
+void errors (char *fmt, char *arg);
 void fatals (char *fmt, char *arg);
 
 

--- a/unix/boot/mkpkg/mkpkg.hlp
+++ b/unix/boot/mkpkg/mkpkg.hlp
@@ -340,7 +340,8 @@ Test if the value of the named symbol matches one of the listed value strings.
 .ls \fB$iferr\fR
 .sp
 Test for an error return from the last directive executed which touched
-a file.
+a file. This has only effect if mkpkg is invoked with the \fB-i\fR option
+so that it doesn't exit on the first error.
 .le
 .ls \fB$iffile\fR (file [, file,...])
 .sp

--- a/unix/boot/mkpkg/mkpkg.hlp
+++ b/unix/boot/mkpkg/mkpkg.hlp
@@ -20,8 +20,7 @@ The special value "stdin" (lower case) allows commands to be entered
 interactively from the standard input, e.g., for debugging \fImkpkg\fR.
 .le
 .ls 10 \fB-i\fR
-Ignore errors.  Execution continues even if an error occurs.  In most cases
-it does anyhow, so this switch has little effect at present.
+Ignore errors.  Execution continues even if an error occurs.
 .le
 .ls 10 \fB-n\fR
 No execute.  Go through the motions, but do not touch any files.

--- a/unix/boot/mkpkg/mkpkg.man
+++ b/unix/boot/mkpkg/mkpkg.man
@@ -326,7 +326,9 @@ Test if the value of the named symbol matches one of the listed value strings.
 .B $iferr
 .sp
 Test for an error return from the last directive executed which touched
-a file.
+a file. This has only effect if mkpkg is invoked with the \fB-i\fR option
+so that it doesn't exit on the first error.
+
 .TP
 .B $iffile\fP (\fIfile\fP [, \fIfile\fP, \fI...\fP])
 .sp

--- a/unix/boot/mkpkg/mkpkg.man
+++ b/unix/boot/mkpkg/mkpkg.man
@@ -28,8 +28,7 @@ interactively from the standard input, e.g., for debugging
 \fBmkpkg\fP.
 .TP
 .B \-i
-Ignore errors.  Execution continues even if an error occurs.  In most
-cases it does anyhow, so this switch has little effect at present.
+Ignore errors. Execution continues even if an error occurs.
 .TP
 .B \-n
 No execute.  Go through the motions, but do not touch any files.  No

--- a/unix/boot/mkpkg/pkg.c
+++ b/unix/boot/mkpkg/pkg.c
@@ -46,7 +46,7 @@ do_mkpkg (
 		topcx = cx->prev;
 
 	    sprintf (fname, "%s%s", cx->curdir, cx->mkpkgfile);
-	    warns ("cannot open `%s'", fname);
+	    errors ("cannot open `%s'", fname);
 
 	    topcx = save_cx;
 	    return (ERR);
@@ -147,7 +147,7 @@ scan_modlist (
 	     * library is possible.
 	     */
 	    if ((exit_status = h_scanlibrary (cx->library)) != OK) {
-		warns ("error reading library file `%s'", cx->library);
+		errors ("error reading library file `%s'", cx->library);
 		return (ERR);
 	    }
 	}
@@ -372,6 +372,8 @@ next_:	    tok = gettok (cx, token, SZ_FNAME);
 	     */
 	    if ((exit_status = h_rebuildlibrary (cx->library)) == INTERRUPT)
 		fatals ("<ctrl/c> interrupt %s", cx->library);
+	    if (exit_status != OK)
+	        errors ("Error rebuilding library %s", cx->library);
 	    printf ("Updated %d files in %s\n", cx->totfiles, cx->library);
 	    fflush (stdout);
 	}
@@ -550,7 +552,7 @@ push_context (
 	    }
 
 	    if (os_chdir (newdir) == ERR) {
-		warns ("cannot access subdirectory `%s'", newdir);
+		errors ("cannot access subdirectory `%s'", newdir);
 		free (ncx);
 		return (NULL);
 	    } else {
@@ -657,13 +659,13 @@ get_dependency_list (
 		goto done;
 	    case TOK_FNAME:
 		if (nfiles >= MAX_DEPFILES)
-		    warns ("too many dependency files for module `%s'", module);
+		    errors ("too many dependency files for module `%s'", module);
 		dflist[nfiles++] = putstr (fname);
 		break;
 	    case TOK_END:
-		warns ("unexpected EOF in dependency list for `%s'", module);
+		errors ("unexpected EOF in dependency list for `%s'", module);
 	    default:
-		warns ("bad token `%s' in dependency list", fname);
+		errors ("bad token `%s' in dependency list", fname);
 	    }
 	}
 

--- a/unix/boot/mkpkg/pkg.c
+++ b/unix/boot/mkpkg/pkg.c
@@ -546,11 +546,6 @@ push_context (
 	    strcat (ncx->curdir, newdir);
 	    strcat (ncx->curdir, "/");
 
-	    if (debug) {
-		printf ("change directory to `%s'\n", newdir);
-		fflush (stdout);
-	    }
-
 	    if (os_chdir (newdir) == ERR) {
 		errors ("cannot access subdirectory `%s'", newdir);
 		free (ncx);
@@ -559,6 +554,9 @@ push_context (
 		os_fpathname ("", ncx->dirpath, SZ_PATHNAME);
 		ncx->level++;
 	    }
+
+	    printf ("mkpkg[%d]: Entering directory `%s'\n",
+		    ncx->level, ncx->dirpath);
 
 	    /* Initialize the file date cache, since the filenames therein
 	     * often reference the current directory.
@@ -596,6 +594,10 @@ pop_context (
 	    level = cx->level;
 	    pcx   = cx->prev;
 
+	    if (level > pcx->level)
+	        printf ("mkpkg[%d]: Leaving directory `%s'\n",
+			cx->level, cx->dirpath);
+
 	    root_modlist = (strcmp (cx->library, pcx->library) != 0);
 	    if (!root_modlist)
 		pcx->totfiles += cx->totfiles;
@@ -611,11 +613,6 @@ pop_context (
 	    iflev    = cx->old_iflev;
 
 	    if (level > pcx->level) {
-		if (debug) {
-		    printf ("chdir ..\n");
-		    fflush (stdout);
-		}
-
 		if (os_chdir (pcx->dirpath) == ERR)
 		    fatals ("cannot return from subdirectory", cx->curdir);
 

--- a/unix/boot/mkpkg/scanlib.c
+++ b/unix/boot/mkpkg/scanlib.c
@@ -64,7 +64,10 @@ h_scanlibrary (char *library)
 	char	lbuf[SZ_LINE];
 	struct	ar_hdr arf;
 	long	length, fdate;
-	int	len=0, len_arfmag, nmodules;
+	int	len_arfmag, nmodules;
+#if defined(AR_EFMT1) && !defined(__CYGWIN__)
+	int	len=0;
+#endif
 	FILE	*fp;
 	struct stat library_stat;
 

--- a/unix/boot/mkpkg/tok.c
+++ b/unix/boot/mkpkg/tok.c
@@ -598,7 +598,7 @@ do_call (
 	int	old_nsymbols;
 
 	strcpy (modspec, program);
-	if (debug && ifstate[iflev] == PASS) {
+	if (ifstate[iflev] == PASS) {
 	    printf ("$call %s\n", modspec);
 	    fflush (stdout);
 	}


### PR DESCRIPTION
One annoying thing of the IRAF build is that errors during the build process are almost ignored, and the build process continues. First, this makes it hard to check if the compilation finally succeeded, then it is a waste of time, and finally, it is very hard to find where the error actually appeared.

This PR solves this by letting mkpkg fail whenever an error appeared. This is implemented by an **errors()** function which complements the existing **warns()** and **fatals()**. While **warns()** just continues, and **fatals()** always exits with an error, **errors()** exits only if the **-i** flag (ignore errors) is not set.

A number of **warns()** calls are now replaced by **errors()** calls; this will make **mkpkg** more picky against errors in the control file by default, which is a good thing.
Also, external calls to **xc**, **xyacc**, **generic** and host programs are now checked and lead to an **errors()** call when not **OK**.

This already found the first bug; a left-over `mkdir bin` in the toplevel mkpkg file which doesn't work anymore.

Old behavior can be restored with the **-i** command line flag. This is required if the `$iferr` directive is used. After checking all the old content of iraf.noao.edu, I didn't find any `mkpkg` file with this directive, so this seems rather exotic.

This PR also makes **mkpkg** a bit more verbose by printing  a message containing the working directory before and after other processing, and also printing the `mkpkg` file name and line number in case of a warning/error:
```
mkpkg[1]: Entering directory `/home/runner/work/iraf/iraf/sys/gio/'
gio/mkpkg:55: warning: file `gtickr.x' not found
/home/runner/work/iraf/iraf/unix/bin.linux64/generic.e -k -t r gtick.gx
[…]
mkpkg[1]: Leaving directory `/home/runner/work/iraf/iraf/sys/gio/'
```
This brings the output a bit closer to the one of the **make** command.