### PR TITLE
Remove outdated options from XC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ export RANLIB = ranlib
 # host tools and software are in unix/Makefile.
 export CFLAGS ?= -g -O2
 export XC_CFLAGS = $(CPPFLAGS) $(CFLAGS)
+export XC_LFLAGS = $(LDFLAGS)
 
 .PHONY: all sysgen clean test arch noao host novos core bindirs bin_links config inplace starttime
 

--- a/test/run_tests
+++ b/test/run_tests
@@ -22,7 +22,7 @@ if [ ! -d $bin -a -d ${iraf}bin ] ; then
     bin=${iraf}bin/
     unset arch IRAFARCH
 fi
-export XC_CFLAGS=-w
+export XC_CFLAGS="${XC_CFLAGS} -w"
 
 TEST_FILES=""
 IRAF_SHELLS=""

--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -93,9 +93,6 @@ char *opt_flags[] = { "-O2",
 #define ispfile(str)	(getextn(str) == 'P')	/* func prototypes	*/
 
 
-int	stripexe 	= NO;
-int	notvsym 	= NO;
-int	noshsym 	= NO;
 int	errflag 	= NO;
 int	objflags 	= NO;
 int	keepfort 	= NO;
@@ -112,7 +109,6 @@ int	hostprog 	= NO;
 int	voslibs 	= YES;
 int	nolibc 		= NO;
 int	usef2c 		= YES;
-int	useg95 		= NO;
 int	userincs	= NO;
 int	host_c_main 	= NO;
 
@@ -234,7 +230,6 @@ main (int argc, char *argv[])
 	if ((s = os_getenv ("XC-F77")) || (s = os_getenv ("XC_F77")))
 	    strcpy (f77comp, s);
 	usef2c = (strncmp (f77comp, "f77", 3) == 0 ? 1 : 0);
-	useg95 = (strncmp (f77comp, "g95", 3) == 0 ? 1 : 0);
 	if ((s = os_getenv ("XC-LINKER")) || (s = os_getenv ("XC_LINKER")))
 	    strcpy (linker, s);
 
@@ -463,12 +458,12 @@ main (int argc, char *argv[])
 			} else if (*ip == 'e') {
 			   // compatibility entry ( noedsym = YES;)
 			} else if (*ip == 't') {
-			    notvsym = YES;
+			  // compatibility entry (notvsym = YES;)
 			} else if (*ip == 'T') {
-			    noshsym = YES;
+			  // compatibility entry (noshsym = YES;)
 			} else if (*ip == 's') {
-			    stripexe = YES;
-			    goto passflag;
+			  // compatibility entry (stripexe = YES;)
+			  //   goto passflag;
 			} else if (*ip == 'N') {
 			    /* "NFS" link option.  Generate the output temp
 			     * file in /tmp during the link, then move it to

--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -61,32 +61,27 @@
 #define	XPP		"xpp.e"
 #define	RPP		"rpp.e"
 #define LIBMAIN		"libmain.o"
-#define IRAFLIB1	"libex.a"
-#define IRAFLIB2	"libsys.a"
-#define IRAFLIB3	"libvops.a"
-#define IRAFLIB4	"libos.a"
-#define IRAFLIB5	"liblapack.a"
-#define IRAFLIB6	"libfftpack.a"
 
-char *fortlib[] = { "-lf2c",			/*  0  */
-		    "-lm",			/*  1  */
-		    "-lcurl",			/*  2  */
-		    "-lexpat",			/*  3  */
+char *iraflibs[] = { "libex.a",
+                     "liblapack.a",
+		     "libsys.a",
+		     "libvops.a",
+		     "libfftpack.a",
+		     "libos.a",
+		     NULL};
+
+char *fortlib[] = { "-lf2c",
+		    "-lm",
+		    "-lcurl",
+		    "-lexpat",
 #if (defined (__linux__) || defined (__gnu_hurd__))
-		    "-lpthread",		/*  5  */
-#else
-		    "",				/*  5  */
+		    "-lpthread",
 #endif
-		    "-lz",			/*  6  */
-		    "",				/*  7  */
-		    "",				/*  8  */
-		    "",				/*  9  */
-		    0};				/* EOF */
+		    "-lz",
+		    NULL};
 
-char *opt_flags[] = { "-O2",			/*  0  */
-		    0};				/* EOF */
-
-int  nopt_flags	   = 1;				/* No. optimizer flags */
+char *opt_flags[] = { "-O2",
+		    NULL};
 
 #define isxfile(str)	(getextn(str) == 'x')
 #define isffile(str)	(getextn(str) == 'f')
@@ -613,8 +608,9 @@ passflag:		    mkobject = YES;
 #endif
 
         if (optimize) {
-	    for (i=0;  i < nopt_flags;  i++)
+	    for (i=0;  opt_flags[i] != NULL;  i++) {
 	        arglist[nargs++] = opt_flags[i];
+	    }
 	}
 
 	/* Add the user-defined flags last so they can override the 
@@ -656,8 +652,9 @@ passflag:		    mkobject = YES;
 #endif
 
         if (optimize) {
-	    for (i=0;  i < nopt_flags;  i++)
-	       arglist[nargs++] = opt_flags[i];
+	    for (i=0;  opt_flags[i] != NULL;  i++) {
+	        arglist[nargs++] = opt_flags[i];
+	    }
 	}
 
 	/* Add the user-defined flags last so they can override the 
@@ -698,8 +695,9 @@ passflag:		    mkobject = YES;
 	arglist[nargs++] = "-c";
 
 	if (optimize) {
-	    for (i=0;  i < nopt_flags;  i++)
+	    for (i=0;  opt_flags[i] != NULL;  i++) {
 	        arglist[nargs++] = opt_flags[i];
+	    }
 	}
 
 	if (! nolibc) {
@@ -796,30 +794,22 @@ passflag:		    mkobject = YES;
 	    arglist[nargs++] = mkfname (LIBMAIN);
 	}
 	if (voslibs) {
-	    arglist[nargs++] = mkfname (IRAFLIB1);
-	    arglist[nargs++] = mkfname (IRAFLIB5);
-	    arglist[nargs++] = mkfname (IRAFLIB2);
-	    arglist[nargs++] = mkfname (IRAFLIB3);
-	    arglist[nargs++] = mkfname (IRAFLIB6);
-	    arglist[nargs++] = mkfname (IRAFLIB4);
+	    for (i=0; iraflibs[i] != NULL; i++) {
+	        arglist[nargs++] = mkfname (iraflibs[i]);
+	    }
 	}
 
 	/* Host libraries, searched after iraf libraries. */
-	for (i=0;  i < nhlibs;  i++)
+	for (i=0;  i < nhlibs;  i++) {
 	    arglist[nargs++] = hlibs[i];
+	}
 
 	/* The remaining system libraries depend upon which version of
 	 * the SunOS compiler we are using. 
 	 */
-	addflags (fortlib[0], arglist, &nargs);
-	addflags (fortlib[1], arglist, &nargs);
-	addflags (fortlib[2], arglist, &nargs);
-	addflags (fortlib[3], arglist, &nargs);
-	addflags (fortlib[4], arglist, &nargs);
-	addflags (fortlib[5], arglist, &nargs);
-	addflags (fortlib[6], arglist, &nargs);
-	addflags (fortlib[7], arglist, &nargs);
-	addflags (fortlib[8], arglist, &nargs);
+	for (i=0; fortlib[i] != NULL; i++) {
+	    addflags (fortlib[i], arglist, &nargs);
+	}
 	arglist[nargs] = NULL;
 
 	if (debug)

--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -615,9 +615,7 @@ passflag:		    mkobject = YES;
 	    arglist[nargs++] = f2cpath;
 	}
 
-#ifdef __i386__
-	arglist[nargs++] = "-m32";
-#elif (__SIZEOF_LONG__ == 8 && __SIZEOF_POINTER__ == 8) /* ILP64 */
+#if (__SIZEOF_LONG__ == 8 && __SIZEOF_POINTER__ == 8) /* ILP64 */
 	arglist[nargs++] = "-i8";
 #endif
 
@@ -660,9 +658,7 @@ passflag:		    mkobject = YES;
 	    arglist[nargs++] = f2cpath;
 	}
 
-#ifdef __i386__
-	arglist[nargs++] = "-m32";
-#elif (__SIZEOF_LONG__ == 8 && __SIZEOF_POINTER__ == 8) /* ILP64 */
+#if (__SIZEOF_LONG__ == 8 && __SIZEOF_POINTER__ == 8) /* ILP64 */
 	arglist[nargs++] = "-i8";
 #endif
 
@@ -707,10 +703,6 @@ passflag:		    mkobject = YES;
 	nargs = 0;
 	arglist[nargs++] = ccomp;
 	arglist[nargs++] = "-c";
-
-#ifdef __i386__
-	arglist[nargs++] = "-m32";
-#endif
 
 	if (optimize) {
 	    for (i=0;  i < nopt_flags;  i++)
@@ -763,9 +755,6 @@ passflag:		    mkobject = YES;
 	if ((s = os_getenv("XC-LFLAGS")) || (s = os_getenv("XC_LFLAGS")))
 	    addflags (s, arglist, &nargs);
 
-#ifdef __i386__
-	arglist[nargs++] = "-m32";
-#endif
 	arglist[nargs++] = "-o";
 
 	if (link_nfs) {

--- a/unix/boot/spp/xc.hlp
+++ b/unix/boot/spp/xc.hlp
@@ -104,9 +104,6 @@ Suppress warnings.
 .ls 10 -x
 Compile and link for debugging.
 .le
-.ls 10 -z
-Create a non-shareable image (default).
-.le
 .ls 10 -V
 Print XC version identification.
 .le

--- a/unix/boot/spp/xc.hlp
+++ b/unix/boot/spp/xc.hlp
@@ -16,9 +16,6 @@ Causes debug messages to be printed during execution.
 .ls 10 -F, -f
 Do not delete the Fortran translation of an SPP source file.
 .le
-.ls 10 -g
-Generates debugging information.
-.le
 .ls 10 -h
 Causes the executable to be linked as a host program, i.e., without the
 IRAF main and without searching the IRAF libraries, unless explicitly
@@ -66,7 +63,7 @@ the link down excessively.
 .ls 10 -Nh [filename]
 This tells xpp that the foreign definitions in the
 file specified should be used in preference to
-standard include files.	
+standard include files.
 .le
 .ls 10 -o
 This flag redirects the output of the compile if used in
@@ -91,15 +88,14 @@ package.
 Disable optimization.  Opposite of -O.  Object code will be optimized
 by default.
 .le
-.ls 10 -v
-Verbose mode.  Causes messages to be printed during execution telling
-what the \fIxc\fR program is doing.
-.le
 .ls 10 -w
-Suppress warnings.				
+Suppress warnings. Forwarded to the compiler and linker.
 .le
 .ls 10 -x
 Compile and link for debugging.
+.le
+.ls 10 -z, -e, -t, -T, -s
+Ignored. Provided for backward compatibility.
 .le
 .ls 10 -V
 Print XC version identification.

--- a/unix/boot/spp/xc.hlp
+++ b/unix/boot/spp/xc.hlp
@@ -91,9 +91,6 @@ package.
 Disable optimization.  Opposite of -O.  Object code will be optimized
 by default.
 .le
-.ls 10 -s
-Strips all symbols and debugging information.
-.le
 .ls 10 -v
 Verbose mode.  Causes messages to be printed during execution telling
 what the \fIxc\fR program is doing.

--- a/unix/boot/spp/xc.man
+++ b/unix/boot/spp/xc.man
@@ -1,4 +1,4 @@
-.\"                                      Hey, EMACS: -*- nroff -*-
+.\"   Hey, EMACS: -*- nroff -*-
 .TH XC "1" "June 2021" "IRAF 2.17" "IRAF commands"
 .SH NAME
 xc \- portable IRAF compile/link utility
@@ -44,9 +44,6 @@ Causes debug messages to be printed during execution.
 .B -F\fR,\fB -f
 Do not delete the Fortran translation of an SPP source file.
 .TP
-.B -g
-Generates debugging information .
-.TP
 .B -h
 Causes the executable to be linked as a host program, i.e., without
 the IRAF main and without searching the IRAF libraries, unless
@@ -84,7 +81,7 @@ besides the standard ones to include.  These must be either on the current
 directory, or in an IRAF system library (lib$ or hlib$).
 The library specification must be immediately after the option as in
 "-lxtools".  No other option may follow the 'l' option in the same
-argument as in -lxtoolsO.	
+argument as in -lxtoolsO.
 .TP
 .B -N
 Generates the output temp file in /tmp during the link, then moves it
@@ -107,7 +104,7 @@ Optimize object code produced; this is now the default, but this
 switch is still provided for backwards compatibility.
 .TP
 .B -p \fIpkgname
-Load the package environment for the named external package, e.g., 
+Load the package environment for the named external package, e.g.,
 "xc \-c \-p noao file.x".  If the same package is always specified the
 environment variable or logical name PKGENV may be defined at the host
 level to accomplish the same thing.  The package name \fImust\fR be
@@ -118,23 +115,16 @@ package.
 Disable optimization.  Opposite of \-O.  Object code will be optimized
 by default.
 .TP
-.B -s
-Strips all symbols and debugging information.
-.TP
-.B -S
-Same as \-s for VMS.
-.TP
-.B -v
-Verbose mode.  Causes messages to be printed during execution telling
-what the \fBxc\fR program is doing.
-.TP
 .B -w
-Suppress warnings.                              
+Suppress warnings. Forwarded to the compiler and linker.
 .TP
-.B -z
-Create a non-shareable image (default).
+.B -x
+Compile and link for debugging.
 .TP
-.B V
+.B -z\fR,\fB -e\fR,\fB -t\fR,\fB -T\fR,\fB -s
+Ignored. Provided for backward compatibility.
+.TP
+.B -V
 Print XC version identification.
 
 .SH SEE ALSO

--- a/unix/hlib/mkpkg.inc
+++ b/unix/hlib/mkpkg.inc
@@ -8,7 +8,7 @@ $set	SITEID		= noao		# site name
 
 $set	XFLAGS		= "-c -w"	# default XC compile flags
 $set	XVFLAGS		= "-c -w"	# VOPS XC compile flags
-$set	LFLAGS		= "-Nz"	        # default XC link flags
+$set	LFLAGS		= ""	        # default XC link flags
 
 $set	USE_LIBMAIN	= yes		# update lib$libmain.o (root object)
 $set	USE_KNET	= yes		# use the KI (network interface)


### PR DESCRIPTION
Major driver here is the removal of the arch dependent `-m32` flag (for i386). This flag shadowed a missing linker flag in the Makefile; this should help us moving towards cross compileability.

Then, all "shared image" support was removed. This was modelled for the SunOS shared library model, which involved patching a shared image. On Linux and macOS, shared library support works completely different, so it is removed here. I we ever want to enable a libiraf.so shared library, we will anyway re-implement this (maybe based on the Digital Unix version which is closer to what is used today).

Finally, a few variables and options were removed that are no longer in use. For compatibility, they stay as no-op in the argument list.