### PR TITLE
Unconditionally remove <stdlib.h> include in (e)cl ytab.c

### DIFF
--- a/pkg/cl/mkpkg
+++ b/pkg/cl/mkpkg
@@ -23,14 +23,9 @@ relink:
 	    $endif
 	    $ifolder (ytab.c,  grammar.y)
 		$echo "rebuilding ytab.c"
-		$ifeq (MACH, linux)
-		    !yacc -vd grammar.y; 
-		    !egrep -v "\<stdlib.h\>" y.tab.c > ytab.c; 
-		    !egrep -v "\<stdio.h\>" ytab.c > ntab.c; mv ntab.c ytab.c
-		    !mv y.tab.h ytab.h
-		$else
-		    !yacc -vd grammar.y; mv y.tab.c ytab.c; mv y.tab.h ytab.h
-		$endif
+		!yacc -vd grammar.y;
+		!grep -v "\<stdlib.h\>" y.tab.c > ytab.c;
+		!mv y.tab.h ytab.h
 	    $endif
 	$endif
 

--- a/pkg/ecl/mkpkg
+++ b/pkg/ecl/mkpkg
@@ -23,14 +23,9 @@ relink:
 	    $endif
 	    $ifolder (ytab.c,  grammar.y)
 		$echo "rebuilding ytab.c"
-		$ifeq (MACH, linux)
-		    !yacc -vd grammar.y; 
-		    !egrep -v "\<stdlib.h\>" y.tab.c > ytab.c; 
-		    !egrep -v "\<stdio.h\>" ytab.c > ntab.c; mv ntab.c ytab.c
-		    !mv y.tab.h ytab.h
-		$else
-		    !yacc -vd grammar.y; mv y.tab.c ytab.c; mv y.tab.h ytab.h
-		$endif
+		!yacc -vd grammar.y;
+		!grep -v "\<stdlib.h\>" y.tab.c > ytab.c;
+		!mv y.tab.h ytab.h
 	    $endif
 	$endif
 


### PR DESCRIPTION
The definitions here contradict with the local definitions in IRAF's libc.  For example, **atof()** is `double atof(const char*)` in **stdio.h**, but `double atof(char *)` in **iraf_libc.h**.

In any case we should make sure that we use the correct declarations. That was already set for 32-bit Linux, but it is useful for all platforms.