### PR TITLE
Fix detection of IRAF root on locally installed systems

### DIFF
--- a/unix/hlib/mkiraf.sh
+++ b/unix/hlib/mkiraf.sh
@@ -30,7 +30,7 @@ cachedir="${HOME}/.iraf/cache/"
 d_iraf="/iraf/iraf/"
 if [ -z "$iraf" ]; then
     if [ -r ${HOME}/.iraf/irafroot ] ; then
-	export iraf=$(cat /etc/iraf/irafroot)
+	export iraf=$(cat ${HOME}/.iraf/irafroot)
     elif [ -r /etc/iraf/irafroot ] ; then
 	export iraf=$(cat /etc/iraf/irafroot)
     else


### PR DESCRIPTION
This is a fix of the **mkiraf** script from #268 to correctly set the `iraf` environment variable from `~/.iraf/irafroot` in a local installation. 
Problem was observed in [#312](https://github.com/orgs/iraf-community/discussions/312#discussioncomment-6420664).