### PR TITLE
Change a few appearances of PKCHAR

### DIFF
--- a/sys/libc/callocate.c
+++ b/sys/libc/callocate.c
@@ -65,7 +65,7 @@ c_devowner (
   int	maxch 
 )
 {
-	PKCHAR	x_owner[SZ_FNAME+1];
+	XCHAR	x_owner[SZ_FNAME+1];
 	XINT	x_maxch = SZ_FNAME;
 	int	status;
 

--- a/sys/libc/cimdrcur.c
+++ b/sys/libc/cimdrcur.c
@@ -23,7 +23,7 @@ c_imdrcur (
   int	pause			/* true to pause for key to terminate read */
 )
 {
-	PKCHAR	x_strval[SZ_LINE+1];
+	XCHAR	x_strval[SZ_LINE+1];
 	XINT  x_maxch = maxch,  x_d_wcs = d_wcs,  x_pause = pause;
 	XINT  x_wcs, x_key;
 

--- a/sys/libc/clexnum.c
+++ b/sys/libc/clexnum.c
@@ -31,7 +31,7 @@ c_lexnum (
 {
 	register char *ip;
 	register XCHAR *op, ch, ndigits;
-	PKCHAR	 numbuf[SZ_FNAME];
+	XCHAR	 numbuf[SZ_FNAME];
 	XINT	 ip_start = 1, x_toklen = *toklen;
 	int      status;
 

--- a/sys/osb/chrpak.c
+++ b/sys/osb/chrpak.c
@@ -12,7 +12,8 @@
  * negative values.
  */
 CHRPAK (a, a_off, b, b_off, nchars)
-XCHAR	*a, *b;
+XCHAR	*a;
+PKCHAR	*b;
 XINT	*a_off, *b_off, *nchars;
 {
 	register XCHAR	*ip;

--- a/sys/osb/chrupk.c
+++ b/sys/osb/chrupk.c
@@ -11,7 +11,8 @@
  * hence we pack the chars into unsigned bytes and restore the sign explicitly.
  */
 CHRUPK (a, a_off, b, b_off, nchars)
-XCHAR	*a, *b;
+PKCHAR	*a;
+XCHAR	*b;
 XINT	*a_off, *b_off, *nchars;
 {
 	register unsigned char *ip;


### PR DESCRIPTION
These are in fact `XCHAR`s as they are used as unpacked, not packed strings.

For the moment, this is not important as `PKCHAR` is defined as `XCHAR` (which is a `short int`) https://github.com/iraf-community/iraf/blob/d057e31702155f79ef8387fd6e97514c58600e4f/unix/hlib/libc/spp.h#L96

However, it may be useful to get that in sync with votable, https://github.com/iraf-community/iraf/blob/d057e31702155f79ef8387fd6e97514c58600e4f/vendor/libvotable/votParse_spp.c#L23-L26