### PR TITLE
NOIRLAB: cosmetic change for the "generic" tool

### DIFF
--- a/unix/boot/generic/generic.c
+++ b/unix/boot/generic/generic.c
@@ -38,7 +38,7 @@ struct _for {
 };
 
 struct	_for forstk[SZ_FORSTK];
-int	forlev;
+int	forlev = 0;
 char	*type_string;
 char	xtype_string[SZ_FNAME+1];
 char	type_char;


### PR DESCRIPTION
This PR collects the fixes from NOIRLAB IRAF for the **generic** tool. For reference, these were the original commits:

521776cf8 - initialize forlevel _not really needed (global C variables are always zeroed), but "explicit is better than implicit"_
~~c2275a714 - added test file~~ *not applied; the test file is just a copy of `sys/vops/aabs.gx`.*
~~8e7e31867 - bug fixes and cleanup~~ *not applied; already fixed in a different way (removing `chario.c`)*
~~3adbf0a52 - fixed unused arg~~ *not applied; this is a no-op*

