### PR TITLE
Fix several glitches and warning that appear when compiled with -std=c99

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -9,20 +9,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CARCH: ${{ matrix.carch }}
+      CFLAGS: ${{ matrix.cflags }}
 
     strategy:
       matrix:
         include:
           - name: Ubuntu latest x86_64
             os: ubuntu-latest
+            cflags: -O2 -g -Wall -Wno-stringop-truncation -Wno-unused-result -Wno-format-overflow -Wno-parentheses
 
           - name: Ubuntu 20.04 Focal i386
             os: ubuntu-20.04
             irafarch: linux
             carch: '-m32'
+            cflags: -O2 -g -Wall -Wno-stringop-truncation -Wno-unused-result -Wno-format-overflow -Wno-parentheses
 
           - name: macOS x86_64
             os: macos-latest
+            cflags: -O2 -g -Wall -Wno-logical-op-parentheses
 
     steps:
       - name: Checkout repository

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ export RANLIB = ranlib
 
 # General compiler flags. Compiler flags specific to the build of the
 # host tools and software are in unix/Makefile.
-export CFLAGS ?= -g -Wall -O2
+export CFLAGS ?= -g -O2
 CFLAGS += $(CARCH)
 export LDFLAGS += $(CARCH)
 export XC_CFLAGS = $(CPPFLAGS) $(CFLAGS)
@@ -78,10 +78,8 @@ noao: host vendor core
 	cd $(noao) && $(MKPKG) -p noao
 
 # Run the test suite.
-# The XC_CFLAGS are reset here since they produce warnings that
-# confuse the test scripts.
 test:
-	env -u XC_CFLAGS ./test/run_tests
+	./test/run_tests
 
 # Remove all binaries built. This keeps .x files that were generated
 # by generic, xyacc and similar.

--- a/pkg/cl/bkg.c
+++ b/pkg/cl/bkg.c
@@ -8,6 +8,7 @@
 #define import_knames
 #define import_xwhen
 #define import_ctype
+#define import_kproto
 #include <iraf.h>
 
 #include "config.h"

--- a/pkg/cl/errs.c
+++ b/pkg/cl/errs.c
@@ -9,6 +9,7 @@
 #define import_knames
 #define	import_xnames
 #define	import_stdarg
+#define import_kproto
 #include <iraf.h>
 
 #include "config.h"

--- a/pkg/cl/exec.c
+++ b/pkg/cl/exec.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_libc
 #define import_stdio

--- a/pkg/cl/gram.c
+++ b/pkg/cl/gram.c
@@ -621,7 +621,7 @@ fieldcvt (register char *f)
 	static char fctbl[] = {
 	    FN_NAME, FN_TYPE, FN_MODE, FN_VALUE, FN_MIN,
 	    FN_MAX, FN_PROMPT, FN_VALUE, FN_LENGTH, FN_VALUE,
-	    FN_XTYPE, NULL
+	    FN_XTYPE, '\0'
 	};
 
 	int kentry;
@@ -1213,7 +1213,7 @@ unsetigoto (int loc)
 {
 	int 	last, curr;
 
-	last = NULL;
+	last = 0;
 	curr = igoto1;
 
 	while (curr != loc) {
@@ -1221,7 +1221,7 @@ unsetigoto (int loc)
 	    curr = coderef(curr)->c_args;
 	}
 
-	if (last == NULL)
+	if (last == 0)
 	    igoto1 = coderef(curr)->c_args;
 	else
 	    coderef(last)->c_args = coderef(curr)->c_args;

--- a/pkg/cl/grammar.l
+++ b/pkg/cl/grammar.l
@@ -70,7 +70,7 @@ A		[a-zA-Z]
 "?"		return (crackident (yytext));	/* current package help	     */
 "??"		return (crackident (yytext));	/* all tasks help	     */
 
-"&"		{	extern bracelevel;
+"&"		{	extern int bracelevel;
 			if (bracelevel) {
 	    eprintf ("ERROR: background not allowed within statement block\n");
 			    return ('#');

--- a/pkg/cl/lexyy.c
+++ b/pkg/cl/lexyy.c
@@ -28,6 +28,11 @@ struct yysvf {
 struct yysvf *yyestate;
 extern struct yysvf yysvec[], *yybgin;
 # define YYNEWLINE 10
+
+int yylook (void);
+int traverse (int);
+int yyback (int *p, int m);
+
 int 
 lex_yylex (void){
 int nstr; extern int yyprevious;
@@ -146,7 +151,7 @@ case 28:
 	return (crackident (yytext));
 break;
 case 29:
-	{	extern bracelevel;
+	{	extern int bracelevel;
 			if (bracelevel) {
 	    eprintf ("ERROR: background not allowed within statement block\n");
 			    return ('#');

--- a/pkg/cl/main.c
+++ b/pkg/cl/main.c
@@ -12,6 +12,7 @@
 #define	import_prtype
 #define	import_xwhen
 #define import_xnames
+#define import_kproto
 #include <iraf.h>
 
 #include <ctype.h>

--- a/pkg/cl/prcache.c
+++ b/pkg/cl/prcache.c
@@ -7,6 +7,7 @@
 #define	import_error
 #define	import_finfo
 #define	import_prstat
+#define import_kproto
 #include <iraf.h>
 
 #include "config.h"

--- a/pkg/ecl/bkg.c
+++ b/pkg/ecl/bkg.c
@@ -8,6 +8,7 @@
 #define import_knames
 #define import_xwhen
 #define import_ctype
+#define import_kproto
 #include <iraf.h>
 
 #include "config.h"

--- a/pkg/ecl/errs.c
+++ b/pkg/ecl/errs.c
@@ -9,6 +9,7 @@
 #define import_knames
 #define	import_xnames
 #define	import_stdarg
+#define import_kproto
 #include <iraf.h>
 
 #include "config.h"

--- a/pkg/ecl/exec.c
+++ b/pkg/ecl/exec.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_libc
 #define import_stdio

--- a/pkg/ecl/gram.c
+++ b/pkg/ecl/gram.c
@@ -723,7 +723,7 @@ fieldcvt (register char *f)
 	static char fctbl[] = {
 	    FN_NAME, FN_TYPE, FN_MODE, FN_VALUE, FN_MIN,
 	    FN_MAX, FN_PROMPT, FN_VALUE, FN_LENGTH, FN_VALUE,
-	    FN_XTYPE, NULL
+	    FN_XTYPE, '\0'
 	};
 
 	int kentry;
@@ -1409,7 +1409,7 @@ unsetigoto (int loc)
 {
 	int 	last, curr;
 
-	last = NULL;
+	last = 0;
 	curr = igoto1;
 
 	while (curr != loc) {
@@ -1417,7 +1417,7 @@ unsetigoto (int loc)
 	    curr = coderef(curr)->c_args;
 	}
 
-	if (last == NULL)
+	if (last == 0)
 	    igoto1 = coderef(curr)->c_args;
 	else
 	    coderef(last)->c_args = coderef(curr)->c_args;

--- a/pkg/ecl/gram.c
+++ b/pkg/ecl/gram.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_libc
 #define import_stdio
@@ -919,7 +921,6 @@ intrfunc (char *fname, int nargs)
 		    int	o1, o2;
 		    struct operand istr;
 		    char *index();
-		    extern void *memset();
 trim_:
 		    if (nargs >= 2) {
 		        /* Get the chars to trim, otherwise its whitespace.  */

--- a/pkg/ecl/grammar.l
+++ b/pkg/ecl/grammar.l
@@ -70,7 +70,7 @@ A		[a-zA-Z]
 "?"		return (crackident (yytext));	/* current package help	     */
 "??"		return (crackident (yytext));	/* all tasks help	     */
 
-"&"		{	extern bracelevel;
+"&"		{	extern int bracelevel;
 			if (bracelevel) {
 	    eprintf ("ERROR: background not allowed within statement block\n");
 			    return ('#');

--- a/pkg/ecl/history.c
+++ b/pkg/ecl/history.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_libc
 #define import_stdio
@@ -66,7 +68,6 @@ extern	char *ifseen;		/* Processing an IF statement?		*/
 
 extern	int do_error;		/* Are we processing errors?		*/
 
-extern	void *memset();
 char   *freadline (char *prompt);
 int     add_history (char *buf);
 

--- a/pkg/ecl/lexyy.c
+++ b/pkg/ecl/lexyy.c
@@ -28,6 +28,11 @@ struct yysvf {
 struct yysvf *yyestate;
 extern struct yysvf yysvec[], *yybgin;
 # define YYNEWLINE 10
+
+int yylook (void);
+int traverse (int);
+int yyback (int *p, int m);
+
 int 
 lex_yylex (void){
 int nstr; extern int yyprevious;
@@ -146,7 +151,7 @@ case 28:
 	return (crackident (yytext));
 break;
 case 29:
-	{	extern bracelevel;
+	{	extern int bracelevel;
 			if (bracelevel) {
 	    eprintf ("ERROR: background not allowed within statement block\n");
 			    return ('#');

--- a/pkg/ecl/main.c
+++ b/pkg/ecl/main.c
@@ -14,6 +14,7 @@
 #define	import_prtype
 #define	import_xwhen
 #define import_xnames
+#define import_kproto
 #include <iraf.h>
 
 #include <ctype.h>

--- a/pkg/ecl/main.c
+++ b/pkg/ecl/main.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define	import_spp
 #define	import_libc
 #define	import_fset

--- a/pkg/ecl/prcache.c
+++ b/pkg/ecl/prcache.c
@@ -7,6 +7,7 @@
 #define	import_error
 #define	import_finfo
 #define	import_prstat
+#define import_kproto
 #include <iraf.h>
 
 #include "config.h"

--- a/sys/libc/cprdet.c
+++ b/sys/libc/cprdet.c
@@ -4,9 +4,8 @@
 #define import_spp
 #define	import_libc
 #define	import_xnames
+#define	import_kproto
 #include <iraf.h>
-
-int PRFODPR (void);
 
 /*
 ** CPRDET -- Detached processes.  A detached process is a process which runs

--- a/sys/libc/cprdet.c
+++ b/sys/libc/cprdet.c
@@ -6,6 +6,7 @@
 #define	import_xnames
 #include <iraf.h>
 
+int PRFODPR (void);
 
 /*
 ** CPRDET -- Detached processes.  A detached process is a process which runs

--- a/sys/libc/cvfnbrk.c
+++ b/sys/libc/cvfnbrk.c
@@ -4,9 +4,8 @@
 #define	import_spp
 #define	import_libc
 #define import_knames
+#define	import_kproto
 #include <iraf.h>
-
-int ZFNBRK (XCHAR *vfn, XINT *uroot_offset, XINT  *uextn_offset);
 
 
 /* C_VFNBRK -- Break a virtual filename (or host filename) into its component

--- a/sys/libc/cvfnbrk.c
+++ b/sys/libc/cvfnbrk.c
@@ -6,6 +6,8 @@
 #define import_knames
 #include <iraf.h>
 
+int ZFNBRK (XCHAR *vfn, XINT *uroot_offset, XINT  *uextn_offset);
+
 
 /* C_VFNBRK -- Break a virtual filename (or host filename) into its component
 ** parts, i.e., logical directory (ldir), root, and extension.  No characters

--- a/sys/libc/cwmsec.c
+++ b/sys/libc/cwmsec.c
@@ -4,9 +4,9 @@
 #define	import_spp
 #define	import_libc
 #define	import_knames
+#define	import_kproto
 #include <iraf.h>
 
-int ZWMSEC (XINT *msec);
 
 /* C_WMSEC -- Delay for so may milliseconds.
 */

--- a/sys/libc/cwmsec.c
+++ b/sys/libc/cwmsec.c
@@ -6,6 +6,7 @@
 #define	import_knames
 #include <iraf.h>
 
+int ZWMSEC (XINT *msec);
 
 /* C_WMSEC -- Delay for so may milliseconds.
 */

--- a/sys/libc/cxgmes.c
+++ b/sys/libc/cxgmes.c
@@ -7,6 +7,7 @@
 #define	import_knames
 #include <iraf.h>
 
+int ZXGMES (XINT *os_exception, PKCHAR  *errmsg, XINT *maxch);
 
 /* C_XGMES -- Fetch the machine dependent integer code and message string
 ** for the most recent exception.  The integer code XOK is returned if

--- a/sys/libc/cxgmes.c
+++ b/sys/libc/cxgmes.c
@@ -5,9 +5,9 @@
 #define	import_libc
 #define	import_xnames
 #define	import_knames
+#define	import_kproto
 #include <iraf.h>
 
-int ZXGMES (XINT *os_exception, PKCHAR  *errmsg, XINT *maxch);
 
 /* C_XGMES -- Fetch the machine dependent integer code and message string
 ** for the most recent exception.  The integer code XOK is returned if

--- a/sys/libc/cxwhen.c
+++ b/sys/libc/cxwhen.c
@@ -5,6 +5,7 @@
 #define	import_xnames
 #define	import_knames
 #define	import_libc
+#define import_kproto
 #include <iraf.h>
 
 /* CXWHEN -- Post an exception handler.  The exception handler procedure

--- a/sys/libc/freadline.c
+++ b/sys/libc/freadline.c
@@ -1,10 +1,15 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
 */
 
+#include <string.h>
+
 #define	import_spp
 #define	import_libc
 #define	import_stdio
+#define	import_knames
 #include <iraf.h>
+
+int ZFREE (void  *buf);
 
 
 /*  FREADLINE -- Get a line from a user with editing.  This is a libc 
@@ -27,7 +32,7 @@ freadline (
             return ((char *) NULL);
 	} else {
 	    strcpy (line, cmd);		/* save to static buffer	*/
-	    zfree_ ((void *) cmd);	/* free readline() buffer	*/
+	    ZFREE ((void *) cmd);	/* free readline() buffer	*/
 	}
 
 	return ((char *) line);

--- a/sys/libc/freadline.c
+++ b/sys/libc/freadline.c
@@ -7,9 +7,8 @@
 #define	import_libc
 #define	import_stdio
 #define	import_knames
+#define	import_kproto
 #include <iraf.h>
-
-int ZFREE (void  *buf);
 
 
 /*  FREADLINE -- Get a line from a user with editing.  This is a libc 

--- a/sys/libc/mkpkg
+++ b/sys/libc/mkpkg
@@ -10,8 +10,6 @@ $checkin  libc.a lib$
 $exit
 
 libc.a:
-	$set	XFLAGS	= "$(XFLAGS) -/Wall"
-
 	atof.c		<libc/ctype.h> <libc/libc.h> <libc/spp.h>\
 			<libc/xnames.h>
 	atoi.c		<libc/ctype.h> <libc/libc.h> <libc/spp.h>

--- a/sys/libc/system.c
+++ b/sys/libc/system.c
@@ -4,6 +4,7 @@
 #define	import_spp
 #define	import_libc
 #define	import_knames
+#define	import_kproto
 #include <iraf.h>
 
 

--- a/sys/osb/abs.c
+++ b/sys/osb/abs.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <stdlib.h>
+
 #define	import_spp
 #include <iraf.h>
 

--- a/sys/osb/aclrb.c
+++ b/sys/osb/aclrb.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/osb/bytmov.c
+++ b/sys/osb/bytmov.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define	import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/osb/ipak32.c
+++ b/sys/osb/ipak32.c
@@ -1,3 +1,6 @@
+#include <string.h>
+#include <stdlib.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/osb/iscl32.c
+++ b/sys/osb/iscl32.c
@@ -1,9 +1,11 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+#include <stdlib.h>
+
 #define	import_spp
 #define import_knames
-#include <stdlib.h>
 #include <iraf.h>
 
 

--- a/sys/osb/iscl64.c
+++ b/sys/osb/iscl64.c
@@ -1,9 +1,11 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+#include <stdlib.h>
+
 #define	import_spp
 #define import_knames
-#include <stdlib.h>
 #include <iraf.h>
 
 

--- a/sys/osb/iupk16.c
+++ b/sys/osb/iupk16.c
@@ -1,3 +1,6 @@
+#include <string.h>
+#include <stdlib.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/osb/iupk32.c
+++ b/sys/osb/iupk32.c
@@ -1,3 +1,6 @@
+#include <stdlib.h>
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/osb/strsum.c
+++ b/sys/osb/strsum.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #define	import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/ak/aclrc.c
+++ b/sys/vops/ak/aclrc.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/ak/aclrd.c
+++ b/sys/vops/ak/aclrd.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/ak/aclri.c
+++ b/sys/vops/ak/aclri.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/ak/aclrl.c
+++ b/sys/vops/ak/aclrl.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/ak/aclrr.c
+++ b/sys/vops/ak/aclrr.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/ak/aclrs.c
+++ b/sys/vops/ak/aclrs.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/lz/amovc.c
+++ b/sys/vops/lz/amovc.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/lz/amovd.c
+++ b/sys/vops/lz/amovd.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/lz/amovi.c
+++ b/sys/vops/lz/amovi.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/lz/amovl.c
+++ b/sys/vops/lz/amovl.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/lz/amovr.c
+++ b/sys/vops/lz/amovr.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/sys/vops/lz/amovs.c
+++ b/sys/vops/lz/amovs.c
@@ -1,6 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#include <string.h>
+
 #define import_spp
 #define import_knames
 #include <iraf.h>

--- a/test/run_tests
+++ b/test/run_tests
@@ -22,7 +22,7 @@ if [ ! -d $bin -a -d ${iraf}bin ] ; then
     bin=${iraf}bin/
     unset arch IRAFARCH
 fi
-export PATH=$HOME/.iraf/bin:${PATH}
+export XC_CFLAGS=-w
 
 TEST_FILES=""
 IRAF_SHELLS=""

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -1,4 +1,4 @@
-export HSI_CF = $(XC_CFLAGS) -I$(iraf)include
+export HSI_CF = $(XC_CFLAGS) -I$(iraf)include -D_GNU_SOURCE
 export HSI_XF = -x -Inolibc -/Wall -/O2
 export HSI_FF = -g -DBLD_KERNEL -O2
 export HSI_LF = $(LDFLAGS)

--- a/unix/boot/xyacc/y2.c
+++ b/unix/boot/xyacc/y2.c
@@ -30,6 +30,7 @@
 
 #include "dextern.h"
 #include <stdio.h>
+#include <string.h>
 
 char *os_getenv (char *envvar);
 

--- a/unix/f2c/libf2c/uninit.c
+++ b/unix/f2c/libf2c/uninit.c
@@ -178,8 +178,7 @@ ieee0(Void)
 	}
 #endif /* MSpc */
 
-/* What follows is for SGI IRIX only */
-#if defined(__mips) && defined(__sgi)   /* must link with -lfpe */
+#ifdef __mips	/* must link with -lfpe */
 #define IEEE0_done
 /* code from Eric Grosse */
 #include <stdlib.h>
@@ -232,36 +231,7 @@ ieee0(Void)
 	}
 #endif /* mips */
 
-/*
- * The following is the preferred method but depends upon a GLIBC extension only
- * to be found in GLIBC 2.2 or later.  It is a GNU extension, not included in the
- * C99 extensions which allow the FP status register to be examined in a platform
- * independent way.  It should be used if at all possible  -- AFRB
- */
-
-
-#if (defined(__GLIBC__)&& ( __GLIBC__>=2) && (__GLIBC_MINOR__>=2) )
-#define _GNU_SOURCE 1
-#define IEEE0_done
-#include <fenv.h>
- static void
-  ieee0(Void)
-        
-{
-    /* Clear all exception flags */
-    if (fedisableexcept(FE_ALL_EXCEPT)==-1)
-         unsupported_error();
-    if (feenableexcept(FE_DIVBYZERO|FE_INVALID|FE_OVERFLOW)==-1)
-         unsupported_error();
-}
-
-#endif /* Glibc control */
-
-/* Many linux cases will be treated through GLIBC.  Note that modern
- * linux runs on many non-i86 plaforms and as a result the following code
- * must be processor dependent rather than simply OS specific */
- 
-#if (defined(__linux__)&&(!defined(IEEE0_done)))
+#ifdef __linux__
 #define IEEE0_done
 #include "fpu_control.h"
 

--- a/unix/f2c/src/sysdep.c
+++ b/unix/f2c/src/sysdep.c
@@ -20,6 +20,7 @@ data or profits, whether in an action of contract, negligence or
 other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
+#include <unistd.h>
 #include "defs.h"
 #include "usignal.h"
 

--- a/unix/f2c/src/sysdeptest.c
+++ b/unix/f2c/src/sysdeptest.c
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h>
 
  int
 #ifdef KR_headers

--- a/unix/hlib/libc/setjmp.h
+++ b/unix/hlib/libc/setjmp.h
@@ -10,16 +10,13 @@
 #endif
 #endif
 
-typedef	int	jmp_buf[LEN_JUMPBUF];
+void ZDOJMP (XINT *jmpbuf, XINT *status);
+void ZSVJMP (XINT *jmpbuf, XINT *status);
+
+typedef	XINT	jmp_buf[LEN_JUMPBUF];
 static	XINT	u_jmpstat;
 
 #define	setjmp(e)	(ZSVJMP((e),&u_jmpstat),u_jmpstat)
 #define	longjmp(e,v)	(u_jmpstat=(v),ZDOJMP((e),&u_jmpstat))
-
-/* The following is necessary to prevent to prevent the optimizer from
- * doing unwise things with setjmp on a Sun-4.
- */
-extern	int zsvjmp_();
-#pragma unknown_control_flow(zsvjmp_)
 
 #define	D_setjmp

--- a/unix/hlib/libc/setjmp.h
+++ b/unix/hlib/libc/setjmp.h
@@ -8,10 +8,10 @@
 #ifndef import_knames
 #include "knames.h"
 #endif
+#ifndef import_kproto
+#include "kproto.h"
 #endif
-
-void ZDOJMP (XINT *jmpbuf, XINT *status);
-void ZSVJMP (XINT *jmpbuf, XINT *status);
+#endif
 
 typedef	XINT	jmp_buf[LEN_JUMPBUF];
 static	XINT	u_jmpstat;

--- a/unix/os/zfacss.c
+++ b/unix/os/zfacss.c
@@ -63,7 +63,7 @@ ZFACSS (
 
 	if (accessible && *type == DIRECTORY_FILE) {
 	    stat ((char *)fname, &fi);
-	    if (fi.st_mode & S_IFDIR)
+	    if (S_ISDIR(fi.st_mode))
 		*status = YES;
 	    else
 		*status = NO;
@@ -71,7 +71,7 @@ ZFACSS (
 
 	} else if (!accessible && *type == SYMLINK_FILE) {
 	    lstat ((char *)fname, &fi);
-	    if (fi.st_mode & S_IFLNK)
+	    if (S_ISLNK(fi.st_mode))
 		*status = YES;
 	    else
 		*status = NO;
@@ -89,7 +89,7 @@ ZFACSS (
 	    stat ((char *)fname, &fi);
 
 	    /* Do NOT read from a special device (may block) */
-	    if ((fi.st_mode & S_IFMT) & S_IFREG) {
+	    if (S_ISREG(fi.st_mode)) {
 		/* If we are testing for a text file the portion of the file
 		 * tested must consist of only printable ascii characters or
 		 * whitespace, with occasional newline line delimiters.
@@ -116,7 +116,7 @@ ZFACSS (
 			accessible = NO;
 		    close (fd);
 		}
-	    } else if (fi.st_mode & S_IFCHR && *type != TEXT_FILE)
+	    } else if (S_ISCHR(fi.st_mode) && *type != TEXT_FILE)
 		accessible = NO;
 	}
 		

--- a/unix/os/zfinfo.c
+++ b/unix/os/zfinfo.c
@@ -39,11 +39,11 @@ ZFINFO (
 
 	/* Determine file type.
 	 */
-	if (osfile.st_mode & S_IFDIR)
+	if (S_ISDIR(osfile.st_mode))
 	    fs->fi_type = FI_DIRECTORY;
-	else if (osfile.st_mode & S_IEXEC)
+	else if (osfile.st_mode & S_IXUSR)
 	    fs->fi_type = FI_EXECUTABLE;
-	else if (osfile.st_mode & S_IFREG)
+	else if (S_ISREG(osfile.st_mode))
 	    fs->fi_type = FI_REGULAR;
 	else
 	    fs->fi_type = FI_SPECIAL;

--- a/unix/os/zfiond.c
+++ b/unix/os/zfiond.c
@@ -224,7 +224,7 @@ ZOPNND (
 		    if (host_addr == INADDR_NONE)
 			goto err;
 		} else if ((hp = gethostbyname(host_str))) {
-  		    memcpy (&host_addr, hp->h_addr, sizeof(host_addr));
+ 		    memcpy (&host_addr, hp->h_addr_list[0], sizeof(host_addr));
 		} else
 		    goto err;
 

--- a/unix/os/zfiond.c
+++ b/unix/os/zfiond.c
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/un.h>

--- a/unix/os/zgcmdl.c
+++ b/unix/os/zgcmdl.c
@@ -6,7 +6,7 @@
 
 #include "osproto.h"
 
-extern	char *environ[];
+extern char **environ;
 #ifdef	__APPLE__
 extern  char ***_NSGetArgv();
 extern  int *_NSGetArgc();

--- a/unix/os/zgtenv.c
+++ b/unix/os/zgtenv.c
@@ -1,8 +1,8 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
-
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 #include <libgen.h>
 #define import_spp

--- a/unix/os/zmain.c
+++ b/unix/os/zmain.c
@@ -187,7 +187,7 @@ ipc_:
 	 * code only in the event of a panic.
 	 */
 	errstat = IRAF_MAIN (irafcmd, &inchan, &outchan, &errchan,
-	    &driver, &devtype, &prtype, osfn_bkgfile, &jobcode, SYSRUK,ONENTRY);
+			     &driver, &devtype, &prtype, (XCHAR*)osfn_bkgfile, &jobcode, SYSRUK,ONENTRY);
 
 	/* Normal process shutdown.  Our only action is to delete the bkgfile
 	 * if run as a detached process (see also zpanic).

--- a/unix/os/zopdir.c
+++ b/unix/os/zopdir.c
@@ -110,7 +110,7 @@ ZOPDIR (PKCHAR *fname, XINT *chan)
 	}
 
 	/* Sort the file list. */
-	d_qsort (soff, nentries, sizeof(int), d_compar);
+	d_qsort ((void *)soff, nentries, sizeof(int), d_compar);
 
 	/* Free unused space. */
 	if ((soff = (int *) realloc (soff, nentries * sizeof(int))) == NULL)

--- a/vendor/libvotable/votAttr.c
+++ b/vendor/libvotable/votAttr.c
@@ -8,15 +8,14 @@
  *  @brief  	(Private) Methods to manage XML attributes.
  */
 
-#define _GNU_SOURCE
+#define _DEFAULT_SOURCE 1       /* strdup/strcasecomp comes from BSD */
+#define _GNU_SOURCE 1		/* strcasestr */
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
 
 #include "votParseP.h"
-
-extern char  *strcasestr();
 
 
 /** 

--- a/vendor/libvotable/votElement.c
+++ b/vendor/libvotable/votElement.c
@@ -8,6 +8,7 @@
  *  @brief      (Private) Methods to manage XML elements.
  */
 
+#define _DEFAULT_SOURCE 1       /* strcasecomp comes from BSD */
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/vendor/libvotable/votParse.c
+++ b/vendor/libvotable/votParse.c
@@ -8,9 +8,10 @@
  *  @brief      Public interface procedures for the libVOTable parser.
  */
 
+#define _DEFAULT_SOURCE 1       /* strcasecomp/strdup comes from BSD */
+#define _GNU_SOURCE 1       /* strcasecomp/strdup comes from BSD */
 #include <stdio.h>
 #include <stdlib.h>
-#define _GNU_SOURCE
 #include <string.h>
 #include <expat.h>
 #include <unistd.h>
@@ -29,9 +30,6 @@
 
 
 #define	BUFSIZE			4096
-
-    
-extern char  *strcasestr();
 
 
 /* Private procedures

--- a/vendor/libvotable/votParse.c
+++ b/vendor/libvotable/votParse.c
@@ -1841,7 +1841,7 @@ vot_copyElement (handle_t src_h, handle_t parent_h)
 {
     /* A recurseive function to copy a node and it's children. */
     Element   *src_ptr, *return_ptr;
-    handle_t   return_handle, parent;
+    handle_t   return_handle, parent = 0;
     handle_t   src_child_h, src_next_h;
     
 


### PR DESCRIPTION
IRAF is still quite sloppy when it comes to function prototypes. On the most recent XCode version 14.3, compilation therefore fails (see discussion #272).

This PR addresses all "implicit declaration of function" warnings. For the standard (Linux/macOS) C library, the required includes and defines are added. Missing `host$os` declarations, added manually; a better way would be to have a separate include file here. `iraf_kproto.h` is however buggy (internal conflicts; between the local and the network-ready functions). Maybe fixing and including this one would be the better way...

For some reason, c99 compilation creates a bug on 32-bit architecture causing a crash in the [test with imcoords](https://github.com/iraf-community/iraf/blob/main/test/images.imcoords.md).

Closes: #273

however still untested on XCode-14.3 (feedback welcome)

> **Note** to self: After merging #277, the individual external prototypes in `sys$libc` should be replaced by a `#define import_kproto` statement on top.