### PR TITLE
NOIRLAB: fmtio fixes

### DIFF
--- a/sys/fmtio/evvexpr.gy
+++ b/sys/fmtio/evvexpr.gy
@@ -247,7 +247,8 @@ $/
 
 %token		CONSTANT IDENTIFIER NEWLINE YYEOS
 %token		PLUS MINUS STAR SLASH EXPON CONCAT QUEST COLON
-%token		LT GT LE GT EQ NE SE LAND LOR LNOT BAND BOR BXOR BNOT AT
+%token		LT GT LE EQ NE SE LAND LOR LNOT BAND BOR BXOR BNOT AT
+%token		GE UMINUS
 
 %nonassoc	QUEST
 %left		LAND LOR
@@ -1368,7 +1369,7 @@ begin
 	    optype = O_TYPE(args[1])
 	    nelem = O_LEN(args[1])
 	    do i = 2, nargs {
-		optype = xvv_newtype (optype, args[i])
+		optype = xvv_newtype (optype, O_TYPE(args[i]))
 		if (O_LEN(args[i]) > 0)
 		    if (nelem > 0)
 			nelem = min (nelem, O_LEN(args[i]))


### PR DESCRIPTION
This PR from NOIRLAB IRAF fixes the order of tokens in fmtio, and the argument type for some functions.

Original commits:

a2a381742 - fix for GE/GT token confusion
7caef6d96 - backed out of GT/GE token changes
0d7551924 - fixed duplicate GT token def, arg type for min/max/mode/median func
