### PR TITLE
Replace SIGFUNC by sighandler_t

### DIFF
--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -182,8 +182,8 @@ static int   run (char *task, char *argv[]);
 static int   sys (char *cmd);
 
 static void  done (int k);
-static void  enbint (SIGFUNC handler);
-static void  interrupt (void);
+static void  enbint (void (*handler)(int));
+static void  interrupt (int);
 static int   await (int waitpid);
 static void  rmfiles (void);
 
@@ -230,7 +230,7 @@ main (int argc, char *argv[])
 	sig_hup  = (long) signal (SIGHUP,  SIG_IGN) & 01;
 	sig_term = (long) signal (SIGTERM, SIG_IGN) & 01;
 
-	enbint ((SIGFUNC)interrupt);
+	enbint (interrupt);
 	pid = getpid();
 
 	/* Load general environment definitions.
@@ -1307,7 +1307,7 @@ done (int k)
  * of interrupt occurs.
  */
 static void
-enbint (SIGFUNC handler)
+enbint (void (*handler)(int))
 {
 	if (sig_int == 0)
 	    signal (SIGINT, handler);
@@ -1324,7 +1324,7 @@ enbint (SIGFUNC handler)
  * during compilation.
  */
 static void
-interrupt (void)
+interrupt (int signum)
 {
 	done (2);
 }
@@ -1341,7 +1341,7 @@ await (int waitpid)
 	while ((w = wait (&status)) != waitpid)
 	    if (w == -1)
 		fatal ("bad wait code");
-	enbint ((SIGFUNC)interrupt);
+	enbint (interrupt);
 	if (status & 0377) {
 	    if (status != SIGINT) {
 		fprintf (stderr, "Termination code %d", status);

--- a/unix/hlib/libc/kernel.h
+++ b/unix/hlib/libc/kernel.h
@@ -84,8 +84,6 @@ extern	struct fiodes zfd[];		/* array of descriptors		*/
 #define	LEN_SETREDRAW	6		/* nchars in setredraw string	*/
 #define SETREDRAW	"\033=rDw"	/* set/enable screenredraw code	*/
 
-typedef	void  (*SIGFUNC)();
-
 typedef	void  (*PFV)();
 typedef	int   (*PFI)();
 

--- a/unix/os/zfiomt.c
+++ b/unix/os/zfiomt.c
@@ -1619,7 +1619,7 @@ zmtbsr (int fd, int nrecords)
  */
 
 #ifdef TCPIP
-static	SIGFUNC sigpipe = NULL;
+static	void (*sigpipe)(int) = NULL;
 static	int nsockets = 0;
 static	int s_port[MAXDEV];
 static	FILE *s_fp[MAXDEV];
@@ -1654,7 +1654,7 @@ static void zmtdbgopen (struct mtdesc *mp)
 	 */
         if (mp->mtdev.statusout) {
 	    if (nsockets > 0 && !sigpipe)
-		sigpipe = (SIGFUNC) signal (SIGPIPE, SIG_IGN);
+		sigpipe = signal (SIGPIPE, SIG_IGN);
 	    return;
 	}
 
@@ -1777,7 +1777,7 @@ static void zmtdbgclose (struct mtdesc *mp)
 
 	    if (sigpipe && nsockets <= 0) {
 		signal (SIGPIPE, sigpipe);
-		sigpipe = (SIGFUNC) NULL;
+		sigpipe = NULL;
 		nsockets = 0;
 	    }
 	}

--- a/unix/os/zfiond.c
+++ b/unix/os/zfiond.c
@@ -158,8 +158,7 @@ static	int recursion = 0;
 extern	int errno;
 static	int getstr(char **ipp, char *obuf, int maxch, int delim);
 
-static void nd_onsig (int sig, int *arg1, int *arg2);
-
+static void nd_onsig (int sig);
 
 
 /* ZOPNND -- Open a network device.
@@ -741,12 +740,12 @@ ZAWRND (
 	int nwritten, maxbytes, n;
 	char *text, *ip = (char *)buf;
 	char obuf[SZ_OBUF];
-	SIGFUNC sigpipe;
+	void (*sigpipe)(int);
 
 
 	/* Enable a signal mask to catch SIGPIPE when the server has died. 
 	 */
-	sigpipe = (SIGFUNC) signal (SIGPIPE, (SIGFUNC)nd_onsig);
+	sigpipe = signal (SIGPIPE, nd_onsig);
 	recursion = 0;
 
 	maxbytes = (np->domain == FIFO || (np->flags & F_TEXT)) ? SZ_OBUF : 0;
@@ -800,9 +799,7 @@ ZAWRND (
  *  */
 static void
 nd_onsig (
-  int     sig,                    /* signal which was trapped     */
-  int     *arg1,                  /* not used */
-  int     *arg2                   /* not used */
+  int     sig                    /* signal which was trapped     */
 )
 {
         /* If we get a SIGPIPE writing to a server the server has probably

--- a/unix/os/zfiotx.c
+++ b/unix/os/zfiotx.c
@@ -84,7 +84,7 @@ static	struct sigaction sigint, sigterm;
 static	struct sigaction sigtstp, sigcont;
 static	struct sigaction oldact;
 static	void  tty_rawon(struct ttyport *port, int flags), tty_reset(struct ttyport *port), uio_bwrite(FILE *fp, short int *buf, int nbytes);
-static	void  tty_onsig(int sig, int *code, int *scp), tty_stop(int sig, int *code, int *scp), tty_continue(int sig, int *code, int *scp);
+static	void  tty_onsig(int sig), tty_stop(int sig), tty_continue(int sig);
 
 /* The ttyports array describes up to MAXOTTYS open terminal i/o ports.
  * Very few processes will ever have more than one or two ports open at
@@ -386,12 +386,12 @@ ZGETTX (XINT *fd, XCHAR *buf, XINT *maxchars, XINT *status)
 	     * because ctrl/s ctrl/q is disabled in raw mode, and that can
 	     * cause sporadic protocol failures.
 	     */
-            sigint.sa_handler = (SIGFUNC) tty_onsig;
+            sigint.sa_handler = tty_onsig;
             sigemptyset (&sigint.sa_mask);
             sigint.sa_flags = SA_NODEFER;
             sigaction (SIGINT, &sigint, &oldact);
 
-            sigterm.sa_handler = (SIGFUNC) tty_onsig;
+            sigterm.sa_handler = tty_onsig;
             sigemptyset (&sigterm.sa_mask);
             sigterm.sa_flags = SA_NODEFER;
             sigaction (SIGTERM, &sigterm, &oldact);
@@ -732,12 +732,12 @@ tty_rawon (
 	    /* Post signal handlers to clear/restore raw mode if process is
 	     * suspended.
 	     */
-            sigtstp.sa_handler = (SIGFUNC) tty_stop;
+            sigtstp.sa_handler = tty_stop;
             sigemptyset (&sigtstp.sa_mask);
             sigtstp.sa_flags = SA_NODEFER;
             sigaction (SIGINT, &sigtstp, &oldact);
 
-            sigcont.sa_handler = (SIGFUNC) tty_continue;
+            sigcont.sa_handler = tty_continue;
             sigemptyset (&sigcont.sa_mask);
             sigcont.sa_flags = SA_NODEFER;
             sigaction (SIGTERM, &sigcont, &oldact);
@@ -796,9 +796,7 @@ tty_reset (
  */
 static void
 tty_onsig (
-  int	sig,			/* signal which was trapped	*/
-  int	*code,			/* not used */
-  int	*scp 			/* not used */
+  int	sig			/* signal which was trapped	*/
 )
 {
 	longjmp (jmpbuf, CTRLC);
@@ -810,9 +808,7 @@ tty_onsig (
  */
 static void
 tty_stop (
-  int	sig,			/* signal which was trapped	*/
-  int	*code,			/* not used */
-  int	*scp 			/* not used */
+  int	sig			/* signal which was trapped	*/
 )
 {
 	register struct ttyport *port = lastdev;
@@ -845,9 +841,7 @@ tty_stop (
  */
 static void
 tty_continue (
-  int	sig,			/* signal which was trapped	*/
-  int	*code,			/* not used */
-  int	*scp 			/* not used */
+  int	sig			/* signal which was trapped	*/
 )
 {
 	register struct ttyport *port = lastdev;

--- a/unix/os/zwmsec.c
+++ b/unix/os/zwmsec.c
@@ -41,7 +41,7 @@ ZWMSEC (XINT *msec)
 #define	mask(s)	(1<<((s)-1))
 
 static int ringring;
-static void napmsx();
+static void napmsx(int);
 
 
 /* ZWMSEC -- Suspend task execution (sleep) for the specified number
@@ -52,7 +52,7 @@ ZWMSEC (XINT *msec)
 {
 	struct itimerval itv, oitv;
 	register struct itimerval *itp = &itv;
-	SIGFUNC	sv_handler;
+	void	(*sv_handler)(int);
 	int omask;
 
 	if (*msec == 0)
@@ -83,7 +83,7 @@ ZWMSEC (XINT *msec)
 	}
 
 	ringring = 0;
-	sv_handler = signal (SIGALRM, (SIGFUNC)napmsx);
+	sv_handler = signal (SIGALRM, napmsx);
 	(void) setitimer (ITIMER_REAL, itp, (struct itimerval *)0);
 
 	while (!ringring)
@@ -97,7 +97,7 @@ ZWMSEC (XINT *msec)
 
 
 static void 
-napmsx (void)
+napmsx (int)
 {
 	ringring = 1;
 }


### PR DESCRIPTION
The global C type `SIGFUNC` was used of a generic signal handling function type. However, this was used for three incompatible function types:

* C signal handlers (`void  (*)(int)`), i.e. a function called with the signal number

* C signal actions (`void  (*)(int, siginfo_t *, void *)`), i.e. a function called with the signal number, additional signal information,  and some payload,

* IRAF signal handlers (`void  (*)(XINT *, XINT *)`), i.e. a function called with a pointer to the signal number and a pointer to the next handler.

Replacing these with proper types leaves only the last case in `zxwhen.c` as a use for `SIGFUNC`. However, this type is not used outside of `zxwhen.c`. As IRAF/SPP doesn't generally support function prototypes, it doesn't make sense to have it exposed anymore.

Fixing this, a bug in `zxwhen.c` was discovered and fixed where the result of **setsig()** was compared to `SIG_IGN` https://github.com/iraf-community/iraf/blob/d057e31702155f79ef8387fd6e97514c58600e4f/unix/os/zxwhen.c#L225-L227

however **setsig()** only returns a the return status of **sigaction()** (0 on success)https://github.com/iraf-community/iraf/blob/d057e31702155f79ef8387fd6e97514c58600e4f/unix/os/zxwhen.c#L264-L266