### PR TITLE
Fix iraf$ variable for "inplace" (personal) installation

### DIFF
--- a/unix/hlib/setup.sh
+++ b/unix/hlib/setup.sh
@@ -2,7 +2,7 @@
 d_iraf="/iraf/iraf/"
 if [ -z "$iraf" ]; then
     if [ -r ${HOME}/.iraf/irafroot ] ; then
-	export iraf=$(cat /etc/iraf/irafroot)
+	export iraf=$(cat ${HOME}/.iraf/irafroot)
     elif [ -r /etc/iraf/irafroot ] ; then
 	export iraf=$(cat /etc/iraf/irafroot)
     else


### PR DESCRIPTION
This problem was found when using PyRAF with an "inplace" installed IRAF version, as described in https://github.com/iraf-community/pyraf/issues/149. 

Thanks to @monodera for the fix. I kept you as the author of the patch; please let me know if you don't want this.