### PR TITLE
Update Ubuntu version used for 32-bit to 20.04

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -16,8 +16,8 @@ jobs:
           - name: Ubuntu latest x86_64
             os: ubuntu-latest
 
-          - name: Ubuntu 18.04 Bionic i386
-            os: ubuntu-18.04
+          - name: Ubuntu 20.04 Focal i386
+            os: ubuntu-20.04
             irafarch: linux
             carch: '-m32'
 


### PR DESCRIPTION
18.04 is deprecated since a while, and 20.04 still supports building and running 32-bit apps. So for the time being, we use this one.