### PR TITLE
Rename ecl canonical name to irafcl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,10 +134,10 @@ bindirs:
 config:
 	sed -E -i.orig \
 	    s+'^([[:space:]]*d_iraf=).*+\1"$(iraf)"'+ \
-	    $(DESTDIR)$(hlib)ecl.sh \
+	    $(DESTDIR)$(hlib)irafcl.sh \
 	    $(DESTDIR)$(hlib)setup.sh \
             $(DESTDIR)$(hlib)mkiraf.sh
-	grep '"$(iraf)"' $(DESTDIR)$(hlib)ecl.sh
+	grep '"$(iraf)"' $(DESTDIR)$(hlib)irafcl.sh
 	grep '"$(iraf)"' $(DESTDIR)$(hlib)setup.sh
 	grep '"$(iraf)"' $(DESTDIR)$(hlib)mkiraf.sh
 	sed -E -i.orig \
@@ -150,8 +150,9 @@ bindir = $(HOME)/.iraf/bin
 # Create symbolic links for user callable scripts and executables
 binary_links:
 	mkdir -p $(DESTDIR)$(bindir)
-	ln -sf $(hlib)ecl.sh $(DESTDIR)$(bindir)/cl
-	ln -sf $(hlib)ecl.sh $(DESTDIR)$(bindir)/ecl
+	ln -sf $(hlib)irafcl.sh $(DESTDIR)$(bindir)/irafcl
+	ln -sf $(hlib)irafcl.sh $(DESTDIR)$(bindir)/cl
+	ln -sf $(hlib)irafcl.sh $(DESTDIR)$(bindir)/ecl
 	ln -sf $(hlib)mkiraf.sh $(DESTDIR)$(bindir)/mkiraf
 	for hprog in mkpkg rmbin rmfiles rtar sgidispatch wtar xc xyacc ; do \
 	    ln -sf $(hbin)$${hprog}.e $(DESTDIR)$(bindir)/$${hprog} ; \
@@ -184,8 +185,9 @@ install: noao/bin/x_quad.e
 	         $(DESTDIR)$(prefix)/lib/iraf
 	$(MAKE) config binary_links strip iraf=$(prefix)/lib/iraf/ bindir=$(prefix)/bin
 	cp -f $(hlib)mkiraf.man $(DESTDIR)$(prefix)/share/man/man1/mkiraf.1
-	cp -f $(hlib)ecl.man $(DESTDIR)$(prefix)/share/man/man1/ecl.1
-	ln -sf ecl.1 $(DESTDIR)$(prefix)/share/man/man1/cl.1
+	cp -f $(hlib)irafcl.man $(DESTDIR)$(prefix)/share/man/man1/irafcl.1
+	ln -sf irafcl.1 $(DESTDIR)$(prefix)/share/man/man1/ecl.1
+	ln -sf irafcl.1 $(DESTDIR)$(prefix)/share/man/man1/cl.1
 	cp -f $(host)boot/mkpkg/mkpkg.man $(DESTDIR)$(prefix)/share/man/man1/mkpkg.1
 	cp -f $(host)boot/spp/xc.man $(DESTDIR)$(prefix)/share/man/man1/xc.1
 	cp -f $(host)boot/xyacc/xyacc.man $(DESTDIR)$(prefix)/share/man/man1/xyacc.1

--- a/unix/hlib/irafcl.man
+++ b/unix/hlib/irafcl.man
@@ -1,20 +1,26 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
 .TH CL "1" "April 2023" "IRAF 2.17.1" "IRAF commands"
 .SH NAME
-ECL/CL \- IRAF Command Language Interpreter
+IRAFCL \- IRAF Command Language Interpreter
 .SH SYNOPSIS
+irafcl [\fB\,\-V\fR|\fB\-c\fR|\fB\-e\/\fR] [\fB\,-f \fIFILE\/\fR]
+
 ecl [\fB\,\-V\fR|\fB\-c\fR|\fB\-e\/\fR] [\fB\,-f \fIFILE\/\fR]
 
 cl [\fB\,\-V\fR|\fB\-c\fR|\fB\-e\/\fR] [\fB\,-f \fIFILE\/\fR]
 .SH DESCRIPTION
-\fBECL\fR or \fBCL\fR starts up the command language interpreter for
-IRAF, the Image Reduction and Analysis Facility.  It can be fed a
-series of commands that will be executed in sequence.
+\fBirafcl\fR, \fBecl\fR or \fBcl\fR starts up the command language
+interpreter for IRAF, the Image Reduction and Analysis Facility.  It
+can be fed a series of commands that will be executed in sequence.
 
 The ECL (Enhanced CL) has a number of features over CL, including
 better error handling, command line editing, new functions and
 constants. Unless for compatibility reasons, ECL should be used over
 CL.
+
+Because the names \fBecl\fR and \fBcl\fR conflict with other commonly
+used command names for Common Lisp, the canonical name of the
+interpreter is \fBirafcl\fR, which defaults to \fBECL\fR behaviour.
 .TP
 \fB\-V\fR
 Show version of program.

--- a/unix/hlib/irafcl.sh
+++ b/unix/hlib/irafcl.sh
@@ -45,7 +45,7 @@ case "$nm" in
     "cl" | "cl.sh")
         cl_binary="${bin}cl.e"
         ;;
-    "ecl" | "ecl.sh")
+    "ecl" | "ecl.sh" | "irafcl" | "irafcl.sh")
         cl_binary="${bin}ecl.e"
         ;;
     "vocl" | "vocl.sh")


### PR DESCRIPTION
This is the name that is used in Debian and other Linux distributions. Rationale is that the names cl and ecl are conflicting with command names of other tools that may be installed on these systems (Common Lisp interpreters). For compatibility, symbolic links to cl and ecl are still provided.