### PR TITLE
NOIRLAB: Small fixes in IRAF system packages

### DIFF
--- a/noao/mkpkg
+++ b/noao/mkpkg
@@ -20,7 +20,6 @@ update:
 	$call twodspec
 	$call imred
 
-	$ifeq (HOSTID, vms) $purge [...] $endif
 	$purge noaobin$
 	;
 

--- a/pkg/images/tv/display/t_dcontrol.x
+++ b/pkg/images/tv/display/t_dcontrol.x
@@ -61,7 +61,7 @@ begin
 
 	# Get device information.
 	call clgstr ("device", Memc[device], SZ_FNAME)
-	if (streq (device, stdimage)) {
+	if (streq (Memc[device], stdimage)) {
 	    if (envgets (stdimage, Memc[device], SZ_FNAME) <= 0)
 		call syserrs (SYS_ENVNF, stdimage)
 	}

--- a/pkg/images/tv/mkpkg
+++ b/pkg/images/tv/mkpkg
@@ -10,7 +10,7 @@ update:
 	;
 
 relink:
-	$set   LIBS1 = "-liminterp -lncar -lgks -lds -lxtools"
+	$set   LIBS1 = "-lncar -lgks -lds -lxtools"
 	$set   LIBS2 = "-lgsurfit -lnlfit -lcurfit -lllsq -liminterp"
 	$checkout libds.a lib$
 	$update libds.a

--- a/pkg/mkpkg
+++ b/pkg/mkpkg
@@ -20,7 +20,6 @@ update:
 	$call proto
 	$call utilities
 
-	$ifeq (HOSTID, vms) $purge [...] $endif
 	$purge bin$
 	;
 

--- a/pkg/proto/color/mkpkg
+++ b/pkg/proto/color/mkpkg
@@ -5,14 +5,10 @@ $exit
 
 update:
 	$call update@src
-
-	$ifeq (HOSTID, vms) $purge [...] $endif
 	;
 
 relink:
 	$call relink@src
-
-	$ifeq (HOSTID, vms) $purge [...] $endif
 	;
 
 install:

--- a/pkg/proto/vol/mkpkg
+++ b/pkg/proto/vol/mkpkg
@@ -5,14 +5,10 @@ $exit
 
 update:
 	$call update@src
-
-	$ifeq (HOSTID, vms) $purge [...] $endif
 	;
 
 relink:
 	$call relink@src
-
-	$ifeq (HOSTID, vms) $purge [...] $endif
 	;
 
 install:

--- a/pkg/tbtables/tbbnll.x
+++ b/pkg/tbtables/tbbnll.x
@@ -69,7 +69,7 @@ char	output[ARB]		# o: same as input, bit for bit
 double	buf			# local copy of input
 char	cbuf[SZ_DOUBLE]		# will be copied to output
 int	i
-#equivalence (buf, cbuf)
+equivalence (buf, cbuf)
 
 begin
 	buf = input
@@ -89,7 +89,7 @@ char	output[ARB]		# o: same as input, bit for bit
 real	buf			# local copy of input
 char	cbuf[SZ_REAL]		# will be copied to output
 int	i
-#equivalence (buf, cbuf)
+equivalence (buf, cbuf)
 
 begin
 	buf = input
@@ -109,7 +109,7 @@ char	output[ARB]		# o: same as input, bit for bit
 int	buf			# local copy of input
 char	cbuf[SZ_INT32]		# will be copied to output
 int	i
-#equivalence (buf, cbuf)
+equivalence (buf, cbuf)
 
 begin
 	buf = input
@@ -129,7 +129,7 @@ char	output[ARB]		# o: same as input, bit for bit
 short	buf			# local copy of input
 char	cbuf[SZ_SHORT]		# will be copied to output
 int	i
-#equivalence (buf, cbuf)
+equivalence (buf, cbuf)
 
 begin
 	if (SZ_SHORT == SZ_CHAR) {
@@ -153,7 +153,7 @@ char	output[ARB]		# o: same as input, bit for bit
 bool	buf			# local copy of input
 char	cbuf[SZ_BOOL]		# will be copied to output
 int	i
-#equivalence (buf, cbuf)
+equivalence (buf, cbuf)
 
 begin
 	buf = input

--- a/pkg/tbtables/tbfnew.x
+++ b/pkg/tbtables/tbfnew.x
@@ -79,8 +79,8 @@ bool	simple, extend
 int	status		# zero is OK
 int	hdu		# HDU number (zero is primary header)
 int	fd[2]		# unit number for FITS file; cfitsio pointer
-#double	dfd		# to force alignment of fd
-#equivalence (fd, dfd)	# to force alignment of fd
+double	dfd		# to force alignment of fd
+equivalence (fd, dfd)	# to force alignment of fd
 int	hdutype		# type of current HDU
 int	extver		# value of EXTVER from existing header, or -1
 int	ncols		# number of columns, but min of 1 (for allocating space)

--- a/pkg/tbtables/tbfopn.x
+++ b/pkg/tbtables/tbfopn.x
@@ -53,8 +53,8 @@ int	hdu		# HDU number
 int	extver		# extension version number
 int	hdutype		# type of HDU
 int	fd[2]		# unit number for FITS file; cfitsio pointer
-#double	dfd		# to force alignment of fd
-#equivalence (fd, dfd)	# to force alignment of fd
+double	dfd		# to force alignment of fd
+equivalence (fd, dfd)	# to force alignment of fd
 int	tbffnd()
 bool	strne()
 errchk	tbffnd, tbferr

--- a/pkg/tbtables/tbfpri.x
+++ b/pkg/tbtables/tbfpri.x
@@ -37,9 +37,9 @@ int	ifd[2]		# C pointer for input (template) FITS file
 int	ofd[2]		# C pointer for output FITS file
 # These variables and equivalence statements are used to force 8-byte
 # alignment of ifd and ofd.
-#double	d_ifd, d_ofd
-#equivalence (ifd, d_ifd)
-#equivalence (ofd, d_ofd)
+double	d_ifd, d_ofd
+equivalence (ifd, d_ifd)
+equivalence (ofd, d_ofd)
 int	naxis		# NAXIS from primary header of input
 int	status		# zero is OK
 int	itype, otype	# file type based on filename extension

--- a/pkg/utilities/nttools/nttools.par
+++ b/pkg/utilities/nttools/nttools.par
@@ -1,3 +1,3 @@
-# Dummy LOCAL package parameter file.
+# Dummy NTTOOLS package parameter file.
 
-version,s,h,"10May2000"
+version,s,h,"10Oct2023"

--- a/pkg/xtools/fixpix/ytpmmap.x
+++ b/pkg/xtools/fixpix/ytpmmap.x
@@ -871,16 +871,16 @@ begin
 	# Expand the mask bound to avoid missing the edge.
 	i = (xmin - 1) * icstep + (2*buf) - 1
 	xmin = (i - (2*buf)) / icstep + 1
-	xmin = max (1, min (ncpm, nint(xmin)))
+	xmin = max (1, min (ncpm, nint(xmin*1.0)))
 	i = (xmax - 1) * icstep + (2*buf) + 1.99
 	xmax = (i - (2*buf)) / icstep + 1
-	xmax = max (1, min (ncpm, nint(xmax)))
+	xmax = max (1, min (ncpm, nint(xmax*1.0)))
 	j = (ymin - 1) * ilstep + (2*buf) - 1
 	ymin = (j - (2*buf)) / ilstep + 1
-	ymin = max (1, min (nlpm, nint(ymin)))
+	ymin = max (1, min (nlpm, nint(ymin*1.0)))
 	j = (ymax - 1) * ilstep + (2*buf) + 1.99
 	ymax = (j - (2*buf)) / ilstep + 1
-	ymax = max (1, min (nlpm, nint(ymax)))
+	ymax = max (1, min (nlpm, nint(ymax*1.0)))
 
 	# Determine size of mask pixel in reference system.
 	# This is approximate because we don't take into account the


### PR DESCRIPTION
These are small fixes from NOIRLAB IRAF in the **xtools.fixpix** and **tv.display** tasks, and in some **mkpkg** files.

Original commits:

87c9fd7bd - removed old VMS purge definitions
07c698c38 - pointer fix for unused task
0eebf1888 - fix arg type to intrinsic nint()
51673b5e6 - moved -liminterp to the end to compile x_tv.e
d76ccb8ed - removed duplicate iminterp lib from libs

