### PR TITLE
NOIRLAB: Remove or comment out unused variables

### DIFF
--- a/noao/artdata/mktemplates.x
+++ b/noao/artdata/mktemplates.x
@@ -476,10 +476,8 @@ pointer procedure mkt_object (name)
 char	name[ARB]	# Profile name or file
 
 int	i, j, n, nxm, nym, fd
-real	radius, r, dr, s, b, flux, der[2]
+real	radius, r, dr, s, flux, der[2]
 pointer	sym, mkt, prof, asi, msi, buf, im
-
-real	c3, c4, c5, c6, c7
 
 real	asieval()
 double	uigamma()

--- a/noao/onedspec/t_specplot.x
+++ b/noao/onedspec/t_specplot.x
@@ -1483,7 +1483,7 @@ int	i, j, k, l, m, trans
 pointer	sp, im, mw, sh, stack, aps, bands, str, ptr
 
 int	ctor(), open(), fscan(), nowhite(), clgwrd()
-bool	rng_elementi(), fp_equalr()
+bool	rng_elementi()
 real	clgetr(), asumr(), imgetr(), sp_logerr()
 pointer	immap(), smw_openim(), rng_open()
 

--- a/pkg/images/imcoords/src/t_ccmap.x
+++ b/pkg/images/imcoords/src/t_ccmap.x
@@ -1138,8 +1138,6 @@ pointer	mw, ct, coo
 int	getline(), li_get_numd(), sk_decim()
 pointer	mw_ctrand(), mw_sctran()
 
-int	sk_stati()
-
 begin
 	call smark (sp)
 	call salloc (inbuf, SZ_LINE, TY_CHAR)

--- a/pkg/images/imcoords/src/t_ccmap.x
+++ b/pkg/images/imcoords/src/t_ccmap.x
@@ -1136,7 +1136,7 @@ double	lng1, lat1, lng2, lat2, x, y, z, sumx, sumy, sumz, r, pa, wterm[8]
 pointer	sp, inbuf, linebuf, field_pos
 pointer	mw, ct, coo
 int	getline(), li_get_numd(), sk_decim()
-pointer	mw_ctrand(), mw_sctran()
+pointer	mw_sctran()
 
 begin
 	call smark (sp)

--- a/pkg/images/imutil/src/imdelete.x
+++ b/pkg/images/imutil/src/imdelete.x
@@ -13,7 +13,7 @@ int	list, nchars
 pointer	sp, tty, imname, im
 
 pointer	ttyodes(), immap()
-int	imtopenp(), imtgetim(), imaccess(), strlen(), strncmp()
+int	imtopenp(), imtgetim(), imaccess(), strlen()
 bool	clgetb()
 
 begin

--- a/pkg/images/tv/display/zdisplay.h
+++ b/pkg/images/tv/display/zdisplay.h
@@ -1,6 +1,6 @@
 # Display devices defined by OS
 
-define	IIS		"/dev/iis"	# IIS display device
+#define	IIS		"/dev/iis"	# IIS display device
 define	IIS_CHAN	1		# Device channel identifier
 define	DEVCODE		100		# Channel = DEVCODE * DEVCHAN
 define	FRTOCHAN	(IIS_CHAN*DEVCODE+($1))

--- a/pkg/system/t_fcache.x
+++ b/pkg/system/t_fcache.x
@@ -22,7 +22,7 @@ procedure t_fcache ()
 
 char	cmd[SZ_FNAME], cache[SZ_FNAME], fname[SZ_FNAME]
 char	pattern[SZ_FNAME], src[SZ_FNAME], cname[SZ_FNAME], extn[SZ_FNAME]
-bool	verbose, in_src, exists
+bool	verbose, exists
 int	age
 
 int	strdic(), clgeti(), envgeti()

--- a/pkg/xtools/mef/mefappfile.x
+++ b/pkg/xtools/mef/mefappfile.x
@@ -93,7 +93,7 @@ procedure mef_wrblank (out, olines)
 int	out		#I output file descriptor
 int	olines		#I number of blank lines
 
-int	nlines, i, nbk
+int	nlines, i
 char    card[80]
 
 begin

--- a/sys/etc/miiread.gx
+++ b/sys/etc/miiread.gx
@@ -16,8 +16,6 @@ int	pksize, nchars, nelem
 int	miipksize(), miinelem(), read()
 errchk	read()
 
-long	note()
-
 begin
 	pksize = miipksize (maxelem, MII_PIXEL)
 	nelem  = EOF

--- a/sys/etc/nmiread.gx
+++ b/sys/etc/nmiread.gx
@@ -16,8 +16,6 @@ int	pksize, nchars, nelem
 int	nmipksize(), nminelem(), read()
 errchk	read()
 
-long	note()
-
 begin
 	pksize = nmipksize (maxelem, NMI_PIXEL)
 	nelem  = EOF

--- a/sys/etc/nmireadb.x
+++ b/sys/etc/nmireadb.x
@@ -12,12 +12,9 @@ int	fd			#I input file
 bool	spp[ARB]		#O receives data
 int	maxelem			# max number of data elements to be read
 
-pointer	sp, bp
 int	pksize, nchars, nelem
 int	nminelem(), read()
 errchk	read()
-
-long	note()
 
 begin
 	pksize = nminelem (maxelem, NMI_INT)

--- a/sys/etc/nmireadc.x
+++ b/sys/etc/nmireadc.x
@@ -16,8 +16,6 @@ int	pksize, nchars
 int	nmipksize(), nminelem(), read()
 errchk	read()
 
-long	note()
-
 begin
 	pksize = nmipksize (maxchars, NMI_BYTE)
 	nchars = max (maxchars, pksize)

--- a/sys/fio/fmkcopy.x
+++ b/sys/fio/fmkcopy.x
@@ -19,7 +19,7 @@ procedure fmkcopy (oldfile, newfile)
 char	oldfile[ARB]		# file to be copied
 char	newfile[ARB]		# newfile
 
-char	url[SZ_PATHNAME], old[SZ_PATHNAME]
+char	old[SZ_PATHNAME]
 int	status, file_exists, junk
 pointer	vp, sp, oldosfn, newosfn
 int	vfnadd(), strncmp(), nowhite()

--- a/sys/fio/frmdir.x
+++ b/sys/fio/frmdir.x
@@ -13,7 +13,6 @@ char	dir[ARB]		# virtual or OS-dependent directory spec
 
 int	status
 pointer	sp, osfn, dirname
-int	access()
 errchk	syserrs
 
 begin

--- a/sys/imio/db/imrenf.x
+++ b/sys/imio/db/imrenf.x
@@ -13,9 +13,8 @@ pointer	im			# image descriptor
 char	oldkey[ARB]		# old keyword
 char	newkey[ARB]		# new keyword
 
-int	off
 pointer	rp, sp, keyname
-int	idb_kwlookup(), idb_findrecord(), stridxs()
+int	idb_kwlookup(), idb_findrecord()
 errchk	syserrs
 
 begin

--- a/sys/imio/dbc/imgcom.x
+++ b/sys/imio/dbc/imgcom.x
@@ -12,10 +12,9 @@ pointer	im			#I image descriptor
 char	key[ARB]		#I parameter to be set
 char	comment[ARB]		#O comment string
 
-bool	string_valued
-int	ch, i, n, j, ic, op
+int	i, op
 pointer	rp, ip, sp, buf
-int	idb_findrecord(), ctowrd(), stridx(), idb_getstring()
+int	idb_findrecord(), ctowrd()
 errchk	syserrs
 
 define  end_ 91

--- a/sys/imio/dbc/iminfi.x
+++ b/sys/imio/dbc/iminfi.x
@@ -19,7 +19,7 @@ char	datatype[ARB]		#I string permits generalization to domains
 int     baf			# I Insert BEFORE or AFTER
 
 pointer	rp, sp, keyname, ua, ip
-int	fd, max_lenuserarea, curlen, buflen, nchars, piv
+int	max_lenuserarea, curlen, buflen, nchars, piv
 int	idb_kwlookup(), idb_findrecord()
 int	strlen(), idb_filstr(), nowhite()
 char	card[IDB_RECLEN+1]

--- a/sys/imio/iki/fxf/zfiofxf.x
+++ b/sys/imio/iki/fxf/zfiofxf.x
@@ -180,9 +180,9 @@ end
 
 procedure fxf_zaltrr (data, npix, bscale, bzero)
 
-real data[ARB], rt
-int    npix
-double bscale, bzero
+real    data[ARB]
+int     npix
+double  bscale, bzero
 
 int i
 

--- a/sys/imio/iki/fxf/zfiofxf.x
+++ b/sys/imio/iki/fxf/zfiofxf.x
@@ -110,8 +110,6 @@ pointer fit, im
 int	ip, pixtype, nb
 int	status, totpix, npix
 int	datasizeb, pixoffb, nb_skipped, i
-double  dtemp
-real    rtemp, rscale, roffset
 
 include <szpixtype.inc>
 

--- a/sys/imio/iki/fxf/zfiofxf.x
+++ b/sys/imio/iki/fxf/zfiofxf.x
@@ -24,7 +24,7 @@ int	status			#O output status - i/o channel if successful
 
 pointer im, fit
 int	ip, indx, channel, strldx(), ctoi()
-bool	lscale, lzero, bfloat, fxf_fpl_equald()
+bool	lscale, lzero, fxf_fpl_equald()#, bfloat
 char    fname[SZ_PATHNAME]
 
 begin

--- a/sys/imio/imgobf.x
+++ b/sys/imio/imgobf.x
@@ -15,8 +15,6 @@ int	sizeof()
 
 errchk	imopsf, malloc, realloc, calloc
 
-include	<szpixtype.inc>
-
 begin
 	# If first write, and if new image, create pixel storage file,
 	# otherwise open pixel storage file.  Allocate and initialize

--- a/sys/imio/imrdpx.x
+++ b/sys/imio/imrdpx.x
@@ -24,8 +24,6 @@ pointer	pl
 long	offset
 int	sz_pixel, nbytes, fd, op, step, nchars, n
 
-char	zbuf[1024]
-
 int	read()
 long	imnote()
 errchk	imerr, seek, read, pl_glpi, pl_glri

--- a/sys/imio/imt/imt.x
+++ b/sys/imio/imt/imt.x
@@ -329,14 +329,5 @@ begin
 	    }
 	}
 	outstr[op] = EOS
-
-	#  FIXME
-	if (envgetb ("vo_prefetch") && strncmp (outstr, "cache", 5) == 0) {
-#	    call sprintf (cfname, SZ_LINE, "%s.fits")
-	    call sprintf (cfname, SZ_LINE, "%s")
-		call pargstr (outstr)
-	    call fcwait ("cache$", cfname)
-	}
-	
 	return (op - 1)
 end

--- a/sys/imio/imt/imx.x
+++ b/sys/imio/imt/imx.x
@@ -17,7 +17,7 @@ pointer	procedure imxopen (template)
 char	template[ARB]		# image template
 
 int	i, sort, level, ip, ch, expand, nchars, nimages, index, type
-int	max_fnt, fnt_len, len, flen
+int	max_fnt, fnt_len, len
 pointer	listp, intmp, fnt, op, exp
 char    lfile[SZ_LINE], lexpr[SZ_LINE], likparams[SZ_LINE], lsec[SZ_LINE]
 char    lindex[SZ_LINE], lextname[SZ_LINE], lextver[SZ_LINE], elem[SZ_LINE]
@@ -26,8 +26,6 @@ pointer	imx_preproc (), imx_imexpand (), imx_fexpand ()
 pointer	imx_texpand (), imx_dexpand ()
 int	imx_filetype (), imx_parse (), imx_get_element ()
 int	fntopnb (), strlen (), strsearch()
-int	sum, fntlenb()
-bool	envgetb()
 
 define	output 	{Memc[op]=$1;op=op+1}
 define	escape 	{output('\\');output($1)}

--- a/sys/imio/imt/imxbreakout.x
+++ b/sys/imio/imt/imxbreakout.x
@@ -23,7 +23,7 @@ int     nchars, ip, op
 bool	is_sif
 
 bool 	imx_issection(), imx_sifmatch()
-int	stridx()
+#int	stridx()
 
 define	next_str_	99
 

--- a/sys/imio/imt/imxexpand.x
+++ b/sys/imio/imt/imxexpand.x
@@ -373,7 +373,7 @@ char	ikparams[ARB]			# IKI parameters
 char	sec[ARB]			# Image section
 int	nimages				# Number of output images
 
-pointer	sp, exp, nodename, imname, listout
+pointer	sp, nodename, imname, listout
 int     dir, len, llen, nim, ip, delim, vfd, status, maxlen
 char    dirname[SZ_PATHNAME], ofname[SZ_PATHNAME], pdir[SZ_PATHNAME]
 char    fpath[SZ_PATHNAME], fname[SZ_PATHNAME]
@@ -495,7 +495,7 @@ char	buf[SZ_LINE], cfname[SZ_PATHNAME]
 
 int	open(), getline(), strlen()
 int	imx_decode_ranges()
-bool	imx_in_range(), envgetb()
+bool	imx_in_range()
 
 begin
 	call aclrc (buf, SZ_LINE)

--- a/sys/imio/imt/imxparse.x
+++ b/sys/imio/imt/imxparse.x
@@ -30,12 +30,10 @@ char    sec[ARB]                        #o image section string
 char    ikparams[ARB]                   #o image kernel section params
 int	maxch				#i max chars in string params
 
-pointer	im
 int     nchars, ip, idx
 char	comma, lexpr[SZ_LINE], subex[SZ_LINE], name[SZ_PATHNAME]
 
 int	imx_breakout(), imx_next_expr(), imx_expr_type(), stridx()
-pointer	immap()
 
 begin
         call aclrc (expr, maxch)		# initialize
@@ -108,12 +106,6 @@ begin
 	    call strcat (sec, name, SZ_PATHNAME)
 	    call strcat ("]", name, SZ_PATHNAME)
 	}
-
-#	iferr {
-#	    im = immap (name, READ_ONLY, 0)
-#	    call imunmap (im)
-#	} then
-#	    ;
 
         return (nchars)
 end

--- a/sys/imio/imupk.gx
+++ b/sys/imio/imupk.gx
@@ -8,8 +8,6 @@ procedure imupk$t (a, b, npix, dtype)
 PIXEL	b[npix]
 int	a[npix], npix, dtype
 
-pointer	bp
-
 begin
 	switch (dtype) {
 	case TY_USHORT:

--- a/sys/mwcs/wftpv.x
+++ b/sys/mwcs/wftpv.x
@@ -63,7 +63,7 @@ int	i, ualen, index, ip
 double	dec, dval
 pointer	ct, mw, wp, wv, im, idb, rp
 
-int	idb_nextcard(), itoc(), ctod()
+int	idb_nextcard(), ctod()
 pointer	idb_open()
 errchk	wf_decaxis()
 

--- a/sys/mwcs/wfzpn.x
+++ b/sys/mwcs/wfzpn.x
@@ -71,8 +71,8 @@ double	dec, zd1, d1, zd2, d2, zd, d, r, tol, dval
 pointer	sp, atname, atvalue, ct, mw, wp, wv, im, idb, rp
 char    compare[4]
 bool    match
-int	ctod(), strlen(), idb_nextcard(), itoc()
-pointer	wf_gsopen(), idb_open()
+int	ctod(), idb_nextcard(), itoc()
+pointer	idb_open()
 data	tol/1.0d-13/
 errchk	wf_decaxis(), mw_gwattrs()
 


### PR DESCRIPTION
These commits from NOIRLAB IRAF remove a number of unused declarations throughout the whole system.

Original commits:

2453f858c - removed unused url variable
5a920ed16 - removed unused access() declaration
dd5e01037 - removed unused note() decl
5c384ef4e - removed unused sp/bp/note() decl
75c6374dd - removed unused bp decl
516d03920 - removed unused off/stridxs() decl
64958671b - removed unused j/n/ch/ic/idbgeg/strind/stridx decl
1eb8cede3 - removed unused fd decl
2384c7d58 - commented out bfloat decl in fxfzop
be730aff2 - commented out unused dtemp/rtemp/rscale/roffset decl
5345adc31 - removed unused sum/flen/envgetb()/fntlenb() decl
f33f8e569 - commented out stridx decl
0c3a167cb - removed unused im/immap() decl
f385463af - removed unused exp/envgetb() decl
f4ccde18e - removed unused szpixtype.inc include
37504bfeb - removed unused itoc() decl
245778556 - removed unused wf_gsopen()/strlen() decl
d87f3368e - removed unused LUMFUNCS decl
99df9ac82 - removed unused decls, fixed pargi error (partially)
2cb18ba59 - removed unused fp_equalr() decl
399bd0d1c - removed unused symbols decl
92c2e55a1 - removed unused note() decl
7acc7e765 - removed unused rt decl
65a299d14 - removed unused zbuf decl
6380d62fe - removed unused host/nread decl
d22580c4f - commented out unused 'IIS' string
75c948292 - removed unused 'in_src' decl
6fc91adf5 - removed unused 'nbk' decl
ec600d143 - removed unused sk_stati() decl from cc_rdxyrd1()
c5967b5c7 - removed unused mw_ctrand() decl from cc_rdxyrd1()
083654ce7 - removed unused strncmp() decl
0b08f9f67 - removed unused note() decl
cca4069d0 - removed 'vo_prefetch' flag, unused
