### PR TITLE
Ensure NULL is a pointer in SPP

### DIFF
--- a/pkg/cl/builtin.c
+++ b/pkg/cl/builtin.c
@@ -348,11 +348,11 @@ clflprcache (void)
 	    if ((o.o_type & OT_BASIC) == OT_STRING) {
 		ltp = ltasksrch ("", o.o_val.v_s);
 		if (ltp->lt_flags & (LT_SCRIPT|LT_BUILTIN|LT_FOREIGN|LT_PSET))
-		    pid = NULL;
+		    pid = 0;
 		else
 		    pid = pr_pnametopid (findexe(ltp->lt_pkp,
 			ltp->lt_u.ltu_pname));
-		if (pid == NULL) {
+		if (pid == 0) {
 		    eprintf ("Warning: task `%s' not in cache\n", o.o_val.v_s);
 		    continue;
 		}

--- a/pkg/cl/param.c
+++ b/pkg/cl/param.c
@@ -762,7 +762,7 @@ defpar (char *param_spec)
 	breakout (sbuf, &pkname, &ltname, &pname, &junk);
 
 	switch ((XINT) lookup_param (pkname, ltname, pname)) {
-	case NULL:
+	case 0:
 	case ERR:
 	    return (NO);
 	default:

--- a/pkg/cl/prcache.c
+++ b/pkg/cl/prcache.c
@@ -240,7 +240,7 @@ pr_pconnect (
 	    intr_disable();
 	    if ((pr->pr_pid = c_propen (process, &fd_in, &fd_out)) == NULL) {
 		intr_enable();
-		return (NULL);
+		return (0);
 	    }
 	    intr_enable();
 
@@ -273,7 +273,7 @@ pr_pdisconnect (struct process *pr)
 	/* Ignore attempts to dump active processes.  This might happen
 	 * when an active process executes a command which calls dumpcache.
 	 */
-	if (pr == NULL || pr->pr_pid == NULL || pr_busy(pr))
+	if (pr == NULL || pr->pr_pid == 0 || pr_busy(pr))
 	    return;
 
 	if (cltrace)
@@ -311,7 +311,7 @@ pr_setcache (int new_szprcache)
 	     * then dump the cache.
 	     */
 	    for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn)
-		if (pr->pr_pid != NULL && (pr->pr_flags & P_LOCKED))
+		if (pr->pr_pid != 0 && (pr->pr_flags & P_LOCKED))
 		    strcpy (pname[nprocs++], pr->pr_name);
 	    pr_dumpcache (0, 1);
 	}
@@ -350,7 +350,7 @@ pr_findproc (char *process)
 	struct	process *pr;
 
 	for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn) {
-	    if (pr->pr_pid != NULL && pr_idle(pr))
+	    if (pr->pr_pid != 0 && pr_idle(pr))
 		if (strcmp (process, pr->pr_name) == 0)
 		    return (pr);
 	}
@@ -375,7 +375,7 @@ pr_cachetask (
 	ltp = ltasksrch ("", ltname);
 	if (ltp->lt_flags & (LT_SCRIPT|LT_BUILTIN))
 	    return (ERR);
-	if ((pid = pr_pnametopid(findexe(ltp->lt_pkp,ltp->lt_pname))) == NULL) {
+	if ((pid = pr_pnametopid(findexe(ltp->lt_pkp,ltp->lt_pname))) == 0) {
 	    pid = pr_connect (findexe(ltp->lt_pkp,ltp->lt_pname), "\n", &fdummy,
 		&fdummy, stdin, stdout, stderr, 0,0,0, 0);
 	    pr_disconnect (pid);
@@ -396,7 +396,7 @@ pr_lock (
 {
 	struct process *pr;
 
-	if (pid != NULL) {
+	if (pid != 0) {
 	    for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn)
 		if (pr->pr_pid == pid) {
 		    pr->pr_flags |= P_LOCKED;
@@ -418,7 +418,7 @@ pr_unlock (
 {
 	struct process *pr;
 
-	if (pid != NULL)
+	if (pid != 0)
 	    for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn)
 		if (pr->pr_pid == pid)
 		    return (pr->pr_flags &= ~P_LOCKED);
@@ -532,7 +532,7 @@ pr_getpno (void)
 
 
 /* PR_PNAMETOPID -- Lookup the named process in the cache and return the pid
- * if found, NULL otherwise.
+ * if found, 0 otherwise.
  */
 int
 pr_pnametopid (char *pname)
@@ -558,9 +558,9 @@ pr_chdir (register int pid, char *newdir)
 
 	pr_checkup();
 	for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn) {
-	    if (pr->pr_pid == NULL || !pr_idle(pr))
+	    if (pr->pr_pid == 0 || !pr_idle(pr))
 		continue;
-	    else if (pid == NULL || pr->pr_pid == pid)
+	    else if (pid == 0 || pr->pr_pid == pid)
 		c_prchdir (pr->pr_pid, newdir);
 	}
 }
@@ -576,9 +576,9 @@ pr_envset (register int pid, char *envvar, char *valuestr)
 
 	pr_checkup();
 	for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn) {
-	    if (pr->pr_pid == NULL || !pr_idle(pr))
+	    if (pr->pr_pid == 0 || !pr_idle(pr))
 		continue;
-	    else if (pid == NULL || pr->pr_pid == pid)
+	    else if (pid == 0 || pr->pr_pid == pid)
 		c_prenvset (pr->pr_pid, envvar, valuestr);
 	}
 }
@@ -599,7 +599,7 @@ pr_checkup (void)
 	 * causing premature termination.
 	 */
 	for (pr=pr_cache, n=sz_prcache;  --n >= 0;  pr++) {
-	    if (pr->pr_pid != NULL) {
+	    if (pr->pr_pid != 0) {
 		if (c_prstati (pr->pr_pid, PR_STATUS) == P_DEAD) {
 		    pr->pr_flags = 0;
 		    pr_pdisconnect (pr);
@@ -624,7 +624,7 @@ onipc (
 	register struct	process *pr;
 
 	for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn) {
-	    if (pr->pr_pid != NULL) {
+	    if (pr->pr_pid != 0) {
 		if (c_prstati (pr->pr_pid, PR_STATUS) == P_DEAD)
 		    break;
 	    }

--- a/pkg/cl/task.c
+++ b/pkg/cl/task.c
@@ -263,7 +263,7 @@ int
 defpac (char *pkname)
 {
 	switch ((XINT) pacfind (pkname)) {
-	case NULL:
+	case 0:
 	    return (NO);
 	case ERR:
 	    cl_error (E_UERR, e_pckambig, pkname);
@@ -334,18 +334,18 @@ deftask (char *task_spec)
 	if (pkname[0] != '\0') {	/* explicit package named	*/
 	    if ((pkp = pacfind (pkname)) == NULL)
 		cl_error (E_UERR, e_pcknonexist, pkname);
-	    if ((stat = (XINT) ltaskfind (pkp, ltname, 1)) == NULL)
+	    if ((stat = (XINT) ltaskfind (pkp, ltname, 1)) == 0)
 		return (NO);
 
 	} else {			/* search all packages		*/
 	    pkp = reference (package, pachead);
-	    stat = NULL;
+	    stat = 0;
 
 	    while (pkp != NULL) {
 		stat = (XINT) ltaskfind (pkp, ltname, 1);
 		if (stat == ERR)
 		    break;
-		else if (stat != NULL)
+		else if (stat != 0)
 		    return (YES);
 		pkp = pkp->pk_npk;
 	    }
@@ -353,7 +353,7 @@ deftask (char *task_spec)
 
 	if (stat == ERR)
 	    cl_error (E_UERR, e_tambig, ltname);
-	if (stat != NULL)
+	if (stat != 0)
 	    return (YES);
 	return (NO);
 }

--- a/pkg/ecl/builtin.c
+++ b/pkg/ecl/builtin.c
@@ -352,11 +352,11 @@ clflprcache (void)
 	    if ((o.o_type & OT_BASIC) == OT_STRING) {
 		ltp = ltasksrch ("", o.o_val.v_s);
 		if (ltp->lt_flags & (LT_SCRIPT|LT_BUILTIN|LT_FOREIGN|LT_PSET))
-		    pid = NULL;
+		    pid = 0;
 		else
 		    pid = pr_pnametopid (findexe(ltp->lt_pkp,
 			ltp->lt_u.ltu_pname));
-		if (pid == NULL) {
+		if (pid == 0) {
 		    eprintf ("Warning: task `%s' not in cache\n", o.o_val.v_s);
 		    continue;
 		}
@@ -385,7 +385,7 @@ flpr_task (char *task)
 
 	ltp = ltasksrch ("", task);
 	if (ltp->lt_flags & (LT_SCRIPT|LT_BUILTIN|LT_FOREIGN|LT_PSET))
-	    pid = NULL;
+	    pid = 0;
 	else
 	    pid = pr_pnametopid (findexe(ltp->lt_pkp, ltp->lt_u.ltu_pname));
 
@@ -2246,7 +2246,7 @@ clonerror (void)
 	extern  char *onerr_handler;
 
 
-	handler[0] = NULL;
+	handler[0] = '\0';
 	pushbparams (pfp->pf_pp);
 	if (nargs(pfp) > 0) {
 	    popop();			/* discard the $n name		*/

--- a/pkg/ecl/param.c
+++ b/pkg/ecl/param.c
@@ -773,7 +773,7 @@ defpar (char *param_spec)
 	breakout (sbuf, &pkname, &ltname, &pname, &junk);
 
 	switch ((XINT) lookup_param (pkname, ltname, pname)) {
-	case NULL:
+	case 0:
 	case ERR:
 	    return (NO);
 	default:

--- a/pkg/ecl/prcache.c
+++ b/pkg/ecl/prcache.c
@@ -240,7 +240,7 @@ pr_pconnect (
 	    intr_disable();
 	    if ((pr->pr_pid = c_propen (process, &fd_in, &fd_out)) == NULL) {
 		intr_enable();
-		return (NULL);
+		return (0);
 	    }
 	    intr_enable();
 
@@ -273,7 +273,7 @@ pr_pdisconnect (struct process *pr)
 	/* Ignore attempts to dump active processes.  This might happen
 	 * when an active process executes a command which calls dumpcache.
 	 */
-	if (pr == NULL || pr->pr_pid == NULL || pr_busy(pr))
+	if (pr == NULL || pr->pr_pid == 0 || pr_busy(pr))
 	    return;
 
 	if (cltrace)
@@ -311,7 +311,7 @@ pr_setcache (int new_szprcache)
 	     * then dump the cache.
 	     */
 	    for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn)
-		if (pr->pr_pid != NULL && (pr->pr_flags & P_LOCKED))
+		if (pr->pr_pid != 0 && (pr->pr_flags & P_LOCKED))
 		    strcpy (pname[nprocs++], pr->pr_name);
 	    pr_dumpcache (0, 1);
 	}
@@ -350,7 +350,7 @@ pr_findproc (char *process)
 	struct	process *pr;
 
 	for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn) {
-	    if (pr->pr_pid != NULL && pr_idle(pr))
+	    if (pr->pr_pid != 0 && pr_idle(pr))
 		if (strcmp (process, pr->pr_name) == 0)
 		    return (pr);
 	}
@@ -375,7 +375,7 @@ pr_cachetask (
 	ltp = ltasksrch ("", ltname);
 	if (ltp->lt_flags & (LT_SCRIPT|LT_BUILTIN))
 	    return (ERR);
-	if ((pid = pr_pnametopid(findexe(ltp->lt_pkp,ltp->lt_pname))) == NULL) {
+	if ((pid = pr_pnametopid(findexe(ltp->lt_pkp,ltp->lt_pname))) == 0) {
 	    pid = pr_connect (findexe(ltp->lt_pkp,ltp->lt_pname), "\n", &fdummy,
 		&fdummy, stdin, stdout, stderr, 0,0,0, 0);
 	    pr_disconnect (pid);
@@ -396,7 +396,7 @@ pr_lock (
 {
 	struct process *pr;
 
-	if (pid != NULL) {
+	if (pid != 0) {
 	    for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn)
 		if (pr->pr_pid == pid) {
 		    pr->pr_flags |= P_LOCKED;
@@ -418,7 +418,7 @@ pr_unlock (
 {
 	struct process *pr;
 
-	if (pid != NULL)
+	if (pid != 0)
 	    for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn)
 		if (pr->pr_pid == pid)
 		    return (pr->pr_flags &= ~P_LOCKED);
@@ -532,7 +532,7 @@ pr_getpno (void)
 
 
 /* PR_PNAMETOPID -- Lookup the named process in the cache and return the pid
- * if found, NULL otherwise.
+ * if found, 0 otherwise.
  */
 int
 pr_pnametopid (char *pname)
@@ -558,9 +558,9 @@ pr_chdir (register int pid, char *newdir)
 
 	pr_checkup();
 	for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn) {
-	    if (pr->pr_pid == NULL || !pr_idle(pr))
+	    if (pr->pr_pid == 0 || !pr_idle(pr))
 		continue;
-	    else if (pid == NULL || pr->pr_pid == pid)
+	    else if (pid == 0 || pr->pr_pid == pid)
 		c_prchdir (pr->pr_pid, newdir);
 	}
 }
@@ -576,9 +576,9 @@ pr_envset (register int pid, char *envvar, char *valuestr)
 
 	pr_checkup();
 	for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn) {
-	    if (pr->pr_pid == NULL || !pr_idle(pr))
+	    if (pr->pr_pid == 0 || !pr_idle(pr))
 		continue;
-	    else if (pid == NULL || pr->pr_pid == pid)
+	    else if (pid == 0 || pr->pr_pid == pid)
 		c_prenvset (pr->pr_pid, envvar, valuestr);
 	}
 }
@@ -599,7 +599,7 @@ pr_checkup (void)
 	 * causing premature termination.
 	 */
 	for (pr=pr_cache, n=sz_prcache;  --n >= 0;  pr++) {
-	    if (pr->pr_pid != NULL) {
+	    if (pr->pr_pid != 0) {
 		if (c_prstati (pr->pr_pid, PR_STATUS) == P_DEAD) {
 		    pr->pr_flags = 0;
 		    pr_pdisconnect (pr);
@@ -624,7 +624,7 @@ onipc (
 	register struct	process *pr;
 
 	for (pr=pr_head;  pr != NULL;  pr=pr->pr_dn) {
-	    if (pr->pr_pid != NULL) {
+	    if (pr->pr_pid != 0) {
 		if (c_prstati (pr->pr_pid, PR_STATUS) == P_DEAD)
 		    break;
 	    }

--- a/pkg/ecl/task.c
+++ b/pkg/ecl/task.c
@@ -266,7 +266,7 @@ int
 defpac (char *pkname)
 {
 	switch ((XINT) pacfind (pkname)) {
-	case NULL:
+	case 0:
 	    return (NO);
 	case ERR:
 	    cl_error (E_UERR, e_pckambig, pkname);
@@ -337,18 +337,18 @@ deftask (char *task_spec)
 	if (pkname[0] != '\0') {	/* explicit package named	*/
 	    if ((pkp = pacfind (pkname)) == NULL)
 		cl_error (E_UERR, e_pcknonexist, pkname);
-	    if ((stat = (XINT) ltaskfind (pkp, ltname, 1)) == NULL)
+	    if ((stat = (XINT) ltaskfind (pkp, ltname, 1)) == 0)
 		return (NO);
 
 	} else {			/* search all packages		*/
 	    pkp = reference (package, pachead);
-	    stat = NULL;
+	    stat = 0;
 
 	    while (pkp != NULL) {
 		stat = (XINT) ltaskfind (pkp, ltname, 1);
 		if (stat == ERR)
 		    break;
-		else if (stat != NULL)
+		else if (stat != 0)
 		    return (YES);
 		pkp = pkp->pk_npk;
 	    }
@@ -356,7 +356,7 @@ deftask (char *task_spec)
 
 	if (stat == ERR)
 	    cl_error (E_UERR, e_tambig, ltname);
-	if (stat != NULL)
+	if (stat != 0)
 	    return (YES);
 	return (NO);
 }

--- a/sys/libc/cpoll.c
+++ b/sys/libc/cpoll.c
@@ -31,7 +31,7 @@ c_poll_open ( void )
 	XINT	fds;
 
 	iferr ((fds = (XINT) POLL_OPEN ()))
-	    return (NULL);
+	    return (0);
 	else 
 	    return (fds);
 }

--- a/sys/libc/cprcon.c
+++ b/sys/libc/cprcon.c
@@ -64,7 +64,7 @@ c_propen (
 	XINT  x_in = *in, x_out = *out;
 
 	iferr (pid = (unsigned int) PROPEN (c_sppstr(process), &x_in, &x_out))
-	    return (NULL);
+	    return (0);
 	else {
 	    *in = (int) x_in;
 	    *out = (int) x_out;

--- a/sys/libc/cprdet.c
+++ b/sys/libc/cprdet.c
@@ -51,7 +51,7 @@ c_propdpr (
 	c_strupk (bkgfile, spp_bkgfile, SZ_PATHNAME);
 	c_strupk (bkgmsg,  spp_bkgmsg,  SZ_LINE);
 	iferr (job = PROPDPR (c_sppstr(process), spp_bkgfile, spp_bkgmsg))
-	    return (NULL);
+	    return (0);
 	else
 	    return (job);
 }

--- a/sys/libc/realloc.c
+++ b/sys/libc/realloc.c
@@ -20,7 +20,7 @@ realloc (
 	XINT	x_nchars = (newsize + sizeof(XCHAR)-1) / sizeof(XCHAR);
 	XINT	x_ptr, x_dtype = TY_CHAR;
 
-	x_ptr = buf ? Memcptr(buf) : NULL;
+	x_ptr = buf ? Memcptr(buf) : 0;
 	iferr (REALLOC (&x_ptr, &x_nchars, &x_dtype))
 	    return (NULL);
 	else

--- a/unix/hlib/libc/iraf_spp.h
+++ b/unix/hlib/libc/iraf_spp.h
@@ -50,7 +50,7 @@
 #endif
 
 #ifndef NULL
-#define	NULL		0
+#define	NULL		((void*)0)
 #endif
 
 #ifndef EOF

--- a/unix/hlib/libc/iraf_stdio.h
+++ b/unix/hlib/libc/iraf_stdio.h
@@ -13,7 +13,7 @@
 typedef	struct _iobuf	FILE;
 
 # ifndef NULL
-#define	NULL		0
+#define	NULL		((void*)0)
 # endif
 # ifndef EOF
 #define	EOF		(-1)


### PR DESCRIPTION
The macro **NULL** [must either be an integer 0, or a 0, casted to `void*`](http://port70.net/~nsz/c/c99/n1256.html#6.3.2.3):

> #### 6.3.2.3 Pointers
> [...]
> 3 An integer constant expression with the value 0, or such an expression cast to type void *, is called a null pointer constant. If a null pointer constant is converted to a pointer type, the resulting pointer, called a null pointer, is guaranteed to compare unequal to a pointer to any object or function.

While IRAF locally defines the first (if not already defined), common usage (in gcc and clang) is to have it a pointer. This is unreliable, since if it was defined before, the system definition is kept.

This PR uses the common definition (as a pointer) and then fixes the places where **NULL** was abused as a verbose 0.