### PR TITLE
NOIRLAB: Force exclusion of .git directory from processing in rmbin and rmfiles

### DIFF
--- a/unix/boot/rmbin/rmbin.c
+++ b/unix/boot/rmbin/rmbin.c
@@ -134,6 +134,13 @@ rmbin (
 	char	fname[SZ_PATHNAME+1];
 	int	dp, ftype;
 
+
+        /* Hardwire an exclusion for a .git directory so we don't 
+         * unintentially delete the repo files.
+         */
+        if (strncmp (".git", dir, 4) == 0)
+            return;
+
 	if ((dp = os_diropen (dir)) == ERR) {
 	    fprintf (stderr, "cannot open directory `%s'\n", dir);
 	    fflush (stderr);

--- a/unix/boot/rmfiles/rmfiles.c
+++ b/unix/boot/rmfiles/rmfiles.c
@@ -134,6 +134,13 @@ rmfiles (
 	int	nextn, mode;
 	FILE	*fp = NULL;
 
+
+        /* Hardwire an exclusion for a .git directory so we don't
+         * unintentially delete the repo files.
+         */
+        if (strncmp (".git", dir, 4) == 0)
+            return;
+
 	if (debug) {
 	    fprintf (stderr, "rmfiles @(%s), exe=%d, ver=%d\n", prog, execute,
 		verbose);


### PR DESCRIPTION
This commit from NOIRLABs IRAF may be useful when parts of the target are in a git repository

Original commit:

595416f30 - force exclusion of .git directory from processing
