### PR TITLE
NOIRLAB: Rewrite file taken from IRAF64

### DIFF
--- a/sys/osb/i32to64.c
+++ b/sys/osb/i32to64.c
@@ -1,5 +1,7 @@
-/* Copyright 2006-2009 Chisato Yamauchi (C-SODA/ISAS/JAXA)
+/* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
+
+#include <string.h>
 
 #define import_spp
 #define import_knames
@@ -13,32 +15,21 @@ I32TO64 (void *a, void *b, XINT *nelems)
 	XINT  i, j, k;
 	char  *ip = (char *) a, 
 	      *op = (char *) b;
+	int fill;
 
 
-	j = *nelems * 8;
-	k = *nelems * 4;
+	/* Move the input data to the output array so we can
+	 * do an in-place conversion.
+	 */
+	memmove ((void *)op, (void *)ip, *nelems * 8);
 
-	if ( ip < op ) {
-	    for ( i = k ; 0 < i ; i-- )
-		op[i-1] = ip[i-1];
-	}
-	else if ( op < ip ) {
-	    for ( i = 0 ; i < k ; i++ )
-		op[i] = ip[i];
-	}
-
-	for ( i=0 ; i < *nelems ; i++ ) {
-	    char pad;
-	    op[--j] = op[--k];
-	    op[--j] = op[--k];
-	    op[--j] = op[--k];
-	    op[--j] = op[--k];
-	    if ( (op[k] & 0x080) != 0 ) pad = 0x0ff;
-	    else pad = 0;
-	    op[--j] = pad;
-	    op[--j] = pad;
-	    op[--j] = pad;
-	    op[--j] = pad;
+	j = (*nelems) * 8 - 4;
+	k = (*nelems) * 4 - 4;
+	for (i=(*nelems - 1); i >= 0; i--) {
+	    memmove ((void *)&op[j], (void *)&ip[k], sizeof (int));
+	    fill = ((ip[k] & 0x080) != 0) ? 0x0ff : 0;
+	    memset ((void *)&op[j-4], (int)fill, 4);
+	    k -= 4, j -= 8;
 	}
 
 	return 0;

--- a/sys/osb/i64to32.c
+++ b/sys/osb/i64to32.c
@@ -1,5 +1,8 @@
-/* Copyright 2006-2009 Chisato Yamauchi (C-SODA/ISAS/JAXA)
+/* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
+
+#include <string.h>
+#include <stdlib.h>
 
 #define import_spp
 #define import_knames
@@ -10,92 +13,16 @@
 int
 I64TO32 (void *a, void *b, XINT *nelems)
 {
-	char *ip = (char *)a,
-	     *op = (char *)b;
-	XINT i;
+	XINT *ip = (XINT *)a;
+	int *op = (int *) calloc (*nelems, sizeof (int));
+	int *tmp = (int *)NULL, i;
 
-
-	/*
-	 *  in      |--------|
-	 *  out   |----|
-	 */
-	if ( op <= ip ) {
-	    for ( i=0 ; i < *nelems ; i++ ) {
-		ip += 4;
-		*op = *ip;
-		op++; ip++;
-		*op = *ip;
-		op++; ip++;
-		*op = *ip;
-		op++; ip++;
-		*op = *ip;
-		op++; ip++;
-	    }
+	tmp = op;
+	for (i=0 ; i < *nelems ; i++, ip++) {
+	    *tmp++ = (int) (*ip >> 32);
 	}
-	else {
+	memmove (b, op, *nelems * sizeof(int));
 
-	    char *ipe = (char *)a + *nelems * 8 - 1;
-	    char *ope = (char *)b + *nelems * 4 - 1;
-	    
-	    /*
-	     *  in      |--------|
-	     *  out           |----|
-	     */
-	    if ( ipe <= ope ) {
-		for ( i=0 ; i < *nelems ; i++ ) {
-		    *ope = *ipe;
-		    ope--; ipe--;
-		    *ope = *ipe;
-		    ope--; ipe--;
-		    *ope = *ipe;
-		    ope--; ipe--;
-		    *ope = *ipe;
-		    ope--; ipe--;
-		    ipe -= 4;
-		}
-	    }
-	    /*
-	     *  in      |--------|
-	     *  out       |----|
-	     */
-	    else {
-		
-		for ( i=0 ; i < *nelems ; i++ ) {
-		    /* --------> */
-		    ip += 4;
-		    if ( op < ip ) {
-			*op = *ip;
-			op++; ip++;
-			*op = *ip;
-			op++; ip++;
-			*op = *ip;
-			op++; ip++;
-			*op = *ip;
-			op++; ip++;
-		    }
-		    else {
-			op += 4;
-			ip += 4;
-		    }
-		    /* <-------- */
-		    if ( ipe < ope ) {
-			*ope = *ipe;
-			ope--; ipe--;
-			*ope = *ipe;
-			ope--; ipe--;
-			*ope = *ipe;
-			ope--; ipe--;
-			*ope = *ipe;
-			ope--; ipe--;
-		    }
-		    else {
-			ope -= 4;
-			ipe -= 4;
-		    }
-		    ipe -= 4;
-		}
-	    }
-	}
-
+	free ((void *) op);
 	return 0;
 }


### PR DESCRIPTION
This is an attempt to get rid of the IRAF64 provided sources. 

Original commit:

5fe155e3c - license:  rewrote code

The files `unix/as.macintel/zsvjmp.s` and `unix/as.linux64/zsvjmp.s` still contain code from IRAF64, see [noirlab-iraf/iraf-v218#3](https://gitlab.com/nsf-noirlab/csdc/usngo/iraf/iraf-v218/-/issues/3)