### PR TITLE
NOIRLAB: several patches for libos.a

### DIFF
--- a/unix/os/alloc.c
+++ b/unix/os/alloc.c
@@ -126,7 +126,7 @@ alloc (
 		    printf ("rw access to %s is denied\n", fp->f_name);
 		return (DV_DEVINUSE);
 	    } else if (ruid && uid_executing(ruid)) {
-		if (ruid != getuid()) {
+		if ((uid_t)ruid != getuid()) {
 		    if (!statonly)
 			printf ("%s already allocated to %s\n",
 			    fp->f_name, (getpwuid(ruid))->pw_name);

--- a/unix/os/getproc.c
+++ b/unix/os/getproc.c
@@ -24,7 +24,7 @@ uid_executing (int uid)
 	    sprintf (fname, "/proc/%s", direntp->d_name);
 	    if (stat (fname, &st))
 		return (0);
-	    else if (st.st_uid == uid)
+	    else if (st.st_uid == (uid_t) uid)
 		return (1);
 	}
 	(void) closedir (dirp);

--- a/unix/os/getproc.c
+++ b/unix/os/getproc.c
@@ -16,7 +16,7 @@ uid_executing (int uid)
 {
 	register struct dirent *direntp;
 	register DIR *dirp;
-	char fname[256];
+	char fname[320];
 	struct stat st;
 
 	dirp = opendir ("/proc");

--- a/unix/os/zawset.c
+++ b/unix/os/zawset.c
@@ -39,7 +39,7 @@ ZAWSET (
   XINT	*max_size 		/* max working set size, bytes		*/
 )
 {
-	int physmem=0, kb_page;
+	unsigned int physmem=0, kb_page;
 	int debug = (getenv(ENV_DEBUG) != NULL);
 	char *s;
 

--- a/unix/os/zawset.c
+++ b/unix/os/zawset.c
@@ -113,7 +113,7 @@ ZAWSET (
 		setrlimit (RLIMIT_RSS, &rlp);
 	    getrlimit (RLIMIT_RSS, &rlp);
 	    *old_size = working_set_size;
-	    *new_size = min(*best_size, min(max_wss,
+	    *new_size = min((rlim_t)*best_size, min(max_wss,
 		rlp.rlim_cur == RLIM_INFINITY ? max_wss : rlp.rlim_cur));
 	}
 	if (debug)

--- a/unix/os/zfinfo.c
+++ b/unix/os/zfinfo.c
@@ -76,7 +76,7 @@ ZFINFO (
 	    static	char owner[SZ_OWNERSTR+1];
 	    struct	passwd *pw;
 
-	    if (osfile.st_uid == uid) {
+	    if (osfile.st_uid == (uid_t) uid) {
 		strncpy ((char *)fs->fi_owner, owner, SZ_OWNERSTR);
                 fs->fi_owner[SZ_OWNERSTR-1] = '\0'; // ensure NULL term
 	    } else {

--- a/unix/os/zfinfo.c
+++ b/unix/os/zfinfo.c
@@ -76,22 +76,25 @@ ZFINFO (
 	    static	char owner[SZ_OWNERSTR+1];
 	    struct	passwd *pw;
 
-	    if (osfile.st_uid == uid)
+	    if (osfile.st_uid == uid) {
 		strncpy ((char *)fs->fi_owner, owner, SZ_OWNERSTR);
-	    else {
+                fs->fi_owner[SZ_OWNERSTR-1] = '\0'; // ensure NULL term
+	    } else {
 		setpwent();
 		pw = getpwuid (osfile.st_uid);
 		endpwent();
 
-		if (pw == NULL)
+		if (pw == NULL) {
 		    sprintf ((char *)fs->fi_owner, "%d", osfile.st_uid);
-		else {
+                    fs->fi_owner[SZ_OWNERSTR-1] = '\0'; // ensure NULL term
+		} else {
 		    strncpy (owner, pw->pw_name, SZ_OWNERSTR);
 		    strncpy ((char *)fs->fi_owner, owner, SZ_OWNERSTR);
+                    fs->fi_owner[SZ_OWNERSTR-1] = '\0'; // ensure NULL term
 		    uid = osfile.st_uid;
 		}
 	    }
-	    ((char *)fs->fi_owner)[SZ_OWNERSTR] = EOS;
+	    ((char *)fs->fi_owner)[SZ_OWNERSTR-1] = EOS;
 	}
 
 	*status = XOK;

--- a/unix/os/zfinfo.c
+++ b/unix/os/zfinfo.c
@@ -94,7 +94,6 @@ ZFINFO (
 		    uid = osfile.st_uid;
 		}
 	    }
-	    ((char *)fs->fi_owner)[SZ_OWNERSTR-1] = EOS;
 	}
 
 	*status = XOK;

--- a/unix/os/zfioks.c
+++ b/unix/os/zfioks.c
@@ -1528,7 +1528,7 @@ query:		if ((namep = ks_getpass (loginname, hostname)))
 
 	    setjmp (jmpbuf);
 	    value = time(NULL);
-	    for (i=0;  i < sizeof(jmpbuf)/sizeof(int);  i++)
+	    for (i=0;  i < (int)(sizeof(jmpbuf)/sizeof(int));  i++)
 		value ^= ((int *)jmpbuf)[i];
 	    value = (value << 13) / 1000 * 1000;
 	    if (value < 0)

--- a/unix/os/zfioks.c
+++ b/unix/os/zfioks.c
@@ -1238,7 +1238,7 @@ ks_puti (int fd, int ival)
 static int
 ks_geti (int fd)
 {
-	register int value = 0;
+	int     value = 0;
 	struct  timeval timeout;
 	int	stat, sig;
 	fd_set  rfd;
@@ -1393,8 +1393,8 @@ ks_getlogin (
   struct ksparam *ks 		/* networking parameters */
 )
 {
-	register struct irafhosts *hp;
 	register int i;
+	struct  irafhosts *hp;
 	char	userfile[SZ_PATHNAME];
 	char	sysfile[SZ_PATHNAME];
 	char	fname[SZ_PATHNAME];

--- a/unix/os/zfioks.c
+++ b/unix/os/zfioks.c
@@ -179,6 +179,9 @@ static int   ks_getword (char **ipp, char *obuf);
 static void  ks_whosts (struct irafhosts *hp, char *filename);
 static char *ks_getpass (char *user, char *host);
 
+static int rcmd_ (char **ahost, int inport, const char *locuser,
+                  const char *remuser, const char *cmd, int *fd2p);
+
 void  pr_mask (char *str);
 
 /* ZOPNKS -- Open a connected subprocess on a remote node.  Parse the "server"
@@ -585,7 +588,7 @@ s_err:		    dbgmsgf ("S:in.irafksd fork complete, status=%d\n",
 	     */
 	    hostp = host;
 	    dbgmsgf ("C:rexec for host=%s, user=%s\n", host, username);
-	    *chan = rcmd (&hostp, ks_rexecport(),
+	    *chan = rcmd_ (&hostp, ks_rexecport(),
 		getlogin(), username, cmd, 0);
 
 	} else if (ks.protocol == C_REXEC_CALLBACK) {
@@ -622,7 +625,7 @@ s_err:		    dbgmsgf ("S:in.irafksd fork complete, status=%d\n",
 	    hostp = host;
 	    dbgmsgf ("rexec for host=%s, user=%s, using client port %d\n",
 		host, username, s_port);
-	    ss = rcmd (&hostp, ks_rexecport(),
+	    ss = rcmd_ (&hostp, ks_rexecport(),
 		getlogin(), username, callback_cmd, 0);
 
 	    /* Wait for the server to call us back. */
@@ -769,7 +772,7 @@ retry:
 			dbgmsgf ("C:rexec %s@%s: %s\n", username, host, command);
 
 			hostp = host;
-			fd = rcmd (&hostp, ks_rexecport(),
+			fd = rcmd_ (&hostp, ks_rexecport(),
 			    getlogin(), username, command, 0);
 
 			if (fd < 0) {
@@ -1957,4 +1960,18 @@ void pr_mask (char *str)
 	    dbgmsg ("sigpending error");
 	if (sigismember (&pending, SIGCHLD))
 	    dbgmsg ("\tpr_mask: SIGCHLD pending\n"); 
+}
+
+
+/* RCMD_ -- Compat routine for deprecated system rcmd().
+ */
+static  int
+rcmd_(char **ahost, int inport, const char *locuser, const char *remuser,
+         const char *cmd, int *fd2p)
+{
+    int res = 0;
+#ifndef __APPLE__
+    res = rcmd (ahost, inport, locuser, remuser, cmd, fd2p);
+#endif
+    return res;
 }

--- a/unix/os/zfiond.c
+++ b/unix/os/zfiond.c
@@ -683,7 +683,7 @@ ZARDND (
 	FD_SET (np->datain, &readfds);
 
 	/* Determine maximum amount of data to be read. */
-	maxread = (np->flags & F_TEXT) ? *maxbytes/sizeof(XCHAR) : *maxbytes;
+	maxread = (np->flags & F_TEXT) ?  (int)(*maxbytes/sizeof(XCHAR)) : (int)*maxbytes;
 
 	/* The following call to select shouldn't be necessary, but it
 	 * appears that, due to the way we open a FIFO with O_NDELAY, read
@@ -806,8 +806,9 @@ nd_onsig (
         /* If we get a SIGPIPE writing to a server the server has probably
          * died.  Make it look like there was an i/o error on the channel.
          */
-        if (sig == SIGPIPE && recursion++ == 0)
+        if (sig == SIGPIPE && recursion++ == 0) {
             ;
+        }
 
         if (jmpset)
             longjmp (jmpbuf, sig);

--- a/unix/os/zmain.c
+++ b/unix/os/zmain.c
@@ -161,7 +161,7 @@ ipc_:
 	 */
 	if (arg < argc) {
 	    for (nchars=0;  arg < argc;  arg++) {
-		while (nchars + strlen(argv[arg]) > len_irafcmd) {
+		while ((int)(nchars + strlen(argv[arg])) > len_irafcmd) {
 		    len_irafcmd += 1024;
 		    irafcmd = (XCHAR *) realloc ((char *)irafcmd,
 			len_irafcmd * sizeof(XCHAR));


### PR DESCRIPTION
There is a number of patches that fix several glitches in `libos.a`:

a6459af81 - increased 'fname' buffer size to avoid overflow
~~48b2f614f - fixed fcancel() macro for OSX~~
997ff1c63 - deprecated use of rcmd() on OSX systems
28a9b9e7c - ensure null termination following strncpy(), gcc 8 -Wstringop-truncation err
1dfb2a7af - ensure null termination following strncpy(), gcc 8 -Wstringop-truncation err
~~ab2ec08d9 - ensure null termination following strncpy(), gcc 8 -Wstringop-truncation err~~
a55a788a0 - fix sign compare
0e72cfc3e - fix clobber warning from linux64
d8226de5e - fix compiler warnings from linux64

The commit ab2ec08d9 looks a bit weird:
```diff
diff --git a/unix/os/zfiond.c b/unix/os/zfiond.c
index 294a6eb2b..33d779b9c 100644
--- a/unix/os/zfiond.c
+++ b/unix/os/zfiond.c
@@ -375,6 +375,11 @@ ZOPNND (
                sockaddr.sun_family = AF_UNIX;
                strncpy (sockaddr.sun_path,
                    np->path1, sizeof(sockaddr.sun_path));
+#ifdef MACOSX
+               sockaddr.sun_path[103] = '\0';  // ensure NULL termination
+#else
+               sockaddr.sun_path[107] = '\0';  // ensure NULL termination
+#endif
 
                /* Connect to server. */
                if (fd >= MAXOFILES || (connect (fd,
[… same change few lines later …]
```
The commit currently in the PR has `MACOSX` replaced with `__APPLE__` (because we consequently use compiler provided flags instead of self-defined if possible). It is however unclear where the magic numbers 103 and 107 come from and why they differ for macOS. I will leave it out yet until we understand it (maybe @mjfitzpatrick may explain).

The other suspicious commit is 48b2f614f, which defines **fcancel()** as [**setvbuf()**](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/setvbuf.3.html) on macOS https://github.com/iraf-community/iraf/blob/3761a03d6bb3d91e5da0a9562e778654f59ab2a3/unix/os/zxwhen.c#L90-L96

First, **setvbuf()** is not macOS specific but part of the standard C library (and therefore also available for Linux). This is changed by the commit in this PR. Then, hard-coding `_IONBF` instead of using the proper include file (`stdio.h`) is bad style, also adjusted here. And finally, **setvbuf()** is not what **fcancel()** is supposed to do, namely to cancel any buffered output. Instead, it just makes the output unbuffered. i.e. when applying this patch, stdout will become unbuffered for the rest of the session. Maybe @mjfitzpatrick can comment on that, otherwise I tend to remove this commit from the PR as well.
Probably the better solution (although non-portable) is to use [**fpurge()**](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fpurge.3.html) on macOS (and BSD variants), and [**__fpurge()**](https://manpages.debian.org/bookworm/manpages-dev/__fpurge.3.en.html) on Linux (and glibc variants, like HURD). This is implemented in #366.

Then there is 997ff1c63, which basically disables network computing capabilities on macOS https://github.com/iraf-community/iraf/blob/997ff1c637266fd0183224ec4ee89b4df351e7b1/unix/os/zfioks.c#L2048-L2057

I am not sure whether network computing capabilities are still needed on Linux; at least standard remove shells (**rsh**) are deprecated everywhere, not just on macOS. If not, we could think about removing the networking layer completely, significantly simplifying the code in `unix/os`. @mjfitzpatrick?