### PR TITLE
NOIRLAB: Potential xc/xpp string overflow fixes

### DIFF
--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -135,7 +135,7 @@ char	f2cpath[SZ_FNAME] 	= "/usr/bin/f2c";
 char	g77path[SZ_FNAME] 	= "/usr/bin/g77";
 
 char	outfile[SZ_FNAME] = "";
-char	tempfile[SZ_FNAME] = "";
+char	tempfile[SZ_PATHNAME] = "";
 char	*lflags[MAXFLAG+1];
 char	*lfiles[MAXFILE+1];			/* all files		*/
 char	*hlibs[MAXFILE+1];			/* host libraries	*/

--- a/unix/boot/spp/xpp/decl.c
+++ b/unix/boot/spp/xpp/decl.c
@@ -117,7 +117,7 @@ d_newproc (
 		/* Enter argument name into the symbol table.
 		 */
 		if (d_lookup (tokstr) != NULL) {
-		    char lbuf[200];
+		    char lbuf[512];
 		    sprintf (lbuf, "%s.%s multiply declared",
 			procname, tokstr);
 		    xpp_warn (lbuf);
@@ -169,7 +169,7 @@ d_declaration (int dtype)
 		    else if (sp->s_flags & S_ARGUMENT && sp->s_dtype == UNDECL)
 			sp->s_dtype = dtype;
 		    else {
-			char lbuf[200];
+			char lbuf[512];
 			sprintf (lbuf, "%s.%s multiply declared",
 			    procname, tokstr);
 			xpp_warn (lbuf);

--- a/unix/boot/spp/xpp/xppcode.c
+++ b/unix/boot/spp/xpp/xppcode.c
@@ -1480,7 +1480,7 @@ void
 do_hollerith (void)
 {
 	register char *op;
-	char	strbuf[SZ_LINE], outbuf[SZ_LINE];
+	char	strbuf[SZ_LINE], outbuf[SZ_LINE+2];
 	int	len;
 
 	/* Read the string into strbuf. */


### PR DESCRIPTION
This adds the NOIRLAB IRAF fixes for possible string overflows.

Original commits:

9101cf98b - prevent string buffer overflow
507b56c42 - fix string overflow possibilities
d56c99de6 - fix string overflow possibilities
