### PR TITLE
Use fpurge/__fpurge to cancel buffered output

### DIFF
--- a/unix/os/zxwhen.c
+++ b/unix/os/zxwhen.c
@@ -2,6 +2,9 @@
  */
 
 #include <stdio.h>
+#ifdef __GLIBC__
+#include <stdio_ext.h>
+#endif
 #include <signal.h>
 
 #include <math.h>
@@ -32,8 +35,10 @@ int debug_sig = 0;
 /* If the OS allows, cancel any buffered output. If the OS doesn't, 
  * do nothing.
  */
-#ifdef __APPLE__
-#define	fcancel(fp)	((fp)->_r = (fp)->_w = 0)
+#if defined(__APPLE__) || defined(BSD) || defined(__USE_BSD)
+#define	fcancel(fp)	(void)fpurge(fp)
+#elif defined(__GLIBC__)
+#define	fcancel(fp)     __fpurge(fp)
 #else
 #define	fcancel(fp)
 #endif


### PR DESCRIPTION
This is an alternative to NOIRLAB IRAFs 48b2f614fbaf28219bcc35e291b440fcc11be03f, which defines **fcancel()** as [**setvbuf()**](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/setvbuf.3.html) on macOS: https://github.com/iraf-community/iraf/blob/3761a03d6bb3d91e5da0a9562e778654f59ab2a3/unix/os/zxwhen.c#L90-L96

**setvbuf()** is not what **fcancel()** is supposed to do, namely to cancel any buffered output. Instead, it just makes the output unbuffered. i.e. when applying this patch, stdout will become unbuffered for the rest of the session after ^C. Also, **setvbuf()** is not macOS specific but part of the standard C library (and therefore also available for Linux). And, hard-coding `_IONBF` instead of using the proper include file (`stdio.h`) is bad style.

The better solution (although non-portable) is to use [**fpurge()**](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fpurge.3.html) on macOS (and BSD variants), and [**__fpurge()**](https://manpages.debian.org/bookworm/manpages-dev/__fpurge.3.en.html) on Linux (and glibc variants, like HURD). This is done in this PR. While not really portable, these are the libc functions for this task. Linux is covered with the `__GLIBC__` macro here, because it is not a Linux but a glibc feature. HURD is handled like Linux.

@mjfitzpatrick, FYI.