### PR TITLE
Don't add empty arguments to xc argument lists

### DIFF
--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -970,7 +970,8 @@ addflags (char *flag, char *arglist[], int *p_nargs)
 		        *p_nargs = nargs;
 		        return (1);
 	        }
-	        arglist[nargs++] = fs;
+		if (strlen(fs))
+		    arglist[nargs++] = fs;
 	    }
 
 	    *p_nargs = nargs;


### PR DESCRIPTION
Empty arguments are sometimes wrongly intepreted by gcc (as object files) and may lead to a compilation error ("object file not found" for gcc), or possibly even to compiler crashes.