### PR TITLE
NOIRLAB: Small "noao" package fixes

### DIFF
--- a/noao/artdata/lists/stcolon.x
+++ b/noao/artdata/lists/stcolon.x
@@ -21,8 +21,6 @@ real	rval
 bool	streq()
 int	strdic(), nscan(), open()
 
-string	lumfuncs LUMFUNCS
-
 begin
 	# Allocate temporary space.
 	call smark (sp)
@@ -403,8 +401,6 @@ long	lval
 real	rval
 bool	streq()
 int	strdic(), nscan(), open()
-
-string	lumfuncs LUMFUNCS
 
 begin
 	call smark (sp)

--- a/noao/artdata/mktemplates.x
+++ b/noao/artdata/mktemplates.x
@@ -511,7 +511,7 @@ begin
 	    if (n < 1 || n > 20) {
 		call eprintf (
 		    "WARNING: Sersic index out of allowed range (%.1f).\n")
-		    call pargi (s)
+		    call pargr (s)
 		return (NULL)
 	    }
 	    nxm = NPROF

--- a/noao/astcat/src/attools/atfnames.x
+++ b/noao/astcat/src/attools/atfnames.x
@@ -326,7 +326,7 @@ begin
 			        call sprintf (Memc[fcname], SZ_FNAME,
 				    "reg%03d.%03d")
 			            call pargi (stnsymbols(st, 0) - i + 1)
-				    call pargstr (j)
+				    call pargi (j)
 			    } else {
 			        call sprintf (Memc[fcname], SZ_FNAME,
 				    "reg%03d")

--- a/noao/imred/ccdred/ccdred.cl
+++ b/noao/imred/ccdred/ccdred.cl
@@ -5,7 +5,7 @@ set	ccdtest	= "ccdred$ccdtest/"
 
 package ccdred
 
-task	$ccdtest	= ccdtest$ccdtest.cl
+task	ccdtest.pkg	= ccdtest$ccdtest.cl
 
 task	badpiximage,
 	ccdgroups,

--- a/noao/imred/ccdred/ccdtest/ccdtest.par
+++ b/noao/imred/ccdred/ccdtest/ccdtest.par
@@ -1,0 +1,3 @@
+# CCDTEST package parameter file
+
+version,s,h,"June 2023"

--- a/noao/imred/dtoi/hdicfit/hdicfit.h
+++ b/noao/imred/dtoi/hdicfit/hdicfit.h
@@ -13,7 +13,7 @@ define	HD_K75		4	   # Ind var is Kaiser transform w/ alpha=0.75
 define	UDELETE		100	   # Point deleted by user flag
 define	PDELETE		101	   # Point deleted by program
 define	NDELETE		102	   # Point not deleted 
-define	ADDED_PT	0.0	   # Indication of added point in sdev array
+define	ADDED_PT	0.0D0	   # Indication of added point in sdev array
 
 # The ICFIT data structure - modified for use with the DTOI package.
 

--- a/noao/imred/dtoi/hdicfit/hdicgfit.x
+++ b/noao/imred/dtoi/hdicfit/hdicgfit.x
@@ -312,7 +312,7 @@ begin
 				oldx = Memd[x+i-1]
 				oldy = Memd[y+i-1]
 			        Memd[x+i-1] = x1
-				call hd_redraw (gp, oldx, oldy, x1, oldy)
+				call hd_redraw (gp, oldx, oldy, real(x1), oldy)
 			        IC_NEWX(ic) = YES
 			    }
 			}
@@ -334,7 +334,7 @@ begin
 				oldx = Memd[x+i-1]
 				oldy = Memd[y+i-1]
 			        Memd[y+i-1] = x1
-				call hd_redraw (gp, oldx, oldy, oldx, x1)
+				call hd_redraw (gp, oldx, oldy, oldx, real(x1))
 			        IC_NEWY(ic) = YES
 			    }
 			}

--- a/noao/imred/dtoi/hdicfit/hdicggraph.x
+++ b/noao/imred/dtoi/hdicfit/hdicggraph.x
@@ -78,11 +78,10 @@ int	npts		# Number of points
 
 pointer	sp, xr, yr, sz, szmk, gt1, gt2
 char	tplot[SZ_TPLOT]
-int	i, xaxis, yaxis, symbols[3], markplot
+int	i, xaxis, yaxis, markplot
 real	size, rmin, rmax, big
 bool	fp_equald(), streq(), fp_equalr()
 int	strncmp()
-data	symbols/GM_PLUS, GM_BOX, GM_CIRCLE/
 include	"hdic.com"
 
 begin

--- a/noao/mtlocal/camera/cam_keywords.x
+++ b/noao/mtlocal/camera/cam_keywords.x
@@ -188,7 +188,7 @@ char	comment[ARB]		# Comment string
 begin
 	call fprintf (fd, "%-8.8s= %20d  /  %-45.45s\n")
 	    call pargstr (keyword)
-	    call pargs (value)
+	    call pargi (value)
 	    call pargstr (comment)
 end
 

--- a/noao/mtlocal/camera/cam_keywords.x
+++ b/noao/mtlocal/camera/cam_keywords.x
@@ -13,6 +13,7 @@ pointer	im		# Pointer to image
 
 int	fd
 real	value
+short   sval
 int	stropen()
 errchk	stropen, cam_sicard, cam_rcard, cam_hmscard, cam_ymdcard, cam_obscard
 
@@ -110,7 +111,8 @@ begin
 	if (BT_FLAG(parameters) != 0) {
 	    call cam_sicard (fd, "OVERSCAN", BT_FLAG(parameters),
 	        "OVERSCAN VALUE SUBTRACTED")
-	    call cam_sicard (fd, "TRIM", short (1), "TRIMMED IMAGE")
+            sval = 1
+	    call cam_sicard (fd, "TRIM", sval, "TRIMMED IMAGE")
 	}
 	if (BI_FLAG(parameters) != 0) {
 	    call cam_sicard (fd, "ZEROCOR", BI_FLAG(parameters),

--- a/noao/mtlocal/camera/cam_longhdr.x
+++ b/noao/mtlocal/camera/cam_longhdr.x
@@ -11,6 +11,7 @@ short	parameters[ARB]	# Pointer to program data structure
 char	text[ARB]	# ID string
 
 real	value
+short	sval
 errchk	cam_sicard, cam_rcard, cam_hmscard, cam_ymdcard, cam_obscard
 
 begin
@@ -113,7 +114,8 @@ begin
 	if (BT_FLAG(parameters) != 0) {
 	    call cam_sicard (STDOUT, "OVERSCAN", BT_FLAG(parameters),
 	        "OVERSCAN SUBTRACTED")
-	    call cam_sicard (STDOUT, "TRIM", short (1), "TRIMMED IMAGE")
+            sval = 1
+	    call cam_sicard (STDOUT, "TRIM", sval, "TRIMMED IMAGE")
 	}
 	if (BI_FLAG(parameters) != 0) {
 	    call cam_sicard (STDOUT, "ZEROCOR", BI_FLAG(parameters),

--- a/noao/onedspec/odcombine/src/icgscale.x
+++ b/noao/onedspec/odcombine/src/icgscale.x
@@ -57,11 +57,11 @@ begin
 		call close (fd)
 		if (i < nimages) {
 		    call salloc (errstr, SZ_LINE, TY_CHAR)
-		    call sprintf (errstr, SZ_FNAME,
+		    call sprintf (Memc[errstr], SZ_FNAME,
 			"Insufficient %s values in %s")
 			call pargstr (param)
 			call pargstr (name[2])
-		    call error (1, errstr)
+		    call error (1, Memc[errstr])
 		}
 	    }
 	} else if (name[1] == '!') {

--- a/noao/rv/rvcorrel.x
+++ b/noao/rv/rvcorrel.x
@@ -13,7 +13,7 @@ include "rvfilter.h"
 # used as a working space.  Sign convention of this routine, if DATA1 lags 
 # DATA2, i.e. is shifted to the right of it, then ANS will show a peak at 
 # positive lags.
-# Referece:  Numerical Recipes in C, ch 12, Press, et al.
+# Reference:  Numerical Recipes in C, ch 12, Press, et al.
 
 procedure rv_correl (rv, data1, data2, npts, ans)
 

--- a/noao/twodspec/longslit/lscombine/src/icgscale.x
+++ b/noao/twodspec/longslit/lscombine/src/icgscale.x
@@ -57,11 +57,11 @@ begin
 		call close (fd)
 		if (i < nimages) {
 		    call salloc (errstr, SZ_LINE, TY_CHAR)
-		    call sprintf (errstr, SZ_FNAME,
+		    call sprintf (Memc[errstr], SZ_FNAME,
 			"Insufficient %s values in %s")
 			call pargstr (param)
 			call pargstr (name[2])
-		    call error (1, errstr)
+		    call error (1, Memc[errstr])
 		}
 	    }
 	} else if (name[1] == '!') {


### PR DESCRIPTION
This is a collection of small fixes to the NOAO package from NOIRLABs IRAF.

Original commits:

2b3637ea2 - removed unused fp_equalr() decl
99df9ac82 - removed unused decls, fixed pargi error (partially)
a02c7118d - made ADDED_PT a double
346a6ea97 - type conversion fix for hd_redraw()
5e4e40cc0 - added ccdtest.par so pyraf pkg loading works
e11ed0942 - pointer to str conversion for error()
ca9e513fe - fixed type conversion error
35d3a58b6 - fixed type conversion error
8944dc58e - fixed pars() error
1bd2984f2 - fixed pargstr error

