### PR TITLE
Remove `CARCH` environment variable

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -8,8 +8,8 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env:
-      CARCH: ${{ matrix.carch }}
       CFLAGS: ${{ matrix.cflags }}
+      LDFLAGS: ${{ matrix.ldflags }}
 
     strategy:
       matrix:
@@ -21,8 +21,8 @@ jobs:
           - name: Ubuntu 20.04 Focal i386
             os: ubuntu-20.04
             irafarch: linux
-            carch: '-m32'
-            cflags: -O2 -g -Wall -Wno-stringop-truncation -Wno-unused-result -Wno-format-overflow -Wno-parentheses
+            ldflags: -m32
+            cflags: -m32 -O2 -g -Wall -Wno-stringop-truncation -Wno-unused-result -Wno-format-overflow -Wno-parentheses
 
           - name: macOS x86_64
             os: macos-latest
@@ -35,7 +35,7 @@ jobs:
       - name: Setup dependencies on Ubuntu
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          if [ ${CARCH} == '-m32' ] ; then
+          if [ ${LDFLAGS} == '-m32' ] ; then
             sudo dpkg --add-architecture i386
             sudo apt-get update -y
             sudo apt-get install -y gcc-multilib libcurl4-openssl-dev:i386 libexpat1-dev:i386 libreadline-dev:i386 zlib1g-dev:i386

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,6 @@ export RANLIB = ranlib
 # General compiler flags. Compiler flags specific to the build of the
 # host tools and software are in unix/Makefile.
 export CFLAGS ?= -g -O2
-CFLAGS += $(CARCH)
-export LDFLAGS += $(CARCH)
 export XC_CFLAGS = $(CPPFLAGS) $(CFLAGS)
 
 .PHONY: all sysgen clean test arch noao host novos core vendor bindirs bin_links config inplace starttime


### PR DESCRIPTION
The `-m32` flag can be better (and more flexibly) added to `CFLAGS` and `LDFLAGS`.