### PR TITLE
Makefile install fixes found when creating the Debian package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,12 +14,12 @@ and zlib libraries to be installed.
 
 On Debian and its derivatives (Ubuntu, Mint, Devuan, Raspbian etc.):
 
-	$ sudo apt install gcc make flex zlib1g-dev
+	$ sudo apt install gcc make bison flex zlib1g-dev
 	$ sudo apt install libcurl4-openssl-dev libexpat-dev libreadline-dev
 
 On Fedora and its derivatives (Redhat, Scientific Linux etc.)
 
-	$ sudo dnf install gcc make perl flex zlib-devel
+	$ sudo dnf install gcc make perl flex bison zlib-devel
 	$ sudo dnf install libcurl-devel expat-devel readline-devel
 
 On MacOS X, you need to have the XCode tools installed. If you

--- a/Makefile
+++ b/Makefile
@@ -189,4 +189,5 @@ install: noao/bin/x_quad.e
 	cp -f $(host)boot/spp/xc.man $(DESTDIR)$(prefix)/share/man/man1/xc.1
 	cp -f $(host)boot/xyacc/xyacc.man $(DESTDIR)$(prefix)/share/man/man1/xyacc.1
 	cp -f $(host)boot/generic/generic.man $(DESTDIR)$(prefix)/share/man/man1/generic.1
+	cp -f $(host)gdev/sgidev/sgidispatch.man $(DESTDIR)$(prefix)/share/man/man1/sgidispatch.1
 	echo $(prefix)/lib/iraf/ > $(DESTDIR)/etc/iraf/irafroot

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ prefix ?= /usr/local
 install: noao/bin/x_quad.e
 	mkdir -p $(DESTDIR)$(prefix)/lib/iraf $(DESTDIR)$(prefix)/bin $(DESTDIR)$(prefix)/share/man/man1 $(DESTDIR)/etc/iraf
 	cp -a -f bin* dev extern include lib local math mkpkg noao pkg sys test unix \
-	         $(prefix)/lib/iraf
+	         $(DESTDIR)$(prefix)/lib/iraf
 	$(MAKE) config binary_links strip iraf=$(prefix)/lib/iraf/ bindir=$(prefix)/bin
 	cp -f $(hlib)mkiraf.man $(DESTDIR)$(prefix)/share/man/man1/mkiraf.1
 	cp -f $(hlib)ecl.man $(DESTDIR)$(prefix)/share/man/man1/ecl.1

--- a/unix/boot/spp/rpp/Makefile
+++ b/unix/boot/spp/rpp/Makefile
@@ -27,13 +27,13 @@ clean:
 
 rppfor:
 	if [ "$(RATFOR)" ] ; then \
-	  rm -f rppfor/*.f rppfor/fort ; \
+	  rm -f rppfor/*.f rpprat/fort ; \
 	  $(MAKE) -C rpprat RATFOR=${RATFOR} ; \
 	fi
 
 ratlibf:
 	if [ "$(RATFOR)" ] ; then \
-	  rm -f ratlibf/*.f ratlibf/fort ; \
+	  rm -f ratlibf/*.f ratlibr/fort ; \
 	  $(MAKE) -C ratlibr RATFOR=${RATFOR} ; \
 	fi
 

--- a/vendor/libvotable/Makefile
+++ b/vendor/libvotable/Makefile
@@ -12,6 +12,7 @@ libVOTable.a: $(OBJS)
 	ar r $@ $?
 
 install: libVOTable.a
+	mkdir -p $(bindir) $(includedir)
 	cp libVOTable.a $(bindir)
 	cp $(INCS) $(includedir)
 


### PR DESCRIPTION
These are a number of small fixes for 2.17.1, found by creating the Debian package:

* typos in rpp/Makefile
* bindir/includedir creation in libvotabe install when they were not created before by cfitsio install
* a missing `DESTDIR` in "make install"
* a missing installation of the sgidispatch manpage

Also, **bison** is required to build IRAF; this should be mentioned in the installation docs.