### PR TITLE
Prepare new version 2.17.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ license-url: "https://github.com/iraf-community/iraf/blob/main/COPYRIGHT"
 
 # Version information
 version: "2.17"
-date-released: "2022-01-04"
+date-released: 2022-01-04
 identifiers:
   - type: doi
     description: DOI for version 2.17
@@ -37,8 +37,8 @@ preferred-citation:
     name: Instrumentation in astronomy
     city: Tucson, AZ
     country: US
-    date-start: "1986-03-04"
-    date-end: "1986-03-08"
+    date-start: 1986-03-04
+    date-end: 1986-03-08
   collection-title: "Proc. SPIE Instrumentation in Astronomy VI"
   collection-type: proceedings
   year: 1986
@@ -68,8 +68,8 @@ references:
       name: "Astronomical Data Analysis Software and Systems II"
       city: Boston, MA
       country: US
-      date-start: "1992-11-02"
-      date-end: "1992-11-04"
+      date-start: 1992-11-02
+      date-end: 1992-11-04
     volume: 52
     collection-title: "A.S.P. Conference Series"
     collection-type: proceedings

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 ## Distribution Files
 
-IRAF v2.17 is available from github at
+IRAF v2.17.1 is available from github at
 
 https://github.com/iraf-community/iraf/releases/latest/
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IRAF Release 2.17
+# IRAF Release 2.17.1
 
 [![IRAF CI test](https://github.com/iraf-community/iraf/workflows/IRAF%20CI%20test/badge.svg)](https://github.com/olebole/iraf/actions?query=workflow%3A%22IRAF+CI+test%22)
 [![GitHub release](https://img.shields.io/github/release/iraf-community/iraf.svg)](https://github.com/iraf-community/iraf/releases/latest)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,18 +1,42 @@
-# IRAF 2.17
+# IRAF 2.17.1
 
 The latest NOAO IRAF release is 2.16.1 from October 2013. Intermediate
 releases were snapshots based on that latest available source code. These
 snapshots were tagged with their release date in the version number.
 Changes to the 2.16.1 sources include:
 
+* __Community maintainance__
+
+   IRAF is no longer maintained by NOAO, but by the community of
+   volunteers. Contributions of bug fixes, documentation or improvements
+   are welcome.
+
 * __All known non-free code removed__
 
-    Although IRAF 2.16.1 was claimed to be "free software", it contained
-    source code that is not freely distributable; namely code copied from the
-    book ["Numerical Recipes in Fortran"](http://numerical.recipes/). This
-    code is replaced with free equivalents. The IRAF community edition is
-    [Open Source](https://opensource.org/docs/osd), and as such included in
-    Debian.
+   Although IRAF 2.16.1 was claimed to be "free software", it contained
+   source code that is not freely distributable; namely code copied from the
+   book ["Numerical Recipes in Fortran"](http://numerical.recipes/). This
+   code is replaced with free equivalents. The IRAF community edition is
+   [Open Source](https://opensource.org/docs/osd), and as such included in
+   Debian.
+
+* __Installation procedure reworked__
+
+   The installation scripts are replaced with makefiles, and the build
+   and installation procedures now use the standard targets, standard
+   paths, and customization environment variables. The standard
+   installation place is `/usr/local/lib/iraf`. On a build error the
+   build now stops now immediately, making it easier to find the
+   cause.
+   
+* __IRAF ported to other architectures__
+
+   IRAF is now ported to a number of little endian architectures (ARM,
+   PowerPC, MIPS, x32, RISC-V64) and operating systems (GNU Hurd and
+   FreeBSD). Specifically, the Mac M1 processor is supported now.
+
+   The code was adjusted to be compliant with newer (C99) C standards,
+   and to be compileable with actual compilers.
 
 * __Major bug fixes__
 
@@ -35,12 +59,15 @@ Changes to the 2.16.1 sources include:
    - On modern systems, background execution did not work
      ([iraf.net](https://iraf.net/forum/viewtopic.php?showtopic=1467431))
 
-* __Fixes to build and run IRAF on non-historic platforms__
+   -  The original code produced errornous executables when build on
+      Linux versions later than 2012. It also did not build from
+      scratch, but required an already compiled IRAF version.
 
-  The original code produced errornous executables when build on Linux
-  versions later than 2012, due to some funny hacks in the IRAF
-  code. It also did not build from scratch, but required an already
-  compiled IRAF version.
+* __Simple CI test framework added__
+
+    The tests are defined and documented in
+    [MarkDown](https://github.com/iraf-community/iraf/blob/main/test/README.md)
+    files. Tests are run using Github Actions on Linux and MacOS X platforms.
 
 * __VO package and vocl removed__
 
@@ -53,15 +80,3 @@ Changes to the 2.16.1 sources include:
     Therefore, no attempt was put into getting these problems fixed,
     and the VO stuff was cut out.  The VOTable functionality, however,
     remains available
-
-* __IRAF ported to other architectures__
-
-    IRAF is now ported to a number of little endian architectures
-    (ARM, PowerPC, MIPS, x32, RISC-V64) and operating systems (GNU Hurd and
-    FreeBSD).
-
-* __Simple CI test framework added__
-
-    The tests are defined and documented in
-    [MarkDown](https://github.com/iraf-community/iraf/blob/main/test/README.md)
-    files. Tests are run using Github Actions on Linux and MacOS X platforms.

--- a/doc/releases/v217revs.rst
+++ b/doc/releases/v217revs.rst
@@ -1,10 +1,10 @@
-IRAF 2.17 Release notes
-=======================
+IRAF 2.17.1 Release notes
+=========================
 
 :Authors: IRAF Community
-:Date: January 07, 2022
+:Date: June 01, 2022
 
-The current IRAF version 2.17 is available from github at
+The current IRAF version 2.17.1 is available from github at
 
 https://github.com/iraf-community/iraf/releases/latest/
 
@@ -27,11 +27,23 @@ Changes to the NOAO 2.16.1 sources include:
    Source <https://opensource.org/docs/osd>`__, and as such included in
    Debian.
 
+-  **Installation procedure reworked**
+
+   The installation scripts are replaced with makefiles, and the build
+   and installation procedures now use the standard targets, standard
+   paths, and customization environment variables. The standard
+   installation place is ``/usr/local/lib/iraf``. On a build error the
+   build now stops now immediately, making it easier to find the
+   cause.
+   
 -  **IRAF ported to other architectures**
 
    IRAF is now ported to a number of little endian architectures (ARM,
    PowerPC, MIPS, x32, RISC-V64) and operating systems (GNU Hurd and
    FreeBSD). Specifically, the Mac M1 processor is supported now.
+
+   The code was adjusted to be compliant with newer (C99) C standards,
+   and to be compileable with actual compilers.
 
 -  **Major bug fixes**
 
@@ -74,6 +86,76 @@ Detailed list of changes
 ------------------------
 
 This list shows all pull requests that were merged since 2.16.1.
+
+Since 2.17
+~~~~~~~~~~
+
+- Update f2c to latest version and document local changes
+  (`#295 <https://github.com/iraf-community/iraf/pull/295>`__)
+- Ensure NULL is a pointer in SPP
+  (`#292 <https://github.com/iraf-community/iraf/pull/292>`__)
+- Replace vosproto.h with prototypes from xnames.h
+  (`#284 <https://github.com/iraf-community/iraf/pull/284>`__)
+- Use typedef instead of #define where applicable
+  (`#283 <https://github.com/iraf-community/iraf/pull/283>`__)
+- Protoize the remaining C code
+  (`#282 <https://github.com/iraf-community/iraf/pull/282>`__)
+- Restructure PFI to be used as "generic" function pointer
+  (`#281 <https://github.com/iraf-community/iraf/pull/281>`__)
+- Fix a few small bugs in sys$
+  (`#280 <https://github.com/iraf-community/iraf/pull/280>`__)
+- Change a few appearances of PKCHAR
+  (`#279 <https://github.com/iraf-community/iraf/pull/279>`__)
+- Replace SIGFUNC by sighandler_t
+  (`#278 <https://github.com/iraf-community/iraf/pull/278>`__)
+- Create useful prototypes for kernel functions (host$os)
+  (`#277 <https://github.com/iraf-community/iraf/pull/277>`__)
+- Fix several errors that appear when compiled with -std=c99
+  (`#276 <https://github.com/iraf-community/iraf/pull/276>`__)
+- Rename iraf subincludes
+  (`#275 <https://github.com/iraf-community/iraf/pull/275>`__)
+- Don't add empty arguments to xc argument lists
+  (`#271 <https://github.com/iraf-community/iraf/pull/271>`__)
+- Fix keyword search in envinit
+  (`#270 <https://github.com/iraf-community/iraf/pull/270>`__)
+- Re-work installation process
+  (`#268 <https://github.com/iraf-community/iraf/pull/268>`__,
+  `#300 <https://github.com/iraf-community/iraf/pull/300>`__)
+- Stop mkpkg execution if an error was discovered
+  (`#267 <https://github.com/iraf-community/iraf/pull/267>`__,
+  `#287 <https://github.com/iraf-community/iraf/pull/287>`__)
+- Convert make scripts (mkpkg.sh) into Makefiles
+  (`#266 <https://github.com/iraf-community/iraf/pull/266>`__,
+  `#293 <https://github.com/iraf-community/iraf/pull/293>`__,
+  `#301 <https://github.com/iraf-community/iraf/pull/301>`__)
+- Update documentation for host commands (xc, mkpkg etc.)
+  (`#265 <https://github.com/iraf-community/iraf/pull/265>`__)
+- Add old release notes as ReStructuredText
+  (`#263 <https://github.com/iraf-community/iraf/pull/263>`__,
+  `#264 <https://github.com/iraf-community/iraf/pull/264>`__)
+- Directly use xc.e, xyacc.e etc. from mkpkg and CL
+  (`#262 <https://github.com/iraf-community/iraf/pull/262>`__)
+- Update cfitsio to version 4.2.0
+  (`#249 <https://github.com/iraf-community/iraf/pull/249>`__)
+- Fix processing onf INDEF in the "generic" preprocessor
+  (`#238 <https://github.com/iraf-community/iraf/pull/238>`__)
+- Ensure the use of the extended image opening code
+  (`#236 <https://github.com/iraf-community/iraf/pull/236>`__)
+- Fix a bug in the parsing of directory arguments of mkfloat
+  (`#231 <https://github.com/iraf-community/iraf/pull/231>`__)
+- Fix off-by-one allocation error in sgi2uhplj.c
+  (`#207 <https://github.com/iraf-community/iraf/pull/207>`__)
+- Update to new C environment
+  (`#225 <https://github.com/iraf-community/iraf/pull/225>`__,
+  `#226 <https://github.com/iraf-community/iraf/pull/226>`__,
+  `#302 <https://github.com/iraf-community/iraf/pull/302>`__)
+- Code cleanup
+  (`#223 <https://github.com/iraf-community/iraf/pull/223>`__,
+  `#274 <https://github.com/iraf-community/iraf/pull/274>`__,
+  `#290 <https://github.com/iraf-community/iraf/pull/290>`__,
+  `#291 <https://github.com/iraf-community/iraf/pull/291>`__,
+  `#294 <https://github.com/iraf-community/iraf/pull/294>`__)
+
 
 Since 2.16.1+2021.06.14
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/releases/v217revs.rst
+++ b/doc/releases/v217revs.rst
@@ -74,13 +74,15 @@ Changes to the NOAO 2.16.1 sources include:
 
 -  **VO package and vocl removed**
 
-   The VO package, and the vocl shell heavily depend on a number of Java
-   jars, where the creation from sources is undocumented. The package
-   also uses outdated VO standards. A discussion with Mike Fitzpatrick
-   resulted in his plan to `move the VO functionality into an external
-   package <https://iraf-community.github.io/iraf-v216/issues/90>`__. Therefore, no attempt was put into
-   getting these problems fixed, and the VO stuff was cut out. The
-   VOTable functionality, however, remains available
+   The VO package, and the vocl shell heavily depend on a number of
+   Java jars, where the creation from sources is undocumented. The
+   package also uses outdated VO standards. A discussion with Mike
+   Fitzpatrick resulted in his plan to `move the VO functionality into
+   an external package
+   <https://iraf-community.github.io/iraf-v216/issues/90>`__. Therefore,
+   no attempt was put into getting these problems fixed, and the VO
+   stuff was cut out. The VOTable functionality, however, remains
+   available
 
 Detailed list of changes
 ------------------------
@@ -90,41 +92,45 @@ This list shows all pull requests that were merged since 2.16.1.
 Since 2.17
 ~~~~~~~~~~
 
+- Add a machine readable citation file
+  (`#306 <https://github.com/iraf-community/iraf/pull/306>`__)
 - Update f2c to latest version and document local changes
   (`#295 <https://github.com/iraf-community/iraf/pull/295>`__)
-- Ensure NULL is a pointer in SPP
+- Ensure ``NULL`` is a pointer in SPP
   (`#292 <https://github.com/iraf-community/iraf/pull/292>`__)
-- Replace vosproto.h with prototypes from xnames.h
+- Replace ``vosproto.h`` with prototypes from ``xnames.h``
   (`#284 <https://github.com/iraf-community/iraf/pull/284>`__)
-- Use typedef instead of #define where applicable
+- Use ``typedef`` instead of ``#define`` where applicable
   (`#283 <https://github.com/iraf-community/iraf/pull/283>`__)
 - Protoize the remaining C code
   (`#282 <https://github.com/iraf-community/iraf/pull/282>`__)
-- Restructure PFI to be used as "generic" function pointer
+- Restructure ``PFI`` to be used as "generic" function pointer
   (`#281 <https://github.com/iraf-community/iraf/pull/281>`__)
-- Fix a few small bugs in sys$
+- Fix a few small bugs in ``sys$``
   (`#280 <https://github.com/iraf-community/iraf/pull/280>`__)
-- Change a few appearances of PKCHAR
+- Change a few appearances of ``PKCHAR``
   (`#279 <https://github.com/iraf-community/iraf/pull/279>`__)
-- Replace SIGFUNC by sighandler_t
+- Replace ``SIGFUNC`` by ``sighandler_t``
   (`#278 <https://github.com/iraf-community/iraf/pull/278>`__)
-- Create useful prototypes for kernel functions (host$os)
+- Create useful prototypes for kernel functions (``host$os``)
   (`#277 <https://github.com/iraf-community/iraf/pull/277>`__)
-- Fix several errors that appear when compiled with -std=c99
+- Fix several errors that appear when compiled with ``-std=c99``
   (`#276 <https://github.com/iraf-community/iraf/pull/276>`__)
 - Rename iraf subincludes
   (`#275 <https://github.com/iraf-community/iraf/pull/275>`__)
 - Don't add empty arguments to xc argument lists
   (`#271 <https://github.com/iraf-community/iraf/pull/271>`__)
-- Fix keyword search in envinit
+- Fix keyword search in ``envinit``
   (`#270 <https://github.com/iraf-community/iraf/pull/270>`__)
-- Re-work installation process
+- Re-work installation process, improve user scripts (cl, mkiraf)
   (`#268 <https://github.com/iraf-community/iraf/pull/268>`__,
-  `#300 <https://github.com/iraf-community/iraf/pull/300>`__)
+  `#300 <https://github.com/iraf-community/iraf/pull/300>`__,
+  `#312 <https://github.com/iraf-community/iraf/pull/312>`__,
+  `#314 <https://github.com/iraf-community/iraf/pull/314>`__)
 - Stop mkpkg execution if an error was discovered
   (`#267 <https://github.com/iraf-community/iraf/pull/267>`__,
   `#287 <https://github.com/iraf-community/iraf/pull/287>`__)
-- Convert make scripts (mkpkg.sh) into Makefiles
+- Convert make scripts (``mkpkg.sh``) to Makefiles
   (`#266 <https://github.com/iraf-community/iraf/pull/266>`__,
   `#293 <https://github.com/iraf-community/iraf/pull/293>`__,
   `#301 <https://github.com/iraf-community/iraf/pull/301>`__)
@@ -133,23 +139,23 @@ Since 2.17
 - Add old release notes as ReStructuredText
   (`#263 <https://github.com/iraf-community/iraf/pull/263>`__,
   `#264 <https://github.com/iraf-community/iraf/pull/264>`__)
-- Directly use xc.e, xyacc.e etc. from mkpkg and CL
+- Directly use ``xc.e``, ``xyacc.e`` etc. from mkpkg and CL
   (`#262 <https://github.com/iraf-community/iraf/pull/262>`__)
 - Update cfitsio to version 4.2.0
   (`#249 <https://github.com/iraf-community/iraf/pull/249>`__)
-- Fix processing onf INDEF in the "generic" preprocessor
+- Fix processing onf ``INDEF`` in the "generic" preprocessor
   (`#238 <https://github.com/iraf-community/iraf/pull/238>`__)
 - Ensure the use of the extended image opening code
   (`#236 <https://github.com/iraf-community/iraf/pull/236>`__)
 - Fix a bug in the parsing of directory arguments of mkfloat
   (`#231 <https://github.com/iraf-community/iraf/pull/231>`__)
-- Fix off-by-one allocation error in sgi2uhplj.c
+- Fix off-by-one allocation error in ``sgi2uhplj.c``
   (`#207 <https://github.com/iraf-community/iraf/pull/207>`__)
 - Update to new C environment
   (`#225 <https://github.com/iraf-community/iraf/pull/225>`__,
   `#226 <https://github.com/iraf-community/iraf/pull/226>`__,
   `#302 <https://github.com/iraf-community/iraf/pull/302>`__)
-- Code cleanup
+- Code cleanup in ``host$`` and ``sys$``
   (`#223 <https://github.com/iraf-community/iraf/pull/223>`__,
   `#274 <https://github.com/iraf-community/iraf/pull/274>`__,
   `#290 <https://github.com/iraf-community/iraf/pull/290>`__,
@@ -184,17 +190,17 @@ Since 2.16.1+2018.11.01
    (`#166 <https://github.com/iraf-community/iraf/pull/166>`__)
 -  fix slalib bug in sla_EQEQX
    (`#160 <https://github.com/iraf-community/iraf/pull/160>`__)
--  Ignore existing iraf env var in ./install
+-  Ignore existing iraf env var in ``./install``
    (`#157 <https://github.com/iraf-community/iraf/pull/157>`__)
 -  Cleanup ecl and cl
    (`#156 <https://github.com/iraf-community/iraf/pull/156>`__)
 -  Add macOS arm64 support
    (`#131 <https://github.com/iraf-community/iraf/pull/131>`__)
--  Replace hard-coded host$bin paths by IRAFPATH
+-  Replace hard-coded ``host$bin`` paths by ``IRAFPATH``
    (`#128 <https://github.com/iraf-community/iraf/pull/128>`__)
--  Remove include/drvrsmem.h
+-  Remove ``include/drvrsmem.h``
    (`#126 <https://github.com/iraf-community/iraf/pull/126>`__)
--  Fix cpu_time calculation in unix/os/zgtime.c
+-  Fix cpu_time calculation in ``unix/os/zgtime.c``
    (`#118 <https://github.com/iraf-community/iraf/pull/118>`__,
    `#136 <https://github.com/iraf-community/iraf/pull/136>`__,
    `#173 <https://github.com/iraf-community/iraf/pull/173>`__)
@@ -343,7 +349,7 @@ Since 2.16.1
    (`#100 <https://iraf-community.github.io/iraf-v216/issues/100>`__)
 -  Fix statement order in ``vfn_expand_ldir``
    (`#99 <https://iraf-community.github.io/iraf-v216/issues/99>`__)
--  Fix linenumber generation with ``xpp -x`` (rpp and spp))
+-  Fix linenumber generation with ``xpp -x`` (rpp and spp)
    (`#98 <https://iraf-community.github.io/iraf-v216/issues/98>`__)
 -  Fix template expansion in ``generic.c``
    (`#94 <https://iraf-community.github.io/iraf-v216/issues/94>`__)
@@ -370,7 +376,7 @@ Since 2.16.1
    (`#78 <https://iraf-community.github.io/iraf-v216/issues/78>`__)
 -  Avoid identical src/target in ``strcpy()`` when creating library
    names in xc (`#77 <https://iraf-community.github.io/iraf-v216/issues/77>`__)
--  *[linux]* Consequently add ``-m32`` flags if compiling for linux(32))
+-  *[linux]* Consequently add ``-m32`` flags if compiling for linux(32)
    (`#76 <https://iraf-community.github.io/iraf-v216/issues/76>`__)
 -  Convert to ANSI C to fix return types of functions in ``memlog.c``
    (`#75 <https://iraf-community.github.io/iraf-v216/issues/75>`__)
@@ -378,7 +384,7 @@ Since 2.16.1
 -  Accept zero date in archives (`#71 <https://iraf-community.github.io/iraf-v216/issues/71>`__)
 -  Fix computation of offset in memory allocation at 32 bit
    (`#67 <https://iraf-community.github.io/iraf-v216/issues/67>`__)
--  Fix ``ADDR_TO_LOC`` for i386 (32 bit))
+-  Fix ``ADDR_TO_LOC`` for i386 (32 bit)
    (`#62 <https://iraf-community.github.io/iraf-v216/issues/62>`__)
 -  Fix declaration of ``cdsmem`` in rpp (`#60 <https://iraf-community.github.io/iraf-v216/issues/60>`__)
 -  Force iraf to align on 128-bit boundaries
@@ -394,7 +400,7 @@ Since 2.16.1
 -  Fixed recursive error in definition of ``LFLAGS``
    (`#39 <https://iraf-community.github.io/iraf-v216/issues/39>`__)
 -  Convert ``mklibs`` to ``/bin/sh`` (`#38 <https://iraf-community.github.io/iraf-v216/issues/38>`__)
--  Replace or remove non-free code (Numerical Recipes etc.))
+-  Replace or remove non-free code (Numerical Recipes etc.)
    (`#37 <https://iraf-community.github.io/iraf-v216/issues/37>`__)
 -  Add continious integration testing with travis-CI
    (`#36 <https://iraf-community.github.io/iraf-v216/issues/36>`__)

--- a/doc/releases/v217revs.rst
+++ b/doc/releases/v217revs.rst
@@ -2,7 +2,7 @@ IRAF 2.17.1 Release notes
 =========================
 
 :Authors: IRAF Community
-:Date: June 01, 2022
+:Date: July 15, 2023
 
 The current IRAF version 2.17.1 is available from github at
 

--- a/pkg/cl/cl.par
+++ b/pkg/cl/cl.par
@@ -20,10 +20,10 @@ menus,b,h,yes,,,Display menu when changing packages?
 showtype,b,h,no,,,Add task-type suffix in menus?
 notify,b,h,yes,,,Send done message when bkgrnd task finishes?
 szprcache,i,h,4,1,10,Size of the process cache
-version,s,h,"IRAF V2.17 2022",,,IRAF version
+version,s,h,"IRAF V2.17.1 2023",,,IRAF version
 logver,s,h,"",,,login.cl version
 logregen,b,h,no,,,Updating of login.cl to current version is advised
-release,s,h,"2.17",,,IRAF release
+release,s,h,"2.17.1",,,IRAF release
 mode,s,h,ql,,,CL mode of execution (query or query+learn)
 
 auto,s,h,a,,,The next 4 params are read-only.

--- a/pkg/ecl/cl.par
+++ b/pkg/ecl/cl.par
@@ -20,10 +20,10 @@ menus,b,h,yes,,,Display menu when changing packages?
 showtype,b,h,no,,,Add task-type suffix in menus?
 notify,b,h,yes,,,Send done message when bkgrnd task finishes?
 szprcache,i,h,4,1,10,Size of the process cache
-version,s,h,"IRAF V2.17 2022",,,IRAF version
+version,s,h,"IRAF V2.17.1 2023",,,IRAF version
 logver,s,h,"",,,login.cl version
 logregen,b,h,no,,,Updating of login.cl to current version is advised
-release,s,h,"2.17",,,IRAF release
+release,s,h,"2.17.1",,,IRAF release
 mode,s,h,ql,,,CL mode of execution (query or query+learn)
 
 auto,s,h,a,,,The next 4 params are read-only.

--- a/unix/hlib/login.cl
+++ b/unix/hlib/login.cl
@@ -2,7 +2,7 @@
 
 # Identify login.cl version (checked in images.cl).
 if (defpar ("logver"))
-    logver = "IRAF V2.17 2021"
+    logver = "IRAF V2.17.1 2023"
 
 set	home		= (envget("HOME") // "/.iraf/")
 set	imdir		= "home$imdir/"

--- a/unix/hlib/mkiraf.sh
+++ b/unix/hlib/mkiraf.sh
@@ -121,9 +121,8 @@ if [ "$copy" ]; then
 	mv -f login.cl login.cl.OLD
     fi
     cp -f "${iraf}unix/hlib/login.cl" login.cl
-fi
-
-if [ ! "$def" ]; then
-    echo 'A new LOGIN.CL file has been created in the current directory.'
-    echo 'You may wish to review and edit this file to change the defaults.'
+    if [ ! "$def" ]; then
+	echo 'A new LOGIN.CL file has been created in the current directory.'
+	echo 'You may wish to review and edit this file to change the defaults.'
+    fi
 fi

--- a/unix/hlib/zzsetenv.def
+++ b/unix/hlib/zzsetenv.def
@@ -42,7 +42,7 @@ set	terminal	= xgterm
 set	ttybaud		= 9600
 set	ttyncols	= 80
 set	ttynlines	= 40
-set	version		= "Community IRAF V2.17"
+set	version		= "Community IRAF V2.17.1"
 
 # System directories.
 


### PR DESCRIPTION
Because version 2.17 does not compile anymore on new XCode (macOS), it is useful to soon release a new version.
This PR creates release notes and updates the version number accordingly.