### PR TITLE
NOIRLAB: minor libboot.a improvements

### DIFF
--- a/unix/boot/bootlib/envinit.c
+++ b/unix/boot/bootlib/envinit.c
@@ -95,7 +95,7 @@ void
 _envinit (void)
 {
 	static	int initialized = 0;
-	char	osfn[SZ_PATHNAME+1], *hlib;
+	char	osfn[SZ_PATHNAME+16], *hlib;
 	char	irafarch[SZ_PATHNAME+1];
 
 

--- a/unix/boot/bootlib/osstrupk.c
+++ b/unix/boot/bootlib/osstrupk.c
@@ -31,7 +31,7 @@ os_strupk (
 	 */
 	if (maxch) {
 	    if (sizeof(char) != sizeof(XCHAR) || str != (char *)outstr) {
-		n = min (n, strlen(ip));
+		n = min ((size_t)n, strlen(ip));
 		op[n] = XEOS;
 
 		while (--n >= 0)

--- a/unix/boot/bootlib/ossysfile.c
+++ b/unix/boot/bootlib/ossysfile.c
@@ -66,7 +66,7 @@ os_sysfile (
 		ip = ip_save;
 
 		/* Exit if the file exists. */
-		if (os_access (fname, 0, 0))
+		if (os_access (fname, 0, 0) == YES)
 		    return (strlen (fname));
 	    }
 	}

--- a/unix/gdev/sgidev/sgi2uimp.c
+++ b/unix/gdev/sgidev/sgi2uimp.c
@@ -75,7 +75,7 @@
 #define DECL_OBUF	register char *op; char *np; char obuf[SZ_OBUF+1];
 #define o_clear		(op=obuf)
 #define o_flush(o)	fwrite(obuf,op-obuf,1,o)
-#define putbyte(v)	(*op++ = (v))
+#define putbyte(v)	(*op++ = (char)(v))
 #define putword(v)	((*op++ = (v)/256), (*op++ = (v)%256))
 #define setcount(b,v)	((np = obuf+b), (*np++ = (v)/256), (*np = (v)%256))
 #define npoints		((op-obuf - SZ_HEAD)/4)


### PR DESCRIPTION
This PR contains a number of (IMO minor) improvements for the bootlib.

Original commits:

6d773e471 - type cast fix for compiler warnings
387c00ae7 - fix sign compareison warnings
e5d528675 - incr size of osfn for irafarch name
~~912574599 - make zzsetenv.def in some locations optional~~ This is fixed differently (via #270)
355199a42 - clarified return of os_access()
