### PR TITLE
NOIRLAB: Small bugfixes for libsys

### DIFF
--- a/lib/nmi.h
+++ b/lib/nmi.h
@@ -6,6 +6,7 @@ define	NMI_INT		32
 define	NMI_LONG	32
 define	NMI_REAL	-32
 define	NMI_DOUBLE	-64
+define	NMI_BOOL	(SZ_BOOL*8)
 
 # Name aliases for generic code.
 define	nmipaks		nmipak16

--- a/math/nlfit/nlfitdefd.h
+++ b/math/nlfit/nlfitdefd.h
@@ -36,16 +36,15 @@ define	NL_CHOFAC	Memi[$1+29]	# Pointer to Cholesky factorization
 
 # Access to buffers
 define	PLIST		Memi[$1]	# Parameter list
-define	OPARAM		Memd[$1]	# Original parameter vector
-define	PARAM		Memd[$1]	# Parameter vector
-define	DPARAM		Memd[$1]	# Parameter change vector
-define	ALPHA		Memd[$1]	# Alpha matrix
-define	BETA		Memd[$1]	# Beta matrix
-define	TRY		Memd[$1]	# Trial vector
-define	DERIV		Memd[$1]	# Derivatives
-define	CHOFAC		Memd[$1]	# Cholesky factorization
-define	COVAR		Memd[$1]	# Covariance matrix
-
+define	OPARAM		Memd[P2P($1)]	# Original parameter vector
+define	PARAM		Memd[P2P($1)]	# Parameter vector
+define	DPARAM		Memd[P2P($1)]	# Parameter change vector
+define	ALPHA		Memd[P2P($1)]	# Alpha matrix
+define	BETA		Memd[P2P($1)]	# Beta matrix
+define	TRY		Memd[P2P($1)]	# Trial vector
+define	DERIV		Memd[P2P($1)]	# Derivatives
+define	CHOFAC		Memd[P2P($1)]	# Cholesky factorization
+define	COVAR		Memd[P2P($1)]	# Covariance matrix
 
 # Defined constants alter for tricky problems
 define	LAMBDAMAX	1000.0

--- a/math/nlfit/nlfitdefr.h
+++ b/math/nlfit/nlfitdefr.h
@@ -36,16 +36,15 @@ define	NL_CHOFAC	Memi[$1+29]	# Pointer to Cholesky factorization
 
 # Access to buffers
 define	PLIST		Memi[$1]	# Parameter list
-define	OPARAM		Memr[$1]	# Original parameter vector
-define	PARAM		Memr[$1]	# Parameter vector
-define	DPARAM		Memr[$1]	# Parameter change vector
-define	ALPHA		Memr[$1]	# Alpha matrix
-define	BETA		Memr[$1]	# Beta matrix
-define	TRY		Memr[$1]	# Trial vector
-define	DERIV		Memr[$1]	# Derivatives
-define	CHOFAC		Memr[$1]	# Cholesky factorization
-define	COVAR		Memr[$1]	# Covariance matrix
-
+define	OPARAM		Memr[P2P($1)]	# Original parameter vector
+define	PARAM		Memr[P2P($1)]	# Parameter vector
+define	DPARAM		Memr[P2P($1)]	# Parameter change vector
+define	ALPHA		Memr[P2P($1)]	# Alpha matrix
+define	BETA		Memr[P2P($1)]	# Beta matrix
+define	TRY		Memr[P2P($1)]	# Trial vector
+define	DERIV		Memr[P2P($1)]	# Derivatives
+define	CHOFAC		Memr[P2P($1)]	# Cholesky factorization
+define	COVAR		Memr[P2P($1)]	# Covariance matrix
 
 # Defined constants alter for tricky problems
 define	LAMBDAMAX	1000.0

--- a/sys/etc/gen/nmireadb.x
+++ b/sys/etc/gen/nmireadb.x
@@ -16,8 +16,6 @@ int	pksize, nchars, nelem
 int	nmipksize(), nminelem(), read()
 errchk	read()
 
-long	note()
-
 begin
 	pksize = nmipksize (maxelem, NMI_BOOL)
 	nelem  = EOF

--- a/sys/etc/miireadc.x
+++ b/sys/etc/miireadc.x
@@ -16,8 +16,6 @@ int	pksize, nchars
 int	miipksize(), miinelem(), read()
 errchk	read()
 
-long	note()
-
 begin
 	pksize = miipksize (maxchars, MII_BYTE)
 	nchars = max (maxchars, pksize)

--- a/sys/etc/urlget.x
+++ b/sys/etc/urlget.x
@@ -47,7 +47,7 @@ char	fname[ARB]				#i local filename
 pointer	reply					#u pointer to reply string
 
 char	protocol[SZ_FNAME], host[SZ_FNAME], path[SZ_BUF], emsg[SZ_PATHNAME]
-char	inurl[SZ_LINE], outname[SZ_LINE]
+char	inurl[SZ_BUF], outname[SZ_PATHNAME]
 int	port, stat
 pointer buf
 
@@ -58,7 +58,7 @@ define	redirect_	99
 
 begin
 	# Breakup the URL into usable pieces.
-	call strcpy (url, inurl, SZ_LINE)
+	call strcpy (url, inurl, SZ_BUF)
 redirect_
 	call url_break (inurl, protocol, host, port, path)
 
@@ -125,6 +125,8 @@ begin
 		for (op=1; op <= SZ_LINE && ip <= reply + SZ_BUF && Memc[ip] != '\n' && Memc[ip] != EOS; op=op+1) {
 		    url[op] = Memc[ip]
 		    ip = ip + 1
+                    if (ip > (reply + SZ_BUF - 1))
+                        break
 		}
 		url[op-1] = EOS
 

--- a/sys/fio/fntgfn.x
+++ b/sys/fio/fntgfn.x
@@ -591,7 +591,7 @@ int	npat			# receives number of PATP elements set
 pointer	sbuf			# used to store output strings
 int	maxch			# maxch chars out
 
-int	ch, peek
+char	ch, peek
 bool	is_url
 pointer	op
 
@@ -786,7 +786,7 @@ int	token				#O token type code
 
 int	nseen, i
 pointer	ip, ip_start, op, cp
-int	stridx(), strncmp()
+int	stridx()
 
 begin
 	ip = U_TEMPLATE_INDEX(pp)			# retrieve pointer

--- a/sys/fio/vfnmap.x
+++ b/sys/fio/vfnmap.x
@@ -886,7 +886,7 @@ end
 
 int procedure vvfn_checksum (a, nchars)
 
-char	a[nchars]		# array to be summed
+int	a[nchars]		# array to be summed
 int	nchars			# length of array
 int	i, sum
 

--- a/sys/fmtio/evvexpr.gy
+++ b/sys/fmtio/evvexpr.gy
@@ -247,7 +247,8 @@ $/
 
 %token		CONSTANT IDENTIFIER NEWLINE YYEOS
 %token		PLUS MINUS STAR SLASH EXPON CONCAT QUEST COLON
-%token		LT GT LE GT EQ NE SE LAND LOR LNOT BAND BOR BXOR BNOT AT
+%token		LT GT LE EQ NE SE LAND LOR LNOT BAND BOR BXOR BNOT AT
+%token		GE UMINUS
 
 %nonassoc	QUEST
 %left		LAND LOR
@@ -1368,7 +1369,7 @@ begin
 	    optype = O_TYPE(args[1])
 	    nelem = O_LEN(args[1])
 	    do i = 2, nargs {
-		optype = xvv_newtype (optype, args[i])
+		optype = xvv_newtype (optype, O_TYPE(args[i]))
 		if (O_LEN(args[i]) > 0)
 		    if (nelem > 0)
 			nelem = min (nelem, O_LEN(args[i]))

--- a/sys/gio/fonts/mkfont.c
+++ b/sys/gio/fonts/mkfont.c
@@ -58,19 +58,12 @@ main (int argc, char *argv[])
 	    hlength = htab[hindex].length;
 	    dp = data = htab[hindex].code;
 
-	    if (DEBUG)
-		printf ("'%c' %4d: index=%4d len=%3d dlen=%3d %s\n",
-		    ch, hnum, hindex, hlength, strlen(data),
-		    (strlen(data) % 2) ? "ERROR" : "");
-
 	    /* Now decode the stroke data into X-Y pairs, first pair is for
 	     * proportional spacing.
 	     */
 	    minx = (*dp - 'R'); dp++;
 	    maxx = (*dp - 'R'); dp++;
 	    chrwid[charnum++] = min (32, maxx - minx + 5);
-
-	    if (DEBUG) printf("\twidth (%02d) (%d,%d)\n", maxx-minx,minx,maxx);
 
 	    /* Next pair is the initial move.  The Y coords are flipped
 	     * for what we need so fix that every place we get a Yval.
@@ -80,8 +73,6 @@ main (int argc, char *argv[])
 x = (ch == '1' ? x-3: x);
 	    y = YCOORD(); dp++;
 	    chrtab[idx++] = ENCODE(pen, x, y);
-
-	    if (DEBUG) printf ("\tmove (%3d,%3d) '%s'\n", x, y, dp);
 
 	    /* The remainder of the codes are move/draw strokes.
 	     */
@@ -99,10 +90,6 @@ x = (ch == '1' ? x-3: x);
 		y = YCOORD(); dp++;
 
 		chrtab[idx++] = ENCODE(pen, x, y);
-
-	        if (DEBUG) 
-		    printf("\t%s (%3d,%3d) => %6d\n",
-			pen?"draw":"move", x, y, ENCODE(pen,x,y));
 	    }
 	    chrtab[idx++] = ENCODE(0, 0, 0);
 	    ch++;
@@ -117,15 +104,21 @@ x = (ch == '1' ? x-3: x);
 }
 
 
-int 
-print_index (int *idxtab, int N)
+static void
+print_index (
+    int	*idxtab, 
+    int N
+)
 {
 	register int i, j, start=1, end=5;
+        char ch;
 
 	for (i=0; i < N; ) {
 	    printf ("data    (chridx(i), i=%03d,%03d) /", start, min(N,end));
-	    for (j=0; j < 5 && i < N; j++)
-		printf ("%5d%c", idxtab[i++], (j<4 && i<N ? ',' : '/'));
+	    for (j=0; j < 5 && i < N; j++) {
+                ch = (j<4 && i<N ? ',' : '/');
+		printf ("%5d%c", idxtab[i++], ch);
+            }
 	    printf ("\n");
 	    start = end + 1;
 	    end += 5;
@@ -133,15 +126,21 @@ print_index (int *idxtab, int N)
 }
 
 
-int 
-print_widths (int *wtab, int N)
+static void
+print_widths (
+    int	*wtab,
+    int	N
+)
 {
 	register int i, j, start=1, end=5;
+        char ch;
 
 	for (i=0; i < N; ) {
 	    printf ("data    (chrwid(i), i=%03d,%03d) /", start, min(N,end));
-	    for (j=0; j < 5 && i < N; j++)
-		printf ("%5d%c", wtab[i++], (j<4 && i<N ? ',' : '/'));
+	    for (j=0; j < 5 && i < N; j++) {
+                ch = (j<4 && i<N ? ',' : '/');
+		printf ("%5d%c", wtab[i++], ch);
+            }
 	    printf ("\n");
 	    start = end + 1;
 	    end += 5;
@@ -149,15 +148,21 @@ print_widths (int *wtab, int N)
 }
 
 
-int 
-print_strokes (int *strtab, int N)
+static void
+print_strokes (
+    int	*strtab,
+    int	N
+)
 {
 	register int i, j, start=1, end=5;
+        char ch;
 
 	for (i=0; i < N; ) {
 	    printf ("data    (chrtab(i), i=%04d,%04d) /", start, min(N,end));
-	    for (j=0; j < 5 && i < N; j++)
-		printf ("%6d%c", strtab[i++], (j<4 && i<N ? ',' : '/'));
+	    for (j=0; j < 5 && i < N; j++) {
+                ch = (j<4 && i<N ? ',' : '/');
+		printf ("%6d%c", strtab[i++], ch);
+            }
 	    printf ("\n");
 	    start = end + 1;
 	    end += 5;
@@ -165,10 +170,12 @@ print_strokes (int *strtab, int N)
 }
 
 
-int 
-print_prologue (int nidx, int nchar)
+static void
+print_prologue (
+    int	nidx,
+    int	nchar
+)
 {
-
 printf ("# CHRTAB -- Table of strokes for the printable ASCII characters.  Each\n");
 printf ("# character is encoded as a series of strokes.  Each stroke is ex-\n");
 printf ("# pressed by a single integer containing the following bitfields:\n");

--- a/sys/imio/immapz.x
+++ b/sys/imio/immapz.x
@@ -105,7 +105,6 @@ begin
 	# to be called when the first i/o operation occurs.
 
 	IM_FAST(im) = YES
-IM_FAST(im) = NO
 
 	# Set the image name field, used by IMERR everywhere.
 	call strcpy (inname, IM_NAME(im), SZ_IMNAME)

--- a/sys/imio/impmmapo.x
+++ b/sys/imio/impmmapo.x
@@ -38,7 +38,8 @@ begin
 
 	# Set up the image descriptor.
 	IM_NDIM(im) = naxes
-	IM_NPHYSDIM(im) = IM_NPHYSDIM(ref_im)
+	if (ref_im != NULL)
+	    IM_NPHYSDIM(im) = IM_NPHYSDIM(ref_im)
 	IM_PIXTYPE(im) = TY_INT
 	call amovl (axlen, IM_LEN(im,1), IM_MAXDIM)
 

--- a/sys/ki/kopdpr.x
+++ b/sys/ki/kopdpr.x
@@ -38,7 +38,7 @@ begin
 	    }
 
 	} else {
-	    # Spawning of detached processes on remote nodes is not really
+	    # Spawning of detached processes on remote notes is not really
 	    # supported as of yet.  Add support for passing the bkgmsg; use
 	    # node name in bkgmsg to submit bkg job to remote node.
 

--- a/sys/ki/zzrdks.c
+++ b/sys/ki/zzrdks.c
@@ -9,8 +9,13 @@ int	spoolfd = 0;
  * it, delete the file, edit the Makefile, and change the reference to
  * zzrdks in irafks.x to zardks.
  */
-int 
-zzrdks_ (int *chan, short *buf, int *maxb, int *off)
+void
+zzrdks_ (
+    int	  *chan,
+    short *buf,
+    int	  *maxb,
+    int	  *off
+)
 {
 	int	status;
 

--- a/sys/libc/ccnvdate.c
+++ b/sys/libc/ccnvdate.c
@@ -19,7 +19,8 @@ c_cnvdate (
 {
 	XCHAR	buf[SZ_LINE];
 	XINT	x_maxch = SZ_LINE;
+        XLONG   _clktime = clktime;
 
-	CNVDATE (&clktime, buf, &x_maxch);
+	CNVDATE (&_clktime, buf, &x_maxch);
 	return (c_strpak (buf, outstr, maxch));
 }

--- a/sys/libc/ccnvtime.c
+++ b/sys/libc/ccnvtime.c
@@ -19,7 +19,8 @@ c_cnvtime (
 {
 	XCHAR	buf[SZ_LINE];
 	XINT	x_maxch = SZ_LINE;
+        XLONG   _clktime = clktime;
 
-	CNVTIME (&clktime, buf, &x_maxch);
+	CNVTIME (&_clktime, buf, &x_maxch);
 	return (c_strpak (buf, outstr, maxch));
 }


### PR DESCRIPTION
These are few small fixes for **libsys** from NOIRLABs IRAF.

Original commits:

a2a381742 - fix for GE/GT token confusion
7caef6d96 - backed out of GT/GE token changes
0d7551924 - fixed duplicate GT token def, arg type for min/max/mode/median func
7f33031c8 - commented out test reset of IM_FAST=NO in immapz
ca10e0bc1 - enable fast i/o
f17758f03 - added def for NMI_BOOL
48aab5deb - fix type clash on 32-bit systems
c3041d4cf - modified 1st arg to vvfn_checksum() to int
ebead5f18 - var decl for stridx() values, removed unused strncmp()
091f1d308 - fixed null ref_im reference crashing fixpix task
e2c12a224 - fix for long URLs
