### PR TITLE
Create useful prototypes for kernel functions (host$os)

### DIFF
--- a/unix/hlib/libc/kernel.h
+++ b/unix/hlib/libc/kernel.h
@@ -87,11 +87,7 @@ extern	struct fiodes zfd[];		/* array of descriptors		*/
 typedef	void  (*SIGFUNC)();
 
 typedef	void  (*PFV)();
-#ifdef __LP64__
-typedef	long  (*PFI)();
-#else
 typedef	int   (*PFI)();
-#endif
 
 
 extern	char *irafpath(char *fname);

--- a/unix/hlib/libc/kproto.h
+++ b/unix/hlib/libc/kproto.h
@@ -2,498 +2,182 @@
  *  KPROTO.H -- IRAF Kernel prototype definitions.
  */
 
-#include <stdio.h>
-#include <time.h>               /* for time_t                   */
-#include <signal.h>             /* for siginfo_t                */
-
-#if (__SIZEOF_INT__ == 4 && __SIZEOF_POINTER__ == 4) /* ILP32 */
-
-/* alloc.c */
-extern int main(int argc, char *argv[]);
-extern int alloc(char *argv[], int statonly);
-extern int dealloc(char *argv[]);
-extern int findsfs(char *argv[]);
-/* dio.c */
-extern int directio(int fd, int advice);
-/* getproc.c */
-extern int uid_executing(int uid);
-/* gmttolst.c */
-extern time_t gmt_to_lst(time_t gmt);
-/* irafpath.c */
-extern char *irafpath(char *fname);
-/* prwait.c */
-extern void pr_enter(int pid, int inchan, int outchan);
-extern int pr_wait(int pid);
-extern int pr_getipc(int pid, int *inchan, int *outchan);
-extern struct proctable *pr_findpid(int pid);
-extern void pr_release(int pid);
-/* tape.c */
-extern int main(int argc, char *argv[]);
-extern void mtop(int op, int count);
-extern char *nextcmd(FILE *in);
-extern char *gettok(void);
-extern char *prompt(void);
-extern void pstatus(void);
-extern void output(char *text);
-extern void phelp(void);
-/* zalloc.c */
-extern int zdvall_(shortint *aliases, int *allflg, int *status);
-extern int zdvown_(shortint *device, shortint *owner, int *maxch, int *status);
-extern int loggedin(int uid);
-/* zawset.c */
-extern int zawset_(int *best_size, int *new_size, int *old_size, int *max_size);
-/* zcall.c */
-extern int zcall0_(int *proc);
-extern int zcall1_(int *proc, void *arg1);
-extern int zcall2_(int *proc, void *arg1, void *arg2);
-extern int zcall3_(int *proc, void *arg1, void *arg2, void *arg3);
-extern int zcall4_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4);
-extern int zcall5_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5);
-extern int zcall6_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6);
-extern int zcall7_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7);
-extern int zcall8_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8);
-extern int zcall9_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8, void *arg9);
-extern int zcalla_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8, void *arg9, void *arg10);
-/* zdojmp.c */
-extern void zdojmp_(int *jmpbuf, int *status);
-/* zfacss.c */
-extern int zfacss_(shortint *fname, int *mode, int *type, int *status);
-/* zfaloc.c */
-extern int zfaloc_(shortint *fname, int *nbytes, int *status);
-/* zfchdr.c */
-extern int zfchdr_(shortint *newdir, int *status);
-/* zfdele.c */
-extern int zfdele_(shortint *fname, int *status);
-/* zfgcwd.c */
-extern int zfgcwd_(shortint *outstr, int *maxch, int *status);
-/* zfinfo.c */
-extern int zfinfo_(shortint *fname, int *finfo_struct, int *status);
-/* zfiobf.c */
-extern int zopnbf_(shortint *osfn, int *mode, int *chan);
-extern int zclsbf_(int *fd, int *status);
-extern int zardbf_(int *chan, shortint *buf, int *maxbytes, int *offset);
-extern int zawrbf_(int *chan, shortint *buf, int *nbytes, int *offset);
-extern int zawtbf_(int *fd, int *status);
-extern int zsttbf_(int *fd, int *param, int *lvalue);
-extern int _u_fmode(int mode);
-extern int vm_access(char *fname, int mode);
-extern int vm_delete(char *fname, int force);
-extern int vm_reservespace(long nbytes);
-extern int vm_largefile(long nbytes);
-extern int vm_directio(int fd, int flag);
-/* zfioks.c */
-extern int zopnks_(shortint *x_server, int *mode, int *chan);
-extern int zclsks_(int *chan, int *status);
-extern int zardks_(int *chan, shortint *buf, int *totbytes, int *loffset);
-extern int zawrks_(int *chan, shortint *buf, int *totbytes, int *loffset);
-extern int zawtks_(int *chan, int *status);
-extern int zsttks_(int *chan, int *param, int *lvalue);
-extern void pr_mask(char *str);
-/* zfiolp.c */
-extern int zopnlp_(shortint *printer, int *mode, int *chan);
-extern int zclslp_(int *chan, int *status);
-extern int zardlp_(int *chan, shortint *buf, int *maxbytes, int *offset);
-extern int zawrlp_(int *chan, shortint *buf, int *nbytes, int *offset);
-extern int zawtlp_(int *chan, int *status);
-extern int zsttlp_(int *chan, int *param, int *lvalue);
-/* zfiomt.c */
-extern int zzopmt_(shortint *device, int *acmode, shortint *devcap, int *devpos, int *newfile, int *chan);
-extern int zzclmt_(int *chan, int *devpos, int *o_status);
-extern int zzrdmt_(int *chan, shortint *buf, int *maxbytes, int *offset);
-extern int zzwrmt_(int *chan, shortint *buf, int *nbytes, int *offset);
-extern int zzwtmt_(int *chan, int *devpos, int *o_status);
-extern int zzstmt_(int *chan, int *param, int *lvalue);
-extern int zzrwmt_(shortint *device, shortint *devcap, int *o_status);
-/* zfiond.c */
-extern int zopnnd_(shortint *pk_osfn, int *mode, int *chan);
-extern int zclsnd_(int *fd, int *status);
-extern int zardnd_(int *chan, shortint *buf, int *maxbytes, int *offset);
-extern int zawrnd_(int *chan, shortint *buf, int *nbytes, int *offset);
-extern int zawtnd_(int *fd, int *status);
-extern int zsttnd_(int *fd, int *param, int *lvalue);
-/* zfiopl.c */
-extern int zopnpl_(shortint *plotter, int *mode, int *chan);
-extern int zclspl_(int *chan, int *status);
-extern int zardpl_(int *chan, shortint *buf, int *maxbytes, int *offset);
-extern int zawrpl_(int *chan, shortint *buf, int *nbytes, int *offset);
-extern int zawtpl_(int *chan, int *status);
-extern int zsttpl_(int *chan, int *param, int *lvalue);
-/* zfiopr.c */
-extern int zopcpr_(shortint *osfn, int *inchan, int *outchan, int *pid);
-extern int zclcpr_(int *pid, int *exit_status);
-extern int zardpr_(int *chan, shortint *buf, int *maxbytes, int *loffset);
-extern int zawrpr_(int *chan, shortint *buf, int *nbytes, int *loffset);
-extern int zawtpr_(int *chan, int *status);
-extern int zsttpr_(int *chan, int *param, int *lvalue);
-/* zfiosf.c */
-extern int zopnsf_(shortint *osfn, int *mode, int *chan);
-extern int zclssf_(int *fd, int *status);
-extern int zardsf_(int *chan, shortint *buf, int *maxbytes, int *offset);
-extern int zawrsf_(int *chan, shortint *buf, int *nbytes, int *offset);
-extern int zawtsf_(int *fd, int *status);
-extern int zsttsf_(int *fd, int *param, int *lvalue);
-/* zfiotx.c */
-extern int zopntx_(shortint *osfn, int *mode, int *chan);
-extern int zclstx_(int *fd, int *status);
-extern int zflstx_(int *fd, int *status);
-extern int zgettx_(int *fd, shortint *buf, int *maxchars, int *status);
-extern int znottx_(int *fd, int *offset);
-extern int zputtx_(int *fd, shortint *buf, int *nchars, int *status);
-extern int zsektx_(int *fd, int *znottx_offset, int *status);
-extern int zstttx_(int *fd, int *param, int *value);
-/* zfioty.c */
-extern int zopnty_(shortint *osfn, int *mode, int *chan);
-extern int zclsty_(int *fd, int *status);
-extern int zflsty_(int *fd, int *status);
-extern int zgetty_(int *fd, shortint *buf, int *maxchars, int *status);
-extern int znotty_(int *fd, int *offset);
-extern int zputty_(int *fd, shortint *buf, int *nchars, int *status);
-extern int zsekty_(int *fd, int *znotty_offset, int *status);
-extern int zsttty_(int *fd, int *param, int *value);
-/* zfmkcp.c */
-extern int zfmkcp_(shortint *osfn, shortint *new_osfn, int *status);
-/* zfmkdr.c */
-extern int zfmkdr_(shortint *newdir, int *status);
-/* zfnbrk.c */
-extern int zfnbrk_(shortint *vfn, int *uroot_offset, int *uextn_offset);
-/* zfpath.c */
-extern int zfpath_(shortint *osfn, shortint *pathname, int *maxch, int *nchars);
-/* zfpoll.c */
-extern int zfpoll_(int *pfds, int *nfds, int *timeout, int *npoll, int *status);
-/* zfprot.c */
-extern int zfprot_(shortint *fname, int *action, int *status);
-/* zfrnam.c */
-extern int zfrnam_(shortint *oldname, shortint *newname, int *status);
-/* zfrmdr.c */
-extern int zfrmdr_(shortint *dir, int *status);
-/* zfsubd.c */
-extern int zfsubd_(shortint *osdir, int *maxch, shortint *subdir, int *nchars);
-/* zfunc.c */
-extern int zfunc0_(int *proc);
-extern int zfunc1_(int *proc, void *arg1);
-extern int zfunc2_(int *proc, void *arg1, void *arg2);
-extern int zfunc3_(int *proc, void *arg1, void *arg2, void *arg3);
-extern int zfunc4_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4);
-extern int zfunc5_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5);
-extern int zfunc6_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6);
-extern int zfunc7_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7);
-extern int zfunc8_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8);
-extern int zfunc9_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8, void *arg9);
-extern int zfunca_(int *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8, void *arg9, void *arg10);
-/* zfutim.c */
-extern int zfutim_(shortint *fname, int *atime, int *mtime, int *status);
-/* zfxdir.c */
-extern int zfxdir_(shortint *osfn, shortint *osdir, int *maxch, int *nchars);
-/* zgcmdl.c */
-extern int zgcmdl_(shortint *cmd, int *maxch, int *status);
-/* zghost.c */
-extern int zghost_(shortint *outstr, int *maxch);
-/* zglobl.c */
-/* zgmtco.c */
-extern int zgmtco_(int *gmtcor);
-/* zgtenv.c */
-extern int zgtenv_(shortint *envvar, shortint *outstr, int *maxch, int *status);
-/* zgtime.c */
-extern int zgtime_(int *clock_time, int *cpu_time);
-/* zgtpid.c */
-extern int zgtpid_(int *pid);
-/* zintpr.c */
-extern int zintpr_(int *pid, int *exception, int *status);
-/* zlocpr.c 
-extern int zlocpr_(PFI proc, int *o_epa);
-*/
-/* zlocva.c */
-extern int zlocva_(shortint *variable, int *location);
-/* zmain.c */
-extern int main(int argc, char *argv[]);
-/* zmaloc.c */
-extern int zmaloc_(int *buf, int *nbytes, int *status);
-/* zmfree.c */
-extern int zmfree_(int *buf, int *status);
-/* zopdir.c */
-extern int zopdir_(shortint *fname, int *chan);
-extern int zcldir_(int *chan, int *status);
-extern int zgfdir_(int *chan, shortint *outstr, int *maxch, int *status);
-/* zopdpr.c */
-extern int zopdpr_(shortint *osfn, shortint *bkgfile, shortint *queue, int *jobcode);
-extern int zfodpr_(void);
-extern int zcldpr_(int *jobcode, int *killflag, int *exit_status);
-/* zoscmd.c */
-extern int zoscmd_(shortint *oscmd, shortint *stdin_file, shortint *stdout_file, shortint *stderr_file, int *status);
-extern int pr_onint(int usig, int *hwcode, int *scp);
-/* zpanic.c */
-extern int zpanic_(int *errcode, shortint *errmsg);
-extern int kernel_panic(char *errmsg);
-/* zraloc.c */
-extern int zraloc_(int *buf, int *nbytes, int *status);
-/* zshlib.c */
-extern void vlibinit_(void);
-/* zwmsec.c */
-extern int zwmsec_(int *msec);
-/* zxwhen.c */
-extern int zxwhen_(int *sig_code, int *epa, int *old_epa);
-extern void ex_handler(int unix_signal, siginfo_t *info, void *ucp);
-extern int zxgmes_(int *os_exception, shortint *errmsg, int *maxch);
-/* zzepro.c */
-extern int zzepro_(void);
-/* zzexit.c */
-extern int exit_(int *code);
-/* zzpstr.c */
-extern int spp_debug(void);
-extern int zzpstr_(shortint *s1, shortint *s2);
-extern int zzlstr_(shortint *s1, shortint *s2);
-extern void spp_printstr(shortint *s);
-extern void spp_printmemc(int memc_ptr);
-/* zzsetk.c */
-extern int zzsetk_(char *ospn, char *osbfn, int prtype, int isatty, int in, int out);
-/* zzstrt.c */
-extern int zzstrt_(void);
-extern int zzstop_(void);
-extern void ready_(void);
-extern void mdump_(int *buf, int *nbytes);
-
-
-
-#elif (__SIZEOF_LONG__ == 8 && __SIZEOF_POINTER__ == 8) /* LP64 */
-
-
-
-/* dio.c */
-extern int directio(int fd, int advice);
-/* getproc.c */
-extern int uid_executing(int uid);
-/* gmttolst.c */
-extern time_t gmt_to_lst(time_t gmt);
-/* irafpath.c */
-extern char *irafpath(char *fname);
-/* prwait.c */
-extern void pr_enter(int pid, int inchan, int outchan);
-extern int pr_wait(int pid);
-extern int pr_getipc(int pid, int *inchan, int *outchan);
-extern struct proctable *pr_findpid(int pid);
-extern void pr_release(int pid);
-/* zalloc.c */
-extern int zdvall_(shortint *aliases, long *allflg, long *status);
-extern int zdvown_(shortint *device, shortint *owner, long *maxch, long *status);
-extern int loggedin(int uid);
-/* zawset.c */
-extern int zawset_(long *best_size, long *new_size, long *old_size, long *max_size);
-/* zcall.c */
-/*
-extern int zcall0_(long *proc);
-extern int zcall1_(long *proc, void *arg1);
-extern int zcall2_(long *proc, void *arg1, void *arg2);
-extern int zcall3_(long *proc, void *arg1, void *arg2, void *arg3);
-extern int zcall4_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4);
-extern int zcall5_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5);
-extern int zcall6_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6);
-extern int zcall7_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7);
-extern int zcall8_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8);
-extern int zcall9_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8, void *arg9);
-extern int zcalla_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8, void *arg9, void *arg10);
-*/
-/* zdojmp.c */
-extern void zdojmp_(long *jmpbuf, long *status);
-/* zfacss.c */
-extern int zfacss_(shortint *fname, long *mode, long *type, long *status);
-/* zfaloc.c */
-extern int zfaloc_(shortint *fname, long *nbytes, long *status);
-/* zfchdr.c */
-extern int zfchdr_(shortint *newdir, long *status);
-/* zfdele.c */
-extern int zfdele_(shortint *fname, long *status);
-/* zfgcwd.c */
-extern int zfgcwd_(shortint *outstr, long *maxch, long *status);
-/* zfinfo.c */
-extern int zfinfo_(shortint *fname, long *finfo_struct, long *status);
-/* zfiobf.c */
-extern int zopnbf_(shortint *osfn, long *mode, long *chan);
-extern int zclsbf_(long *fd, long *status);
-extern int zardbf_(long *chan, shortint *buf, long *maxbytes, long *offset);
-extern int zawrbf_(long *chan, shortint *buf, long *nbytes, long *offset);
-extern int zawtbf_(long *fd, long *status);
-extern int zsttbf_(long *fd, long *param, long *lvalue);
-extern int _u_fmode(int mode);
-extern int vm_access(char *fname, int mode);
-extern int vm_delete(char *fname, int force);
-extern int vm_reservespace(long nbytes);
-extern int vm_largefile(long nbytes);
-extern int vm_directio(int fd, int flag);
-/* zfioks.c */
-extern int zopnks_(shortint *x_server, long *mode, long *chan);
-extern int zclsks_(long *chan, long *status);
-extern int zardks_(long *chan, shortint *buf, long *totbytes, long *loffset);
-extern int zawrks_(long *chan, shortint *buf, long *totbytes, long *loffset);
-extern int zawtks_(long *chan, long *status);
-extern int zsttks_(long *chan, long *param, long *lvalue);
-extern void pr_mask(char *str);
-/* zfiolp.c */
-extern int zopnlp_(shortint *printer, long *mode, long *chan);
-extern int zclslp_(long *chan, long *status);
-extern int zardlp_(long *chan, shortint *buf, long *maxbytes, long *offset);
-extern int zawrlp_(long *chan, shortint *buf, long *nbytes, long *offset);
-extern int zawtlp_(long *chan, long *status);
-extern int zsttlp_(long *chan, long *param, long *lvalue);
-/* zfiomt.c */
-extern int zzopmt_(shortint *device, long *acmode, shortint *devcap, long *devpos, long *newfile, long *chan);
-extern int zzclmt_(long *chan, long *devpos, long *o_status);
-extern int zzrdmt_(long *chan, shortint *buf, long *maxbytes, long *offset);
-extern int zzwrmt_(long *chan, shortint *buf, long *nbytes, long *offset);
-extern int zzwtmt_(long *chan, long *devpos, long *o_status);
-extern int zzstmt_(long *chan, long *param, long *lvalue);
-extern int zzrwmt_(shortint *device, shortint *devcap, long *o_status);
-/* zfiond.c */
-extern int zopnnd_(shortint *pk_osfn, long *mode, long *chan);
-extern int zclsnd_(long *fd, long *status);
-extern int zardnd_(long *chan, shortint *buf, long *maxbytes, long *offset);
-extern int zawrnd_(long *chan, shortint *buf, long *nbytes, long *offset);
-extern int zawtnd_(long *fd, long *status);
-extern int zsttnd_(long *fd, long *param, long *lvalue);
-/* zfiopl.c */
-extern int zopnpl_(shortint *plotter, long *mode, long *chan);
-extern int zclspl_(long *chan, long *status);
-extern int zardpl_(long *chan, shortint *buf, long *maxbytes, long *offset);
-extern int zawrpl_(long *chan, shortint *buf, long *nbytes, long *offset);
-extern int zawtpl_(long *chan, long *status);
-extern int zsttpl_(long *chan, long *param, long *lvalue);
-/* zfiopr.c */
-extern int zopcpr_(shortint *osfn, long *inchan, long *outchan, long *pid);
-extern int zclcpr_(long *pid, long *exit_status);
-extern int zardpr_(long *chan, shortint *buf, long *maxbytes, long *loffset);
-extern int zawrpr_(long *chan, shortint *buf, long *nbytes, long *loffset);
-extern int zawtpr_(long *chan, long *status);
-extern int zsttpr_(long *chan, long *param, long *lvalue);
-/* zfiosf.c */
-extern int zopnsf_(shortint *osfn, long *mode, long *chan);
-extern int zclssf_(long *fd, long *status);
-extern int zardsf_(long *chan, shortint *buf, long *maxbytes, long *offset);
-extern int zawrsf_(long *chan, shortint *buf, long *nbytes, long *offset);
-extern int zawtsf_(long *fd, long *status);
-extern int zsttsf_(long *fd, long *param, long *lvalue);
-/* zfiotx.c */
-extern int zopntx_(shortint *osfn, long *mode, long *chan);
-extern int zclstx_(long *fd, long *status);
-extern int zflstx_(long *fd, long *status);
-extern int zgettx_(long *fd, shortint *buf, long *maxchars, long *status);
-extern int znottx_(long *fd, long *offset);
-extern int zputtx_(long *fd, shortint *buf, long *nchars, long *status);
-extern int zsektx_(long *fd, long *znottx_offset, long *status);
-extern int zstttx_(long *fd, long *param, long *value);
-/* zfioty.c */
-extern int zopnty_(shortint *osfn, long *mode, long *chan);
-extern int zclsty_(long *fd, long *status);
-extern int zflsty_(long *fd, long *status);
-extern int zgetty_(long *fd, shortint *buf, long *maxchars, long *status);
-extern int znotty_(long *fd, long *offset);
-extern int zputty_(long *fd, shortint *buf, long *nchars, long *status);
-extern int zsekty_(long *fd, long *znotty_offset, long *status);
-extern int zsttty_(long *fd, long *param, long *value);
-/* zfmkcp.c */
-extern int zfmkcp_(shortint *osfn, shortint *new_osfn, long *status);
-/* zfmkdr.c */
-extern int zfmkdr_(shortint *newdir, long *status);
-/* zfnbrk.c */
-extern int zfnbrk_(shortint *vfn, long *uroot_offset, long *uextn_offset);
-/* zfpath.c */
-extern int zfpath_(shortint *osfn, shortint *pathname, long *maxch, long *nchars);
-/* zfpoll.c */
-extern int zfpoll_(long *pfds, long *nfds, long *timeout, long *npoll, long *status);
-/* zfprot.c */
-extern int zfprot_(shortint *fname, long *action, long *status);
-/* zfrnam.c */
-extern int zfrnam_(shortint *oldname, shortint *newname, long *status);
-/* zfsubd.c */
-extern int zfsubd_(shortint *osdir, long *maxch, shortint *subdir, long *nchars);
-/* zfunc.c */
-extern long zfunc0_(long *proc);
-extern long zfunc1_(long *proc, void *arg1);
-extern long zfunc2_(long *proc, void *arg1, void *arg2);
-extern long zfunc3_(long *proc, void *arg1, void *arg2, void *arg3);
-extern long zfunc4_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4);
-extern long zfunc5_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5);
-extern long zfunc6_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6);
-extern long zfunc7_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7);
-extern long zfunc8_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8);
-extern long zfunc9_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8, void *arg9);
-extern long zfunca_(long *proc, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5, void *arg6, void *arg7, void *arg8, void *arg9, void *arg10);
-/* zfutim.c */
-extern int zfutim_(shortint *fname, long *atime, long *mtime, long *status);
-/* zfxdir.c */
-extern int zfxdir_(shortint *osfn, shortint *osdir, long *maxch, long *nchars);
-/* zgcmdl.c */
-extern int zgcmdl_(shortint *cmd, long *maxch, long *status);
-/* zghost.c */
-extern int zghost_(shortint *outstr, long *maxch);
-/* zglobl.c */
-/* zgmtco.c */
-extern int zgmtco_(long *gmtcor);
-/* zgtenv.c */
-extern int zgtenv_(shortint *envvar, shortint *outstr, long *maxch, long *status);
-/* zgtime.c */
-extern int zgtime_(long *clock_time, long *cpu_time);
-/* zgtpid.c */
-extern int zgtpid_(long *pid);
-/* zintpr.c */
-extern int zintpr_(long *pid, long *exception, long *status);
-/* zlocpr.c */
-/*
-extern int zlocpr_(PFI proc, long *o_epa);
-*/
-/* zlocva.c */
-extern int zlocva_(shortint *variable, long *location);
-/* zmain.c */
-extern int main(int argc, char *argv[]);
-/* zmaloc.c */
-extern int zmaloc_(long *buf, long *nbytes, long *status);
-/* zmfree.c */
-extern int zmfree_(long *buf, long *status);
-/* zopdir.c */
-extern int zopdir_(shortint *fname, long *chan);
-extern int zcldir_(long *chan, long *status);
-extern int zgfdir_(long *chan, shortint *outstr, long *maxch, long *status);
-/* zopdpr.c */
-extern int zopdpr_(shortint *osfn, shortint *bkgfile, shortint *queue, long *jobcode);
-extern int zcldpr_(long *jobcode, long *killflag, long *exit_status);
-/* zoscmd.c */
-extern int zoscmd_(shortint *oscmd, shortint *stdin_file, shortint *stdout_file, shortint *stderr_file, long *status);
-extern int pr_onint(int usig, int *hwcode, int *scp);
-/* zpanic.c */
-extern int zpanic_(long *errcode, shortint *errmsg);
-extern int kernel_panic(char *errmsg);
-/* zraloc.c */
-extern int zraloc_(long *buf, long *nbytes, long *status);
-/* zshlib.c */
-extern void vlibinit_(void);
-/* zwmsec.c */
-extern int zwmsec_(long *msec);
-/* zxwhen.c */
-extern int zxwhen_(long *sig_code, long *epa, long *old_epa);
-extern void ex_handler(int unix_signal, siginfo_t *info, void *ucp);
-extern int zxgmes_(long *os_exception, shortint *errmsg, long *maxch);
-extern int gfpucw_(long *xcw);
-extern int sfpucw_(long *xcw);
-/* zzepro.c */
-/*
-extern int zzepro_(void);
-*/
-/* zzexit.c */
-extern int exit_(long *code);
-/* zzpstr.c */
-extern int spp_debug(void);
-extern int zzpstr_(shortint *s1, shortint *s2);
-extern int zzlstr_(shortint *s1, shortint *s2);
-extern void spp_printstr(shortint *s);
-extern void spp_printmemc(int memc_ptr);
-/* zzsetk.c */
-extern int zzsetk_(char *ospn, char *osbfn, int prtype, int isatty, int in, int out);
-/* zzstrt.c */
-extern int zzstrt_(void);
-extern int zzstop_(void);
-extern void ready_(void);
-extern void mdump_(long *buf, long *nbytes);
-
-#else
-
-#error "No data model: need either LP64 or ILP32"
-
+#ifndef D_spp
+#include "iraf/spp.h"
 #endif
+#ifndef D_knames
+#include "iraf/knames.h"
+#endif
+
+typedef	int   (*PFI)();
+
+/* zalloc.c */
+int ZDVALL (PKCHAR *aliases, XINT *allflg, XINT *status);
+int ZDVOWN (PKCHAR *device, PKCHAR *owner, XINT *maxch, XINT *status);
+/* zawset.c */
+int ZAWSET (XINT *best_size, XINT *new_size, XINT *old_size, XINT *max_size);
+/* zdojmp.c */
+void ZDOJMP (XINT *jmpbuf, XINT *status);
+/* zfacss.c */
+int ZFACSS (PKCHAR *fname, XINT *mode, XINT *type, XINT *status);
+/* zfaloc.c */
+int ZFALOC (PKCHAR *fname, XLONG *nbytes, XINT *status);
+/* zfchdr.c */
+int ZFCHDR (PKCHAR *newdir, XINT *status);
+/* zfdele.c */
+int ZFDELE (PKCHAR *fname, XINT *status);
+/* zfgcwd.c */
+int ZFGCWD (PKCHAR *outstr, XINT *maxch, XINT *status);
+/* zfinfo.c */
+int ZFINFO(PKCHAR *fname, XLONG *finfo_struct, XINT *status);
+/* zfiobf.c */
+int ZOPNBF (PKCHAR *osfn, XINT *mode, XINT *chan);
+int ZCLSBF (XINT *fd, XINT *status);
+int ZARDBF (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *offset);
+int ZAWRBF (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *offset);
+int ZAWTBF (XINT *fd, XINT *status);
+int ZSTTBF (XINT *fd, XINT *param, XLONG *lvalue);
+/* zfioks.c */
+int ZOPNKS (PKCHAR *x_server, XINT *mode, XINT *chan);
+int ZCLSKS (XINT *chan, XINT *status);
+int ZARDKS (XINT *chan, XCHAR *buf, XINT *totbytes, XLONG *loffset);
+int ZAWRKS (XINT *chan, XCHAR *buf, XINT *totbytes, XLONG *loffset);
+int ZAWTKS (XINT *chan, XINT *status);
+int ZSTTKS (XINT *chan, XINT *param, XLONG *lvalue);
+/* zfiolp.c */
+int ZOPNLP (PKCHAR *printer, XINT *mode, XINT *chan);
+int ZCLSLP (XINT *chan, XINT *status);
+int ZARDLP (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *offset);
+int ZAWRLP (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *offset);
+int ZAWTLP (XINT *chan, XINT *status);
+int ZSTTLP (XINT *chan, XINT *param, XLONG *lvalue);
+/* zfiomt.c */
+int ZZOPMT (PKCHAR *device, XINT *acmode, PKCHAR *devcap, XINT *devpos, XINT *newfile, XINT *chan);
+int ZZCLMT (XINT *chan, XINT *devpos, XINT *o_status);
+int ZZRDMT (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *offset);
+int ZZWRMT (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *offset);
+int ZZWTMT (XINT *chan, XINT *devpos, XINT *o_status);
+int ZZSTMT (XINT *chan, XINT *param, XLONG *lvalue);
+int ZZRWMT (PKCHAR *device, PKCHAR *devcap, XINT *o_status);
+/* zfiond.c */
+int ZOPNND (PKCHAR *pk_osfn, XINT *mode, XINT *chan);
+int ZCLSND (XINT *fd, XINT *status);
+int ZARDND (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *offset);
+int ZAWRND (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *offset);
+int ZAWTND (XINT *fd, XINT *status);
+int ZSTTND (XINT *fd, XINT *param, XLONG *lvalue);
+/* zfiopl.c */
+int ZOPNPL (PKCHAR *plotter, XINT *mode, XINT *chan);
+int ZCLSPL (XINT *chan, XINT *status);
+int ZARDPL (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *offset);
+int ZAWRPL (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *offset);
+int ZAWTPL (XINT *chan, XINT *status);
+int ZSTTPL (XINT *chan, XINT *param, XLONG *lvalue);
+/* zfiopr.c */
+int ZOPCPR (PKCHAR *osfn, XINT *inchan, XINT *outchan, XINT *pid);
+int ZCLCPR (XINT *pid, XINT *exit_status);
+int ZARDPR (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *loffset);
+int ZAWRPR (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *loffset);
+int ZAWTPR (XINT *chan, XINT *status);
+int ZSTTPR (XINT *chan, XINT *param, XLONG *lvalue);
+/* zfiosf.c */
+int ZOPNSF (PKCHAR *osfn, XINT *mode, XINT *chan);
+int ZCLSSF (XINT *fd, XINT *status);
+int ZARDSF (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *offset);
+int ZAWRSF (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *offset);
+int ZAWTSF (XINT *fd, XINT *status);
+int ZSTTSF (XINT *fd, XINT *param, XLONG *lvalue);
+/* zfiotx.c */
+int ZOPNTX (PKCHAR *osfn, XINT *mode, XINT *chan);
+int ZCLSTX (XINT *fd, XINT *status);
+int ZFLSTX (XINT *fd, XINT *status);
+int ZGETTX (XINT *fd, XCHAR *buf, XINT *maxchars, XINT *status);
+int ZNOTTX (XINT *fd, XLONG *offset);
+int ZPUTTX (XINT *fd, XCHAR *buf, XINT *nchars, XINT *status);
+int ZSEKTX (XINT *fd, XLONG *znottx_offset, XINT *status);
+int ZSTTTX (XINT *fd, XINT *param, XLONG *value);
+/* zfioty.c */
+int ZOPNTY (PKCHAR *osfn, XINT *mode, XINT *chan);
+int ZCLSTY (XINT *fd, XINT *status);
+int ZFLSTY (XINT *fd, XINT *status);
+int ZGETTY (XINT *fd, XCHAR *buf, XINT *maxchars, XINT *status);
+int ZNOTTY (XINT *fd, XLONG *offset);
+int ZPUTTY (XINT *fd, XCHAR *buf, XINT *nchars, XINT *status);
+int ZSEKTY (XINT *fd, XLONG *znotty_offset, XINT *status);
+int ZSTTTY (XINT *fd, XINT *param, XLONG *value);
+/* zfmkcp.c */
+int ZFMKCP (PKCHAR *osfn, PKCHAR *new_osfn, XINT *status);
+/* zfmkdr.c */
+int ZFMKDR (PKCHAR *newdir, XINT *status);
+/* zfnbrk.c */
+int ZFNBRK (XCHAR *vfn, XINT *uroot_offset, XINT *uextn_offset);
+/* zfpath.c */
+int ZFPATH (XCHAR *osfn, XCHAR *pathname, XINT *maxch, XINT *nchars);
+/* zfpoll.c */
+int ZFPOLL (XINT *pfds, XINT *nfds, XINT *timeout, XINT *npoll, XINT *status);
+/* zfprot.c */
+int ZFPROT (PKCHAR *fname, XINT *action, XINT *status);
+/* zfrnam.c */
+int ZFRNAM (PKCHAR *oldname, PKCHAR *newname, XINT *status);
+/* zfrmdr.c */
+int ZFRMDR (PKCHAR *dir, XINT *status);
+/* zfsubd.c */
+int ZFSUBD (XCHAR *osdir, XINT *maxch, XCHAR *subdir, XINT *nchars);
+/* zfutim.c */
+int ZFUTIM (PKCHAR *fname, XLONG *atime, XLONG *mtime, XINT *status);
+/* zfxdir.c */
+int ZFXDIR (XCHAR *osfn, XCHAR *osdir, XINT *maxch, XINT *nchars);
+/* zgcmdl.c */
+int ZGCMDL (PKCHAR *cmd, XINT *maxch, XINT *status);
+/* zghost.c */
+int ZGHOST (PKCHAR *outstr, XINT *maxch);
+/* zgmtco.c */
+int ZGMTCO (XINT *gmtcor);
+/* zgtenv.c */
+int ZGTENV (PKCHAR *envvar, PKCHAR *outstr, XINT *maxch, XINT *status);
+/* zgtime.c */
+int ZGTIME (XLONG *clock_time, XLONG *cpu_time);
+/* zgtpid.c */
+int ZGTPID (XINT *pid);
+/* zintpr.c */
+int ZINTPR (XINT *pid, XINT *exception, XINT *status);
+/* zlocpr.c */
+int ZLOCPR (PFI	proc, XINT *o_epa);
+/* zlocva.c */
+int ZLOCVA (XCHAR *variable, XINT *location);
+/* zmaloc.c */
+int ZMALOC (XINT *buf, XINT *nbytes, XINT *status);
+/* zmfree.c */
+int ZMFREE (XINT *buf, XINT *status);
+int ZFREE (void *buf);
+/* zopdir.c */
+int ZOPDIR (PKCHAR *fname, XINT *chan);
+int ZCLDIR (XINT *chan, XINT *status);
+int ZGFDIR (XINT *chan, PKCHAR *outstr, XINT *maxch, XINT *status);
+/* zopdpr.c */
+int ZOPDPR (PKCHAR *osfn, PKCHAR *bkgfile, PKCHAR *queue, XINT *jobcode);
+int ZFODPR (void);
+int ZCLDPR (XINT *jobcode, XINT *killflag, XINT *exit_status);
+/* zoscmd.c */
+int ZOSCMD (PKCHAR *oscmd, PKCHAR *stdin_file, PKCHAR *stdout_file, PKCHAR *stderr_file, XINT *status);
+/* zpanic.c */
+int ZPANIC (XINT *errcode, PKCHAR *errmsg);
+/* zraloc.c */
+int ZRALOC (XINT *buf, XINT *nbytes, XINT *status);
+/* zsvjmp.S */
+void ZSVJMP (XINT *jmpbuf, XINT *status);
+/* zwmsec.c */
+int ZWMSEC (XINT *msec);
+/* zxwhen.c */
+int ZXWHEN (XINT *sig_code, XINT *epa, XINT *old_epa);
+int ZXGMES (XINT *os_exception, PKCHAR *errmsg, XINT *maxch);
+/* zzepro.c */
+int ZZEPRO (void);
+/* zzexit.c */
+int EXIT (XINT *code);
+/* zzpstr.c */
+int ZZPSTR (XCHAR *s1, XCHAR *s2);
+int ZZLSTR (XCHAR *s1, XCHAR *s2);
+/* zzstrt.c */
+int ZZSTRT (void);
+int ZZSTOP (void);

--- a/unix/os/alloc.c
+++ b/unix/os/alloc.c
@@ -16,6 +16,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ALLOC -- Unix task to allocate and deallocate devices given their generic
  * name.  These names are associated with special files in the ALLOCFILE file.

--- a/unix/os/alloc.c
+++ b/unix/os/alloc.c
@@ -63,9 +63,6 @@ int findsfs (char *argv[]);
 int dealloc (char *argv[]);
 int alloc (char	*argv[], int statonly);
 
-extern  int	uid_executing (int uid);
-
-
 
 int main (int argc, char *argv[])
 {

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -10,6 +10,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 #define	SZ_ULIBSTR	512
 #define	ULIB		"IRAFULIB"
 

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -35,9 +35,6 @@ irafpath (char *fname)
 	XINT	x_maxch=SZ_LINE, x_status;
 	char	*ip, *op, *irafarch;
 
-	extern  int  ZGTENV(PKCHAR *envvar, PKCHAR *outstr, XINT *maxch, XINT *status);
-
-
 	/* Search any user libraries first. */
 	strcpy ((char *)ldir, ULIB);
 	(void) ZGTENV (ldir, ulibs, &sz_ulibs, &x_status);

--- a/unix/os/mkproto
+++ b/unix/os/mkproto
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-flags="-DLINUX -DPOSIX -DSYSV -DLINUX64"
-
-cproto -e $flags *.c > ../hlib/libc/kproto64.h

--- a/unix/os/osproto.h
+++ b/unix/os/osproto.h
@@ -1,0 +1,56 @@
+#ifndef _OSPROTO_H
+#define _OSPROTO_H
+
+#include <sys/types.h>
+#include <time.h>               /* for time_t                   */
+#include <signal.h>             /* for siginfo_t                */
+
+/*
+ * Functions exposed to IRAF sys
+ */
+#define import_kproto
+#define import_spp
+#include <iraf.h>
+
+/*
+ * Functions internal to host$os
+ */
+/* dio.c */
+int directio (int fd, int advice);
+/* getproc.c */
+int uid_executing (int uid);
+/* gmttolst.c */
+time_t gmt_to_lst (time_t gmt);
+/* irafpath.c */
+char *irafpath (char *fname);
+/* prwait.c */
+void pr_enter (int pid, int inchan, int outchan);
+int pr_wait (int pid);
+int pr_getipc (int pid, int *inchan, int *outchan);
+struct proctable *pr_findpid (int pid);
+void pr_release (int pid);
+/* zalloc.c */
+int loggedin (int uid);
+/* zfiobf.c */
+int _u_fmode (int mode);
+int vm_access (char *fname, int mode);
+int vm_delete (char *fname, int force);
+int vm_reservespace (long nbytes);
+int vm_largefile (long nbytes);
+int vm_directio (int fd, int flag);
+/* zfioks.c */
+void pr_mask (char *str);
+/* zoscmd.c */
+int pr_onint (int usig, int *hwcode, int *scp);
+/* zpanic.c */
+int kernel_panic (char *errmsg);
+/* zxwhen.c */
+void ex_handler (int unix_signal, siginfo_t *info, void *ucp);
+/* zzpstr.c */
+int spp_debug (void);
+void spp_printstr (XCHAR *s);
+void spp_printmemc (long memc_ptr);
+/* zzsetk.c */
+int ZZSETK (char *ospn, char *osbfn, int prtype, int isatty, int in, int out);
+
+#endif /* _OSPROTO_H */

--- a/unix/os/osproto.h
+++ b/unix/os/osproto.h
@@ -15,8 +15,6 @@
 /*
  * Functions internal to host$os
  */
-/* dio.c */
-int directio (int fd, int advice);
 /* getproc.c */
 int uid_executing (int uid);
 /* gmttolst.c */
@@ -27,10 +25,7 @@ char *irafpath (char *fname);
 void pr_enter (int pid, int inchan, int outchan);
 int pr_wait (int pid);
 int pr_getipc (int pid, int *inchan, int *outchan);
-struct proctable *pr_findpid (int pid);
 void pr_release (int pid);
-/* zalloc.c */
-int loggedin (int uid);
 /* zfiobf.c */
 int _u_fmode (int mode);
 int vm_access (char *fname, int mode);
@@ -40,16 +35,8 @@ int vm_largefile (long nbytes);
 int vm_directio (int fd, int flag);
 /* zfioks.c */
 void pr_mask (char *str);
-/* zoscmd.c */
-int pr_onint (int usig, int *hwcode, int *scp);
 /* zpanic.c */
 int kernel_panic (char *errmsg);
-/* zxwhen.c */
-void ex_handler (int unix_signal, siginfo_t *info, void *ucp);
-/* zzpstr.c */
-int spp_debug (void);
-void spp_printstr (XCHAR *s);
-void spp_printmemc (long memc_ptr);
 /* zzsetk.c */
 int ZZSETK (char *ospn, char *osbfn, int prtype, int isatty, int in, int out);
 

--- a/unix/os/prwait.c
+++ b/unix/os/prwait.c
@@ -44,8 +44,6 @@ pr_enter (int pid, int inchan, int outchan)
 	register struct proctable *pr;
 	struct	proctable *pr_findpid(int pid);
 
-	extern  int kernel_panic (char *msg);
-
 
 	if ((pr = pr_findpid (0)) == NULL)
 	    kernel_panic ("iraf process table overflow");

--- a/unix/os/prwait.c
+++ b/unix/os/prwait.c
@@ -10,6 +10,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* Process table code.  The high level code assumes that it can open and close
  * processes in any order.  The UNIX "wait" primitive, called when a process is
  * closed, returns the process status and pid of the first process to exit.

--- a/unix/os/zalloc.c
+++ b/unix/os/zalloc.c
@@ -57,9 +57,6 @@ ZDVALL (
 {
 	PKCHAR	cmd[SZ_LINE+1], nullstr[1];
 
-	extern int ZOSCMD (PKCHAR *oscmd, PKCHAR *stdin_file, PKCHAR  *stdout_file, PKCHAR *stderr_file, XINT *status);
-
-
 	/* Syntax: $host/hlib/alloc.e -[ad] aliases
 	 */
 	strcpy ((char *)cmd, irafpath(ALLOCEXE));
@@ -189,9 +186,6 @@ u_allocstat (
 {
 	PKCHAR	cmd[SZ_LINE+1], nullstr[1];
 	XINT	x_status;
-
-	extern int ZOSCMD(PKCHAR *oscmd, PKCHAR *stdin_file, PKCHAR  *stdout_file, PKCHAR *stderr_file, XINT *status);
-
 
 	/* Syntax: $host/hlib/alloc.e -s aliases
 	 */

--- a/unix/os/zalloc.c
+++ b/unix/os/zalloc.c
@@ -15,6 +15,8 @@
 
 #include "osproto.h"
 
+static int loggedin (int uid);
+
 /*
  * ZALLOC.C -- Device allocation interface.  Requires the dev$devices table,
  * which is read by the high level code before we are called.
@@ -145,7 +147,7 @@ ZDVOWN (
 
 /* LOGGEDIN -- Return 1 if uid is logged in, else 0.
  */
-int
+static int
 loggedin (int uid)
 {
 	struct	utmpx ubuf;

--- a/unix/os/zalloc.c
+++ b/unix/os/zalloc.c
@@ -13,6 +13,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZALLOC.C -- Device allocation interface.  Requires the dev$devices table,
  * which is read by the high level code before we are called.

--- a/unix/os/zawset.c
+++ b/unix/os/zawset.c
@@ -12,6 +12,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 #define	PCT_RESERVE	10	 /* percent */
 #define	MIN_RESERVE	50	 /* megabytes */
 #define	MIN_WORKSET	32	 /* megabytes */

--- a/unix/os/zcall.c
+++ b/unix/os/zcall.c
@@ -8,6 +8,8 @@
 #define import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZCALL[0-10] -- Call the procedure whose entry point address is pointed to
  * by the first argument, which is the integer valued entry point address of
  * the procedure as returned by ZLOCPR.  Up to ten arguments are passed by

--- a/unix/os/zdojmp.c
+++ b/unix/os/zdojmp.c
@@ -9,6 +9,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZDOJMP -- Restore the saved processor context (non-local goto).  See also
  * as$zsvjmp.s, where most of the work is done.
  */

--- a/unix/os/zfacss.c
+++ b/unix/os/zfacss.c
@@ -12,6 +12,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 #define	SZ_TESTBLOCK	1024		/* for TEXT/BINARY heuristic	*/
 #define	MAX_LINELEN	256		/* when looking for newlines	*/
 #define	R		04		/* UNIX access() codes		*/

--- a/unix/os/zfaloc.c
+++ b/unix/os/zfaloc.c
@@ -13,6 +13,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFALOC -- Preallocate space for a large file of known size, without having
  * to physically write zero blocks.  In UNIX this is done by seeking to the
  * desired end of file and writing some data.  Standard UNIX does not provide

--- a/unix/os/zfchdr.c
+++ b/unix/os/zfchdr.c
@@ -7,6 +7,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 extern	char oscwd[];
 
 

--- a/unix/os/zfdele.c
+++ b/unix/os/zfdele.c
@@ -7,6 +7,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFDELE -- Delete a file.
  */
 int

--- a/unix/os/zfgcwd.c
+++ b/unix/os/zfgcwd.c
@@ -9,6 +9,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 extern	char oscwd[];
 
 

--- a/unix/os/zfinfo.c
+++ b/unix/os/zfinfo.c
@@ -13,6 +13,8 @@
 #define import_finfo
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFINFO -- Get information describing the named file.  Access times
  * are returned in units of seconds since 00:00:00 01-Jan-80, local time.
  */

--- a/unix/os/zfiobf.c
+++ b/unix/os/zfiobf.c
@@ -21,6 +21,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZFIOBF -- FIO interface to UNIX 4.1BSD binary files.
  * This is the interface to general, random access disk resident binary

--- a/unix/os/zfiobf.c
+++ b/unix/os/zfiobf.c
@@ -49,7 +49,6 @@
  * FIO interface is absolute offset, so we have to keep track of the file
  * position to avoid a seek on every i/o access.
  */
-
 int _u_fmode (int mode);
 int vm_access (char *fname, int mode);
 int vm_reservespace (long nbytes);

--- a/unix/os/zfiobf.c
+++ b/unix/os/zfiobf.c
@@ -758,9 +758,6 @@ vm_connect (void)
 	XINT fd;
 	int status = 0;
 
-	extern int ZOPNND(PKCHAR *pk_osfn, XINT *mode, XINT *chan);
-
-
 	/* Already connected? */
 	if (vm_server)
 	    return (0);
@@ -795,7 +792,6 @@ vm_shutdown (void)
 {
 	XINT status;
 	XINT fd = vm_server;
-	extern  int  ZCLSND(XINT *fd, XINT *status);
 
 	if (vm_server) {
 	    if (vm_debug)

--- a/unix/os/zfioks.c
+++ b/unix/os/zfioks.c
@@ -30,6 +30,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 
 /* ZFIOKS -- File i/o to a remote kernel server.  This driver is the network
  * interface for the kernel interface package (sys$ki).  The KS driver is

--- a/unix/os/zfioks.c
+++ b/unix/os/zfioks.c
@@ -1620,8 +1620,6 @@ ks_sysname (char *filename, char *pathname)
 {
 	XCHAR	irafdir[SZ_PATHNAME+1];
 	XINT	x_maxch=SZ_PATHNAME, x_nchars;
-	extern  int  ZGTENV(PKCHAR *envvar, PKCHAR *outstr, XINT *maxch, XINT *status);
-
 
 	ZGTENV ((const int*)"iraf", irafdir, &x_maxch, &x_nchars);
 	if (x_nchars <= 0)

--- a/unix/os/zfiolp.c
+++ b/unix/os/zfiolp.c
@@ -68,17 +68,6 @@ struct	oprinter lpr;			/* printer descriptor		*/
 int	lpr_inuse = NO;			/* set if printer is open	*/
 char	lpstr[SZ_LPSTR+1];		/* save zopnlp argument		*/
 
-
-extern  int ZOPNBF (PKCHAR *osfn, XINT *mode, XINT *chan);
-extern	int ZCLSBF (XINT *fd, XINT *status);
-extern	int ZOSCMD (PKCHAR *oscmd, PKCHAR *stdin_file, PKCHAR  *stdout_file, PKCHAR *stderr_file, XINT *status);
-extern	int ZFDELE (PKCHAR *fname, XINT *status);
-extern	int ZARDBF (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *offset);
-extern  int ZAWRBF (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *offset);
-extern	int ZAWTBF (XINT *fd, XINT *status);
-extern	int ZSTTBF (XINT *fd, XINT *param, XLONG *lvalue);
-
-
 /* ZOPNLP -- Open a printer device for binary file i/o.  If we can talk
  * directly to the printer, do so, otherwise open a spoolfile which is
  * to be sent to the printer when ZCLSLP is later called.

--- a/unix/os/zfiolp.c
+++ b/unix/os/zfiolp.c
@@ -13,6 +13,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZFIOLP -- IRAF FIO interface to the line printer device.  The line printer
  * is opened as a streaming type (no seeks) write-only binary device.

--- a/unix/os/zfiomt.c
+++ b/unix/os/zfiomt.c
@@ -33,6 +33,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZFIOMT.C -- Programmable magtape kernel interface for UNIX/IRAF systems.
  * This file contains only the lowest level i/o routines.  Most of the

--- a/unix/os/zfiond.c
+++ b/unix/os/zfiond.c
@@ -23,6 +23,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZFIOND -- This driver provides a FIO-compatible interface to network or
  * IPC streaming devices such as Berkeley sockets, FIFOs, and the like.

--- a/unix/os/zfiopl.c
+++ b/unix/os/zfiopl.c
@@ -62,16 +62,6 @@ char	plstr[SZ_PLSTR+1];		/* save zopnpl argument		*/
 int	pltr_inuse = NO;		/* set if plotter is open	*/
 
 
-extern  int ZOPNBF (PKCHAR *osfn, XINT *mode, XINT *chan);
-extern	int ZCLSBF (XINT *fd, XINT *status);
-extern	int ZOSCMD (PKCHAR *oscmd, PKCHAR *stdin_file, PKCHAR  *stdout_file, PKCHAR *stderr_file, XINT *status);
-extern	int ZFDELE (PKCHAR *fname, XINT *status);
-extern	int ZARDBF (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *offset);
-extern  int ZAWRBF (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *offset);
-extern	int ZAWTBF (XINT *fd, XINT *status);
-extern	int ZSTTBF (XINT *fd, XINT *param, XLONG *lvalue);
-
-
 /* ZOPNPL -- Open a plotter device for binary file i/o.  If we can talk
  * directly to the plotter, do so, otherwise open a spoolfile which is
  * to be sent to the plotter when ZCLSPL is later called.

--- a/unix/os/zfiopl.c
+++ b/unix/os/zfiopl.c
@@ -13,6 +13,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZFIOPL -- IRAF FIO interface to plotter devices.  A plotter
  * is opened as a streaming type (no seeks) write-only binary device.

--- a/unix/os/zfiopr.c
+++ b/unix/os/zfiopr.c
@@ -15,6 +15,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 extern	int errno;		/* error code returned by the kernel	*/
 
 extern void pr_enter (int pid, int inchan, int outchan);

--- a/unix/os/zfiopr.c
+++ b/unix/os/zfiopr.c
@@ -19,9 +19,6 @@
 
 extern	int errno;		/* error code returned by the kernel	*/
 
-extern void pr_enter (int pid, int inchan, int outchan);
-
-
 
 /* ZFIOPR -- File i/o to a subprocess.  A "connected" subprocess is connected
  * to the parent via two IPC channels (read and write), and is analogous to a
@@ -186,8 +183,6 @@ int
 ZCLCPR (XINT *pid, XINT *exit_status)
 {
 	int	inchan, outchan;
-	extern  int pr_getipc(int pid, int *inchan, int *outchan), pr_wait(int pid);
-
 
 	if (pr_getipc ((int)*pid, &inchan, &outchan) == ERR)
 	    *exit_status = XERR;

--- a/unix/os/zfiosf.c
+++ b/unix/os/zfiosf.c
@@ -8,6 +8,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZFIOSF -- Static file device driver.  In the 4.1BSD UNIX kernel the ordinary
  * binary file driver is used for static files (files that do not change in

--- a/unix/os/zfiosf.c
+++ b/unix/os/zfiosf.c
@@ -37,14 +37,6 @@
  * during file creation and deletion.
  */
 
-extern	int ZARDBF (XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *offset);
-extern	int ZAWRBF (XINT *chan, XCHAR *buf, XINT *nbytes, XLONG *offset);
-extern	int ZAWTBF (XINT *fd, XINT *status);
-extern	int ZCLSBF (XINT *fd, XINT *status);
-extern	int ZOPNBF (PKCHAR *osfn, XINT *mode, XINT *chan);
-extern	int ZSTTBF (XINT *fd, XINT *param, XLONG *lvalue);
-
-
 /* ZOPNSF -- Open a static file.  Only RO, WO, and RW modes are permitted
  * for static files, since allocation is via ZFALOC and appending is not
  * permitted.

--- a/unix/os/zfiotx.c
+++ b/unix/os/zfiotx.c
@@ -24,6 +24,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZFIOTX -- File i/o to textfiles, for UNIX 4.1BSD.  This driver is used for
  * both terminals and ordinary disk text files.  I/O is via the C library

--- a/unix/os/zfioty.c
+++ b/unix/os/zfioty.c
@@ -8,6 +8,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 
 extern  int ZOPNTX (PKCHAR *osfn, XINT *mode, XINT *chan);
 extern	int ZCLSTX (XINT *fd, XINT *status);

--- a/unix/os/zfioty.c
+++ b/unix/os/zfioty.c
@@ -11,16 +11,6 @@
 #include "osproto.h"
 
 
-extern  int ZOPNTX (PKCHAR *osfn, XINT *mode, XINT *chan);
-extern	int ZCLSTX (XINT *fd, XINT *status);
-extern	int ZFLSTX (XINT *fd, XINT *status);
-extern	int ZGETTX (XINT *fd, XCHAR *buf, XINT *maxchars, XINT *status);
-extern  int ZNOTTX (XINT *fd, XLONG *offset);
-extern	int ZPUTTX (XINT *fd, XCHAR *buf, XINT *nchars, XINT *status);
-extern	int ZSEKTX (XINT *fd, XLONG *znottx_offset, XINT *status);
-extern	int ZSTTTX (XINT *fd, XINT *param, XLONG *value);
-
-
 /*
  * ZFIOTY -- Device driver for terminals.  In the 4.1BSD UNIX kernel the same
  * driver is used for both terminals and ordinary text files, hence all we

--- a/unix/os/zflink.c
+++ b/unix/os/zflink.c
@@ -11,6 +11,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 
 /* ZFLINK -- Create a file symlink.
  */

--- a/unix/os/zfmkcp.c
+++ b/unix/os/zfmkcp.c
@@ -35,8 +35,6 @@ ZFMKCP (
 	int	fd, mode;
 	XINT	prot;
 
-	extern  int ZFPROT(PKCHAR *fname, XINT *action, XINT *status);
-
 
 	/* Get directory information for the old file.  Most of the file
 	 * attributes reside in the st_mode field.

--- a/unix/os/zfmkcp.c
+++ b/unix/os/zfmkcp.c
@@ -12,6 +12,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFMKCP -- Make a null length copy of a file.  The new file inherits all
  * attributes of the original file except the file owner (the copy belongs to
  * the owner of the process which called us), the file size (this will be 0

--- a/unix/os/zfmkdr.c
+++ b/unix/os/zfmkdr.c
@@ -10,6 +10,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFMKDR -- Create a new directory.
  */
 int

--- a/unix/os/zfnbrk.c
+++ b/unix/os/zfnbrk.c
@@ -8,6 +8,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFNBRK -- Determine the offsets of the components of a virtual file name:
  *
  * 	"ldir$subdir/root.extn"

--- a/unix/os/zfpath.c
+++ b/unix/os/zfpath.c
@@ -8,6 +8,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFPATH -- Return the absolute pathname equivalent of an OSFN.  If the null
  * string is given the OSFN of the current working directory is returned.
  */

--- a/unix/os/zfpath.c
+++ b/unix/os/zfpath.c
@@ -26,8 +26,6 @@ ZFPATH (
 	register int	n = *maxch;
 	PKCHAR	cwd[SZ_PATHNAME+1];
 
-	extern  int ZFGCWD(PKCHAR  *outstr, XINT *maxch, XINT *status);
-
 
 	op = pathname;
 	for (ip=osfn;  *ip == ' ';  ip++)

--- a/unix/os/zfpoll.c
+++ b/unix/os/zfpoll.c
@@ -11,6 +11,8 @@
 #define import_fpoll
 #include <iraf.h>
 
+#include "osproto.h"
+
 
 /* For compilation on systems with old and dev versions.
 */

--- a/unix/os/zfprot.c
+++ b/unix/os/zfprot.c
@@ -13,6 +13,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 #define	PREFIX		".."		/* hidden link for protected files */
 
 static int chk_prot (char *fname, char *link_name);

--- a/unix/os/zfrmdr.c
+++ b/unix/os/zfrmdr.c
@@ -10,6 +10,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFRMDR -- Remove an existing directory.
  */
 int

--- a/unix/os/zfrnam.c
+++ b/unix/os/zfrnam.c
@@ -8,6 +8,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFRNAM -- Rename a file.  Do nothing to original file if operation
  * fails.  File must retain all attributes; special action is required
  * to transfer file protection.

--- a/unix/os/zfrnam.c
+++ b/unix/os/zfrnam.c
@@ -26,8 +26,6 @@ ZFRNAM (
 	static	XINT setprot    = SET_PROTECTION;
 	XINT	protected;
 
-	extern  int ZFPROT(PKCHAR *fname, XINT *action, XINT *status);
-
 
 	/* Most remove file protection before renaming the file, else
 	 * zfprot will not find the file and will refuse to delete the

--- a/unix/os/zfsubd.c
+++ b/unix/os/zfsubd.c
@@ -33,8 +33,6 @@ ZFSUBD (
 	XCHAR	*slash;
 	char	*cp;
 
-	extern  int ZFGCWD(PKCHAR *outstr, XINT *maxch, XINT *status);
-
 
 	/* If osdir is null, use the current directory.
 	 */

--- a/unix/os/zfsubd.c
+++ b/unix/os/zfsubd.c
@@ -8,6 +8,8 @@
 #define import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFSUBD -- Fold a subdirectory into an OS directory.  If osdir is null the
  * current directory is assumed.  If subdir is null osdir is modified as
  * necessary to make it a legal directory prefix, e.g., if osdir = "/usr/iraf"

--- a/unix/os/zfunc.c
+++ b/unix/os/zfunc.c
@@ -7,6 +7,8 @@
 #define import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFUNC[0-10] -- Call the function whose entry point address is pointed to
  * by the first argument, which is the integer valued entry point address of
  * the procedure as returned by ZLOCPR.  Up to ten arguments are passed by

--- a/unix/os/zfutim.c
+++ b/unix/os/zfutim.c
@@ -12,6 +12,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 #define SECONDS_1970_TO_1980    315532800L
 
 

--- a/unix/os/zfutim.c
+++ b/unix/os/zfutim.c
@@ -33,8 +33,6 @@ ZFUTIM (
 	struct	utimbuf time;
 	XINT	offset = 0;
 
-	extern  int ZGMTCO (XINT  *gmtcor);
-
 
 	/* Get UNIX file info.
 	 */

--- a/unix/os/zfxdir.c
+++ b/unix/os/zfxdir.c
@@ -8,6 +8,8 @@
 #define import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZFXDIR -- Extract OS directory prefix from OSFN.  The null string is
  * returned if there is no directory prefix.  The status value is the number
  * of characters in the output string.

--- a/unix/os/zgcmdl.c
+++ b/unix/os/zgcmdl.c
@@ -4,6 +4,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 extern	char *environ[];
 #ifdef	__APPLE__
 extern  char ***_NSGetArgv();

--- a/unix/os/zghost.c
+++ b/unix/os/zghost.c
@@ -7,6 +7,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZGHOST -- Get the network name of the host computer.
  */
 int

--- a/unix/os/zglobl.c
+++ b/unix/os/zglobl.c
@@ -6,6 +6,8 @@
 #define	import_kernel
 #include <iraf.h>
 
+#include "osproto.h"
+
 #define	SZ_PROCNAME	256
 
 /* Allocate ZFD, the global data structure for the kernel file i/o system.

--- a/unix/os/zgmtco.c
+++ b/unix/os/zgmtco.c
@@ -9,6 +9,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 #define SECONDS_1970_TO_1980    315532800L
 
 /* ZGMTCO -- Return the correction, in seconds, from local standard time

--- a/unix/os/zgmtco.c
+++ b/unix/os/zgmtco.c
@@ -21,7 +21,7 @@ ZGMTCO (
   XINT	*gmtcor				/* seconds */
 )
 {
-	time_t gmt_to_lst(), ltime;
+	time_t ltime;
 
 	/* Given an input value of zero (biased by SECONDS_1970_TO_1980)
 	 * gmt_to_lst will return a negative value in seconds for a location

--- a/unix/os/zgtenv.c
+++ b/unix/os/zgtenv.c
@@ -10,6 +10,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 static char *_ev_scaniraf (char *envvar);
 static char *_ev_irafroot (void);
 

--- a/unix/os/zgtime.c
+++ b/unix/os/zgtime.c
@@ -13,6 +13,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZGTIME -- Get the local standard (clock) time, in units of seconds
  * since 00:00:00 01-Jan-80.  Return the total cpu time consumed by the
  * process (and any subprocesses), in units of milliseconds.

--- a/unix/os/zgtpid.c
+++ b/unix/os/zgtpid.c
@@ -7,6 +7,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZGTPID -- Get process id number (used for process control and to make
  * unique file names).
  */

--- a/unix/os/zintpr.c
+++ b/unix/os/zintpr.c
@@ -8,6 +8,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZINTPR -- Interrupt a connected subprocess, i.e., raise the exception X_INT
  * in the subprocess.  On the UNIX system subprocesses ignore the UNIX SIGINT
  * exception, hence we send SIGTERM instead and the exception handling code

--- a/unix/os/zlocpr.c
+++ b/unix/os/zlocpr.c
@@ -7,6 +7,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 extern	unsigned VSHLIB[], VSHEND;	/* shared library descriptor */
 
 /* ZLOCPR -- Return the entry point address of a procedure as a magic

--- a/unix/os/zlocva.c
+++ b/unix/os/zlocva.c
@@ -7,6 +7,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZLOCVA -- Return the address of a variable or array element in XCHAR units.
  * Must be able to do signed arithmetic on the integer value returned.
  * We ASSUME that XCHAR through XDOUBLE are addressed in the same units.

--- a/unix/os/zmain.c
+++ b/unix/os/zmain.c
@@ -18,6 +18,11 @@
 #define import_kproto
 #include <iraf.h>
 
+extern	int  ONENTRY(XINT *prtype, XCHAR *bkgfile, XCHAR *cmd);
+extern	int  SYSRUK(XCHAR *task, XCHAR *cmd, XINT *rukarf, XINT *rukint);
+extern	int  ZZSETK(char *ospn, char *osbfn, int prtype, int isatty, int in, int out);
+
+
 /*
  * ZMAIN.C -- C main for IRAF processes.
  */
@@ -63,14 +68,6 @@ main (int argc, char *argv[])
 	char	*ip;
 
 	int	arg = 1;
-	extern  int  ZGETTX(XINT *fd, XCHAR *buf, XINT *maxchars, XINT *status);
-	extern	int  ZGETTY(XINT *fd, XCHAR *buf, XINT *maxchars, XINT *status);
-	extern	int  ZARDPR(XINT *chan, XCHAR *buf, XINT *maxbytes, XLONG *loffset);
-	extern	int  SYSRUK(XCHAR *task, XCHAR *cmd, XINT *rukarf, XINT *rukint);
-	extern	int  ONENTRY(XINT *prtype, XCHAR *bkgfile, XCHAR *cmd);
-	extern  int  ZZSTRT(void);
-	extern	int  ZLOCPR(PFI proc, XINT *o_epa );
-	extern	int  ZZSETK(char *ospn, char *osbfn, int prtype, int isatty, int in, int out);
 	extern	int  IRAF_MAIN(XCHAR *acmd, XINT *ainchn, XINT *aoutcn, XINT *aerrcn, XINT *adrivr, XINT *adevte, XINT *prtype, XCHAR *bkgfie, XINT *jobcoe,
 			       int(sysruk)(XCHAR *task, XCHAR *cmd, XINT *rukarf, XINT *rukint),
 			       int(onenty)(XINT *prtype, XCHAR *bkgfile, XCHAR *cmd));

--- a/unix/os/zmain.c
+++ b/unix/os/zmain.c
@@ -15,6 +15,7 @@
 #define import_prtype
 #define	import_knames
 #define	import_xnames
+#define import_kproto
 #include <iraf.h>
 
 /*

--- a/unix/os/zmaloc.c
+++ b/unix/os/zmaloc.c
@@ -8,6 +8,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 
 
 /* ZMALOC -- Allocate space on the heap.  NULL is returned if the buffer

--- a/unix/os/zmfree.c
+++ b/unix/os/zmfree.c
@@ -7,6 +7,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 
 /* ZMFREE -- Return heap space previously allocated by ZMALOC or ZRALOC.
  * The manual page for FREE says nothing about error checking, so we do

--- a/unix/os/zopdir.c
+++ b/unix/os/zopdir.c
@@ -12,6 +12,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZOPDIR.C -- Routines for returning the contents of a directory as a list
  * of filename strings.

--- a/unix/os/zopdpr.c
+++ b/unix/os/zopdpr.c
@@ -19,11 +19,6 @@
 
 #define	QUANTUM		6
 
-extern void pr_enter (int pid, int inchan, int outchan);
-extern int  pr_wait (int pid);
-extern void pr_release (int pid);
-
-
 /* ZOPDPR -- Open a detached process.  In this implementation detached
  * processes begin execution immediately, runing concurrently with the parent.
  * "Jobcode" can be anything we want, provided it is unique.  Since detached

--- a/unix/os/zopdpr.c
+++ b/unix/os/zopdpr.c
@@ -15,6 +15,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 #define	QUANTUM		6
 
 extern void pr_enter (int pid, int inchan, int outchan);

--- a/unix/os/zoscmd.c
+++ b/unix/os/zoscmd.c
@@ -17,7 +17,7 @@
 #include "osproto.h"
 
 static	int lastsig;
-extern	int pr_onint(int usig, int *hwcode, int *scp);
+static	int pr_onint(int usig, int *hwcode, int *scp);
 
 extern void pr_enter (int pid, int inchan, int outchan);
 extern int  pr_wait (int pid);
@@ -165,7 +165,7 @@ ZOSCMD (
  * interrupted, post a flag to indicate this to ZOSCMD when the pr_wait()
  * returns.
  */
-int
+static int
 pr_onint (
   int	usig,				/* SIGINT, SIGFPE, etc.		*/
   int	*hwcode,			/* not used */

--- a/unix/os/zoscmd.c
+++ b/unix/os/zoscmd.c
@@ -14,6 +14,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 static	int lastsig;
 extern	int pr_onint(int usig, int *hwcode, int *scp);
 

--- a/unix/os/zpanic.c
+++ b/unix/os/zpanic.c
@@ -12,6 +12,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 extern	char os_process_name[];		/* process name, set in zmain	*/
 extern	PKCHAR osfn_bkgfile[];		/* bkgfile fname if detached	*/
 extern	int save_prtype;		/* process type saved by zmain	*/

--- a/unix/os/zpanic.c
+++ b/unix/os/zpanic.c
@@ -90,8 +90,6 @@ kernel_panic (char *errmsg)
 	PKCHAR	pkmsg[SZ_LINE];
 	register char	*ip, *op;
 
-	extern  int ZPANIC(XINT *errcode, PKCHAR *errmsg);
-
 
 	/* It is necessary to copy the error message string to get a PKCHAR
 	 * type string since misalignment is possible when coercing from char

--- a/unix/os/zraloc.c
+++ b/unix/os/zraloc.c
@@ -7,6 +7,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZRALOC -- Reallocate space on the heap (change the size of the area).
  */
 int

--- a/unix/os/zshlib.c
+++ b/unix/os/zshlib.c
@@ -4,6 +4,8 @@
 #define import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZSHLIB.C -- This file contains dummy shared library descriptors to be linked
  * into executables which do not use the Sun/IRAF shared library.  See zzstrt.c

--- a/unix/os/zttyio.c
+++ b/unix/os/zttyio.c
@@ -9,6 +9,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 int ZTTYSZ ( XINT *dev, XINT *width, XINT *height )
 {
     struct winsize buf;

--- a/unix/os/zwmsec.c
+++ b/unix/os/zwmsec.c
@@ -7,6 +7,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* Comment out or ifdef the following if usleep is not available. */
 #define USE_USLEEP
 

--- a/unix/os/zxwhen.c
+++ b/unix/os/zxwhen.c
@@ -38,7 +38,7 @@ int debug_sig = 0;
 #define	fcancel(fp)
 #endif
 
-void ex_handler ( int, siginfo_t *, void * );
+static void ex_handler (int unix_signal, siginfo_t *info, void *ucp);
 
 static long setsig(int code, SIGFUNC handler);
 static int ignore_sigint = 0;
@@ -185,8 +185,6 @@ ZXWHEN (
 	int     vex, uex;
 	SIGFUNC	vvector;
 
-	extern  int  kernel_panic (char *errmsg);
-
 
 	/* Convert code for virtual exception into an index into the table
 	 * of exception handler EPA's.
@@ -275,7 +273,7 @@ setsig (int code, SIGFUNC handler)
  * handler.  If we get the software termination signal from the CL, 
  * stop process execution immediately (used to kill detached processes).
  */
-void
+static void
 ex_handler (
   int  	    unix_signal,
   siginfo_t *info,

--- a/unix/os/zxwhen.c
+++ b/unix/os/zxwhen.c
@@ -13,6 +13,8 @@
 #define import_xwhen
 #include <iraf.h>
 
+#include "osproto.h"
+
 /* ZXWHEN.C -- IRAF exception handling interface.  This version has been 
  * customized for PC-IRAF, i.e., LINUX and FreeBSD.
  *

--- a/unix/os/zzdbg.c
+++ b/unix/os/zzdbg.c
@@ -15,6 +15,8 @@
 #define import_prtype
 #include <iraf.h>
 
+#include "osproto.h"
+
 
 
 void zzval_ (XINT *val) 

--- a/unix/os/zzepro.c
+++ b/unix/os/zzepro.c
@@ -5,6 +5,8 @@
 #define import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 
 
 void ex_handler ( int, siginfo_t *, void * );

--- a/unix/os/zzepro.c
+++ b/unix/os/zzepro.c
@@ -7,11 +7,6 @@
 
 #include "osproto.h"
 
-
-
-void ex_handler ( int, siginfo_t *, void * );
-
-
 /*
  * ZZEPRO.C -- Code which is executed at the end of every procedure.
  */

--- a/unix/os/zzexit.c
+++ b/unix/os/zzexit.c
@@ -3,6 +3,8 @@
 #define import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZZEXIT.C -- Fortran callable exit procedure.  Some systems (e.g. libf2c)
  * require this procedure.  We implement it as a separate library procedure

--- a/unix/os/zzpstr.c
+++ b/unix/os/zzpstr.c
@@ -52,13 +52,6 @@ void 	spp_printmemc (long memc_ptr);
 void 	spp_printstr (XCHAR *s);
 
 
-
-/* SPP_DEBUG -- Dummy function called to link the SPP debug functions into
- * a program.
- */
-int spp_debug (void) { return (0); }
-
-
 /* ZZPSTR -- Write SPP text data directly to the host stderr.  Up to two
  * strings may be ouptut.  Either may be the null pointer to disable.
  * A newline is added at the end if not present in the last string.

--- a/unix/os/zzpstr.c
+++ b/unix/os/zzpstr.c
@@ -6,6 +6,8 @@
 #define	import_spp
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZZPSTR.C -- Support for debugging SPP programs.
  *

--- a/unix/os/zzsetk.c
+++ b/unix/os/zzsetk.c
@@ -8,6 +8,8 @@
 #define	import_knames
 #include <iraf.h>
 
+#include "osproto.h"
+
 extern	char os_process_name[];
 extern	PKCHAR osfn_bkgfile[];
 extern	int save_prtype;

--- a/unix/os/zzstrt.c
+++ b/unix/os/zzstrt.c
@@ -45,11 +45,6 @@ int
 ZZSTRT (void)
 {
 	XINT	wsetsize=0L, junk;
-	extern  int  spp_debug(void);
-
-
-	spp_debug ();
-
 	/* Initialize globals.
 	 */
 	sprintf (os_process_name, "%d", getpid());

--- a/unix/os/zzstrt.c
+++ b/unix/os/zzstrt.c
@@ -18,6 +18,8 @@
 #define import_prtype
 #include <iraf.h>
 
+#include "osproto.h"
+
 /*
  * ZZSTRT,ZZSTOP -- Routines to perform initialization and cleanup functions
  * during process startup and shutdown, when the IRAF kernel routines are being

--- a/unix/os/zzstrt.c
+++ b/unix/os/zzstrt.c
@@ -38,11 +38,6 @@ extern	int errno;
 
 void 	ready_ (void);
 
-extern int ZAWSET(XINT *best_size, XINT *new_size, XINT *old_size, XINT *max_size);
-extern int ZOPNTY(PKCHAR *osfn, XINT *mode, XINT *chan);
-extern int ZZSETK(char *ospn, char *osbfn, int prtype, int isatty, int in, int out);
-
-
 
 /* ZZSTRT -- Initialize the IRAF kernel at process startup time.
  */


### PR DESCRIPTION
The `hlib$libc/kproto.h` include file was a simple raw dump of the "cproto" program, which is hard to maintain. It was also buggy with some conflicts, and exposed a number of internal functions.

This PR replaces this file by a manually generated (and maintained) one, with the original types kept. So, this file is now much simpler and better readable. It can probably also be used in `sys$libc`.