### PR TITLE
Restructure PFI to be used as "generic" function pointer

### DIFF
--- a/pkg/cl/main.c
+++ b/pkg/cl/main.c
@@ -59,7 +59,7 @@ extern	int bkgno;		/* job number if bkg job		*/
 int	cldebug = 0;		/* print out lots of goodies if > 0	*/
 int	cltrace = 0;		/* trace instruction execution if > 0	*/
 
-static	PFI old_onipc;		/* X_IPC handler chained to onint()	*/
+static	funcptr_t old_onipc;	/* X_IPC handler chained to onint()	*/
 static	long *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
 static	jmp_buf jmp_save;	/* save IRAF Main jump vector		*/
 static	jmp_buf jmp_clexit;	/* clexit() jumps here			*/
@@ -631,7 +631,7 @@ onint (
 void
 intr_disable (void)
 {
-	PFI	junk;
+	funcptr_t	junk;
 
 	if (intr_sp >= LEN_INTRSTK)
 	    cl_error (E_IERR, "interrupt save stack overflow");
@@ -646,7 +646,7 @@ intr_disable (void)
 void
 intr_enable (void)
 {
-	PFI	junk;
+	funcptr_t	junk;
 
 	if (--intr_sp < 0)
 	    cl_error (E_IERR, "interrupt save stack underflow");
@@ -660,7 +660,7 @@ intr_enable (void)
 void
 intr_reset (void)
 {
-	PFI	junk;
+	funcptr_t	junk;
 
 	c_xwhen (X_INT, onint, &junk);
 	intr_sp = 0;

--- a/pkg/cl/main.c
+++ b/pkg/cl/main.c
@@ -49,7 +49,6 @@
 #define	BKG_QUANTUM	30	/* period(sec) bkgjob checkup		*/
 #define	MAX_INTERRUPTS	5	/* max interrupts of a task		*/
 #define	LEN_INTRSTK	10	/* max nesting of saved interrupts	*/
-typedef	int (*PFI)();
 
 extern	int yydebug;		/* print each parser state if set	*/
 extern	FILE *yyin;		/* where parser reads from		*/

--- a/pkg/cl/prcache.c
+++ b/pkg/cl/prcache.c
@@ -617,7 +617,7 @@ pr_checkup (void)
 void
 onipc (
     int *vex,			/* virtual exception code	*/
-    PFI *next_handler		/* next handler to be called	*/
+    funcptr_t *next_handler	/* next handler to be called	*/
 )
 {
 	register struct	process *pr;

--- a/pkg/cl/prcache.c
+++ b/pkg/cl/prcache.c
@@ -64,8 +64,6 @@
 extern	int	cldebug;
 extern	int	cltrace;
 
-typedef	XINT (*PFI)();
-
 struct process {
 	int	pr_pid;			/* process id of subprocess	*/
 	long	pr_time;		/* time when process executed	*/

--- a/pkg/ecl/main.c
+++ b/pkg/ecl/main.c
@@ -59,7 +59,7 @@ extern	int bkgno;		/* job number if bkg job		*/
 int	cldebug = 0;		/* print out lots of goodies if > 0	*/
 int	cltrace = 0;		/* trace instruction execution if > 0	*/
 
-static	PFI old_onipc;		/* X_IPC handler chained to onint()	*/
+static	funcptr_t old_onipc;	/* X_IPC handler chained to onint()	*/
 static	long *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
 static	jmp_buf jmp_save;	/* save IRAF Main jump vector		*/
 static	jmp_buf jmp_clexit;	/* clexit() jumps here			*/
@@ -739,7 +739,7 @@ onint (
 void
 intr_disable (void)
 {
-	PFI	junk;
+	funcptr_t	junk;
 
 	if (intr_sp >= LEN_INTRSTK)
 	    cl_error (E_IERR, "interrupt save stack overflow");
@@ -754,7 +754,7 @@ intr_disable (void)
 void
 intr_enable (void)
 {
-	PFI	junk;
+	funcptr_t	junk;
 
 	if (--intr_sp < 0)
 	    cl_error (E_IERR, "interrupt save stack underflow");
@@ -768,7 +768,7 @@ intr_enable (void)
 void
 intr_reset (void)
 {
-	PFI	junk;
+	funcptr_t	junk;
 
 	c_xwhen (X_INT, onint, &junk);
 	intr_sp = 0;

--- a/pkg/ecl/main.c
+++ b/pkg/ecl/main.c
@@ -49,7 +49,6 @@
 #define	BKG_QUANTUM	30	/* period(sec) bkgjob checkup		*/
 #define	MAX_INTERRUPTS	5	/* max interrupts of a task		*/
 #define	LEN_INTRSTK	10	/* max nesting of saved interrupts	*/
-typedef	int (*PFI)();
 
 extern	int yydebug;		/* print each parser state if set	*/
 extern	FILE *yyin;		/* where parser reads from		*/

--- a/pkg/ecl/prcache.c
+++ b/pkg/ecl/prcache.c
@@ -617,7 +617,7 @@ pr_checkup (void)
 void
 onipc (
     int *vex,			/* virtual exception code	*/
-    PFI *next_handler		/* next handler to be called	*/
+    funcptr_t *next_handler	/* next handler to be called	*/
 )
 {
 	register struct	process *pr;

--- a/pkg/ecl/prcache.c
+++ b/pkg/ecl/prcache.c
@@ -64,8 +64,6 @@
 extern	int	cldebug;
 extern	int	cltrace;
 
-typedef	XINT (*PFI)();
-
 struct process {
 	int	pr_pid;			/* process id of subprocess	*/
 	long	pr_time;		/* time when process executed	*/

--- a/sys/libc/cxwhen.c
+++ b/sys/libc/cxwhen.c
@@ -7,7 +7,6 @@
 #define	import_libc
 #include <iraf.h>
 
-
 /* CXWHEN -- Post an exception handler.  The exception handler procedure
 ** is called when an exception occurs, unless the exception has been
 ** disabled.  If a user exception handler has not been posted and an
@@ -41,8 +40,6 @@
 */
 
 #define	SZ_ERRMSG	64
-typedef	int (*PFI)();		/* pointer to function returning int	*/
-
 
 /* C_XWHEN -- Post an exception handler for an exception, or disable the
 ** exception (not all exceptions can be disabled).
@@ -50,8 +47,8 @@ typedef	int (*PFI)();		/* pointer to function returning int	*/
 void
 c_xwhen (
   int	exception,		/* code for virtual exception		*/
-  PFI	new_handler,		/* new exception handler		*/
-  PFI	*old_handler		/* old exception handler (output)	*/
+  funcptr_t	new_handler,	/* new exception handler		*/
+  funcptr_t	*old_handler	/* old exception handler (output)	*/
 )
 {
 	XINT	excode = exception;
@@ -59,5 +56,5 @@ c_xwhen (
 	XINT	epa_old_handler;
 
 	XWHEN (&excode, &epa_new_handler, &epa_old_handler);
-	*old_handler = (PFI)epa_old_handler;
+	*old_handler = (funcptr_t)epa_old_handler;
 }

--- a/sys/libc/libc_proto.h
+++ b/sys/libc/libc_proto.h
@@ -217,7 +217,7 @@ extern void c_xonerr(int errcode);
 /* cxttysize.c */
 extern void c_xttysize(int *ncols, int *nlines);
 /* cxwhen.c
-extern void c_xwhen(int exception, PFI new_handler, PFI *old_handler);
+extern void c_xwhen(int exception, funcptr_t new_handler, funcptr_t *old_handler);
  */
 /* eprintf.c */
 extern void u_eprintf(char *format, ...);

--- a/unix/boot/bootlib/osproto.h
+++ b/unix/boot/bootlib/osproto.h
@@ -113,7 +113,7 @@ extern int zgtenv_(short *envvar, short *outstr, int *maxch, int *status);
 extern int zgtime_(int *clock_time, int *cpu_time);
 extern int zgtpid_(int *pid);
 extern int zintpr_(int *pid, int *exception, int *status);
-extern int zlocpr_(PFI proc, int *o_epa);
+extern int zlocpr_(funcptr_t proc, int *o_epa);
 extern int zlocva_(short *variable, int *location);
 extern int zmaloc_(int *buf, int *nbytes, int *status);
 extern int zmfree_(int *buf, int *status);

--- a/unix/hlib/libc/kernel.h
+++ b/unix/hlib/libc/kernel.h
@@ -84,9 +84,7 @@ extern	struct fiodes zfd[];		/* array of descriptors		*/
 #define	LEN_SETREDRAW	6		/* nchars in setredraw string	*/
 #define SETREDRAW	"\033=rDw"	/* set/enable screenredraw code	*/
 
-typedef	void  (*PFV)();
-typedef	int   (*PFI)();
-
+typedef	int   (*PFI)(void);
 
 extern	char *irafpath(char *fname);
 

--- a/unix/hlib/libc/kernel.h
+++ b/unix/hlib/libc/kernel.h
@@ -84,8 +84,6 @@ extern	struct fiodes zfd[];		/* array of descriptors		*/
 #define	LEN_SETREDRAW	6		/* nchars in setredraw string	*/
 #define SETREDRAW	"\033=rDw"	/* set/enable screenredraw code	*/
 
-typedef	int   (*PFI)(void);
-
 extern	char *irafpath(char *fname);
 
 #define	D_kernel

--- a/unix/hlib/libc/kproto.h
+++ b/unix/hlib/libc/kproto.h
@@ -9,8 +9,6 @@
 #include "iraf/knames.h"
 #endif
 
-typedef	int   (*PFI)(void);
-
 /* zalloc.c */
 int ZDVALL (PKCHAR *aliases, XINT *allflg, XINT *status);
 int ZDVOWN (PKCHAR *device, PKCHAR *owner, XINT *maxch, XINT *status);
@@ -142,7 +140,7 @@ int ZGTPID (XINT *pid);
 /* zintpr.c */
 int ZINTPR (XINT *pid, XINT *exception, XINT *status);
 /* zlocpr.c */
-int ZLOCPR (PFI	proc, XINT *o_epa);
+int ZLOCPR (funcptr_t proc, XINT *o_epa);
 /* zlocva.c */
 int ZLOCVA (XCHAR *variable, XINT *location);
 /* zmaloc.c */

--- a/unix/hlib/libc/kproto.h
+++ b/unix/hlib/libc/kproto.h
@@ -9,7 +9,7 @@
 #include "iraf/knames.h"
 #endif
 
-typedef	int   (*PFI)();
+typedef	int   (*PFI)(void);
 
 /* zalloc.c */
 int ZDVALL (PKCHAR *aliases, XINT *allflg, XINT *status);

--- a/unix/hlib/libc/libc.h
+++ b/unix/hlib/libc/libc.h
@@ -318,7 +318,7 @@ extern void	spf_close (XINT fd);
 /*  The following have conflicts because of the order in which the
 **  include files are done in iraf.h.  Commented out for now.
 extern int	c_finfo (char *fname, struct _finfo *fi);
-extern void	c_xwhen (int exception, PFI new_handler, PFI *old_handler);
+extern void	c_xwhen (int exception, funcptr_t new_handler, funcptr_t *old_handler);
 */
 
 #endif

--- a/unix/hlib/libc/spp.h
+++ b/unix/hlib/libc/spp.h
@@ -101,6 +101,9 @@
 #define	XDOUBLE		double
 #define XCOMPLEX	struct cplx
 
+typedef	void (*funcptr_t)(void);
+
+
 struct cplx {
 	float	r;
 	float	i;

--- a/unix/os/zcall.c
+++ b/unix/os/zcall.c
@@ -21,73 +21,85 @@
 
 int ZCALL0 (XINT *proc)
 {
-	return (*(PFI)(*proc))();
+	return (*(int(*)(void))proc) ();
 }
 
 int ZCALL1 (XINT *proc, void *arg1)
 {
-	return (*(PFI)(*proc)) (arg1);
+	return ((int(*)(void *))*proc)
+	  (arg1);
 }
 
 
 int ZCALL2 (XINT *proc, void *arg1, void *arg2)
 {
-	return (*(PFI)(*proc)) (arg1, arg2);
+	return ((int(*)(void *, void *))*proc)
+	  (arg1, arg2);
 }
 
 
 int ZCALL3 (XINT *proc, void *arg1, void *arg2, void *arg3)
 {
-	return (*(PFI)(*proc)) (arg1, arg2, arg3);
+	return ((int(*)(void *, void *, void *))*proc)
+	  (arg1, arg2, arg3);
 }
 
 
 int ZCALL4 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4)
 {
-	return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4);
+	return ((int(*)(void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4);
 }
 
 
-int ZCALL5 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4, 
+int ZCALL5 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
 	     void *arg5)
 {
-	return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4, arg5);
+	return ((int(*)(void *, void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5);
 }
 
 
 int ZCALL6 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
-	     void *arg5, void *arg6)
+	    void *arg5, void *arg6)
 {
-	return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4, arg5, arg6);
+	return ((int(*)(void *, void *, void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6);
 }
 
 
-int ZCALL7 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4, 
+int ZCALL7 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
 	     void *arg5, void *arg6, void *arg7)
 {
-	return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+	return ((int(*)(void *, void *, void *, void *,
+			void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 }
 
 
 int ZCALL8 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
 	     void *arg5, void *arg6, void *arg7, void *arg8)
 {
-	return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+	return ((int(*)(void *, void *, void *, void *,
+			void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 }
 
 
 int ZCALL9 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
 	     void *arg5, void *arg6, void *arg7, void *arg8, void *arg9)
 {
-	return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4, arg5, arg6, arg7, 
-				arg8, arg9);
+	return ((int(*)(void *, void *, void *, void *, void *,
+			void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
 }
 
 
 int ZCALLA (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
-	     void *arg5, void *arg6, void *arg7, void *arg8, void *arg9, 
+	     void *arg5, void *arg6, void *arg7, void *arg8, void *arg9,
 	     void *arg10)
 {
-	return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4, arg5, arg6, arg7, 
-				arg8, arg9, arg10);
+	return ((int(*)(void *, void *, void *, void *, void *,
+			void *, void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
 }

--- a/unix/os/zfunc.c
+++ b/unix/os/zfunc.c
@@ -19,64 +19,76 @@
 
 XINT ZFUNC0 (XINT *proc)
 {
-    return (*(PFI)(*proc))();
+	return ((XINT(*)(void))*proc) ();
 }
 XINT ZFUNC1 (XINT *proc, void *arg1)
 {
-    return (*(PFI)(*proc)) (arg1);
+	return ((XINT(*)(void *))*proc)
+	  (arg1);
 }
 
 XINT ZFUNC2 (XINT *proc, void *arg1, void *arg2)
 {
-    return (*(PFI)(*proc)) (arg1, arg2);
+	return ((XINT(*)(void *, void *))*proc)
+	  (arg1, arg2);
 }
 
 XINT ZFUNC3 (XINT *proc, void *arg1, void *arg2, void *arg3)
 {
-    return (*(PFI)(*proc)) (arg1, arg2, arg3);
+	return ((XINT(*)(void *, void *, void *))*proc)
+	  (arg1, arg2, arg3);
 }
 
 XINT ZFUNC4 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4)
 {
-    return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4);
+	return ((XINT(*)(void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4);
 }
 
-XINT ZFUNC5 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4, 
-	      void *arg5)
+XINT ZFUNC5 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
+	     void *arg5)
 {
-    return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4, arg5);
+	return ((XINT(*)(void *, void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5);
 }
 
-XINT ZFUNC6 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4, 
-	      void *arg5, void *arg6)
+XINT ZFUNC6 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
+	     void *arg5, void *arg6)
 {
-    return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4, arg5, arg6);
+	return ((XINT(*)(void *, void *, void *,
+			 void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6);
 }
 
-XINT ZFUNC7 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4, 
-	      void *arg5, void *arg6, void *arg7)
+XINT ZFUNC7 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
+	     void *arg5, void *arg6, void *arg7)
 {
-    return (*(PFI)(*proc)) (arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+	return ((XINT(*)(void *, void *, void *, void *,
+			 void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 }
 
-XINT ZFUNC8 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4, 
-	      void *arg5, void *arg6, void *arg7, void *arg8)
+XINT ZFUNC8 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
+	     void *arg5, void *arg6, void *arg7, void *arg8)
 {
-    return (*(PFI)(*proc))(arg1, arg2, arg3, arg4, arg5, arg6, arg7, 
-	arg8);
+	return ((XINT(*)(void *, void *, void *, void *,
+			 void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 }
 
-XINT ZFUNC9 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4, 
-	      void *arg5, void *arg6, void *arg7, void *arg8, void *arg9)
+XINT ZFUNC9 (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
+	     void *arg5, void *arg6, void *arg7, void *arg8, void *arg9)
 {
-    return (*(PFI)(*proc))(arg1, arg2, arg3, arg4, arg5, arg6, arg7, 
-	arg8, arg9);
+	return ((XINT(*)(void *, void *, void *, void *, void *,
+			 void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
 }
 
-XINT ZFUNCA (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4, 
-	      void *arg5, void *arg6, void *arg7, void *arg8, void *arg9, 
-	      void *arg10)
+XINT ZFUNCA (XINT *proc, void *arg1, void *arg2, void *arg3, void *arg4,
+	     void *arg5, void *arg6, void *arg7, void *arg8, void *arg9,
+	     void *arg10)
 {
-    return (*(PFI)(*proc))(arg1, arg2, arg3, arg4, arg5, arg6, arg7, 
-	arg8, arg9, arg10);
+	return ((XINT(*)(void *, void *, void *, void *, void *,
+			 void *, void *, void *, void *, void *))*proc)
+	  (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
 }

--- a/unix/os/zlocpr.c
+++ b/unix/os/zlocpr.c
@@ -15,7 +15,7 @@
  */
 int
 ZLOCPR (
-  PFI	proc,			/* procedure for which we desire address */
+  funcptr_t	proc,		/* procedure for which we desire address */
   XINT	*o_epa			/* entry point address */
 )
 {

--- a/unix/os/zmain.c
+++ b/unix/os/zmain.c
@@ -89,7 +89,7 @@ main (int argc, char *argv[])
 
         /* Default if no arguments (same as -h, or host process). */
 	prtype = PR_HOST;
-	ZLOCPR ((PFI)ZGETTY, &driver);
+	ZLOCPR ((funcptr_t)ZGETTY, &driver);
 	devtype = TEXT_FILE;
 
 	if (arg < argc) {
@@ -118,7 +118,7 @@ main (int argc, char *argv[])
 
 ipc_:
 		prtype = PR_CONNECTED;
-		ZLOCPR ((PFI)ZARDPR, &driver);
+		ZLOCPR ((funcptr_t)ZARDPR, &driver);
 		devtype = BINARY_FILE;
 
 	    } else if (strcmp (argv[arg], "-d") == 0) {
@@ -138,7 +138,7 @@ ipc_:
 		setpgid (0, jobcode);
 		freopen ("/dev/null", "r", stdin);
 		prtype = PR_DETACHED;
-		ZLOCPR ((PFI)ZGETTX, &driver);
+		ZLOCPR ((funcptr_t)ZGETTX, &driver);
 		devtype = TEXT_FILE;
 
 		/* Copy the bkgfile to PKCHAR buffer to avoid the possibility

--- a/unix/os/zmain.c
+++ b/unix/os/zmain.c
@@ -89,7 +89,7 @@ main (int argc, char *argv[])
 
         /* Default if no arguments (same as -h, or host process). */
 	prtype = PR_HOST;
-	ZLOCPR (ZGETTY, &driver);
+	ZLOCPR ((PFI)ZGETTY, &driver);
 	devtype = TEXT_FILE;
 
 	if (arg < argc) {
@@ -118,7 +118,7 @@ main (int argc, char *argv[])
 
 ipc_:
 		prtype = PR_CONNECTED;
-		ZLOCPR (ZARDPR, &driver);
+		ZLOCPR ((PFI)ZARDPR, &driver);
 		devtype = BINARY_FILE;
 
 	    } else if (strcmp (argv[arg], "-d") == 0) {
@@ -138,7 +138,7 @@ ipc_:
 		setpgid (0, jobcode);
 		freopen ("/dev/null", "r", stdin);
 		prtype = PR_DETACHED;
-		ZLOCPR (ZGETTX, &driver);
+		ZLOCPR ((PFI)ZGETTX, &driver);
 		devtype = TEXT_FILE;
 
 		/* Copy the bkgfile to PKCHAR buffer to avoid the possibility


### PR DESCRIPTION
Having a generic function pointer is the only real use here; so we also rename it.
If the function is going to be used, it is always converted to the required function type.