### PR TITLE
New Github runner for Mac M1

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -28,6 +28,10 @@ jobs:
             os: macos-latest
             cflags: -O2 -g -Wall -Wno-logical-op-parentheses
 
+          - name: macOS arm64
+            os: macos-14
+            cflags: -O2 -g -Wall -Wno-logical-op-parentheses
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Github just [announced the availability of a Mac M1 runner](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available), and since this is one of our targets, we will use it in a test.