### PR TITLE
Fix keyword search in envinit

### DIFF
--- a/unix/boot/bootlib/envinit.c
+++ b/unix/boot/bootlib/envinit.c
@@ -185,8 +185,8 @@ loadenv (char *osfn)
 		/* Skip comments and blank lines. */
 		for (ip=lbuf;  isspace(*ip);  ip++)
 		    ;
-		if (strncmp (lbuf, "set", 3) != 0) {
-		    if (strncmp (lbuf, "reset", 5) != 0)
+		if (strncmp (ip, "set", 3) != 0) {
+		    if (strncmp (ip, "reset", 5) != 0)
 			continue;
 		    else
 			ip += 5;

--- a/unix/boot/bootlib/envinit.c
+++ b/unix/boot/bootlib/envinit.c
@@ -215,11 +215,8 @@ loadenv (char *osfn)
 			    } else
 				ip++;
 
-			if ((fp = fopen (vfn2osfn(fname,0), "r")) == NULL) {
-			    printf ("envinit: cannot open `%s'\n", fname);
-			    fflush (stdout);
+			if ((fp = fopen (vfn2osfn(fname,0), "r")) == NULL)
 			    break;
-			}
 		    }
 		    continue;
 		}


### PR DESCRIPTION
The searchs works for **set** or **reset** and is done *after* stepping over possible whitespaces. The bug here was that **set** resp. **reset** were searched in the string *before* whitespace removal, but the result was applied to the string *after* the removal. This works for
    
```
set foo = bar
``` 
but not for
    
````
    set foo = bar
````
It is funny to see that this bug is there since 35 years, and nobody discovered or fixed it...
    
For us this is important, since otherwise the **noao** variable was not read in properly.

The second issue is that missing files produce a warning; however they may appear regularly, like in

```
if (access ("iraf$extern/.zzsetenv.def"))
    set @iraf$extern/.zzsetenv.def
;
```
**envinit** does not have scripting capability; it just searches for the **set**/**reset** lines; so silently ignoring missing files seems the best we can do here.

