### PR TITLE
Force numeric user/group ids in irafarch.sh symlink retrieval

### DIFF
--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -53,7 +53,7 @@ if [ $# -gt 0 ]; then
         unset IRAFARCH
 	shift
     elif [ "$1" = "-current" ]; then
-        export IRAFARCH=$(ls -lad "${iraf}bin" 2> /dev/null | \
+        export IRAFARCH=$(ls -lnd "${iraf}bin" 2> /dev/null | \
 			awk '{ printf ("%s\n", $11) }' | \
 			sed -e 's/bin.//g')
 	shift


### PR DESCRIPTION
Problem taken from [#312](https://github.com/orgs/iraf-community/discussions/312#discussioncomment-6419325):

User or group names may contain a space which confuses the awk script. We replace them by numbers so that it will work independently of the names.

While this is not perfect, it may work for another 20 years.

