### PR TITLE
NOIRLAB: string buffer fix in mii_readc in "help" package

### DIFF
--- a/pkg/system/help/helpdb.x
+++ b/pkg/system/help/helpdb.x
@@ -976,10 +976,10 @@ begin
 		next
 	    }
 
-	    call fprintf (fd, "Help database %s created %s by %s, size=%d\n")
+	    call fprintf (fd, "Help database %s created %s by %d, size=%d\n")
 		call pargstr (Memc[fname])
 		call pargstr (Memc[date])
-		call pargstr (FI_OWNER(fi))
+		call pargl (FI_OWNER(fi))
 		call pargl (FI_SIZE(fi))
 	}
 	call fntclsb (list)
@@ -1161,7 +1161,7 @@ int	fd			#I input file
 pointer	obuf			#O receives unpacked helpdir data
 int	buflen			#O max su out
 
-int	i, nelem, nr, sz_mii_struct
+int	nelem, nr, sz_mii_struct
 pointer	op, hp
 int	mii_readi(), mii_readc()
 errchk	mii_readi, mii_readc

--- a/pkg/system/help/helpdb.x
+++ b/pkg/system/help/helpdb.x
@@ -1041,7 +1041,7 @@ begin
 	else
 	    call pargstr ("")
 	call pargstr (Memc[date])
-	call pargstr (FI_OWNER(fi))
+	call pargl (FI_OWNER(fi))
 	call pargstr (DBI_KEY(ix))
 
 	if (verbose) {
@@ -1187,7 +1187,7 @@ begin
 	    # Get string buffer.
 	    op = op + nelem
 	    nelem = HD_SZSBUF(hp) # / (SZ_INT / SZ_INT32)
-	    if (mii_readc (fd, Memi[op], nelem) < nelem)
+	    if (mii_readc (fd, Memc[P2C(op)], nelem) < nelem)
 		goto readerr_
 
 	    nr = nr + ((nelem + SZ_STRUCT32-1) / SZ_STRUCT32)


### PR DESCRIPTION
This PR from NOIRLAB IRAF contains two small fixes for the **help** package.

Original commits:

295cd863e - used P2C macro rather than Memi
cdb42fe7d - helpdb fix, use of Memc instead of Memi for mii_readc()
c4d59fa19 - string buffer fix in mii_readc
d56f07bd3 - removed unused decl and pargstr fix
