### PR TITLE
Provide compatibility link to mkfloat.csh

### DIFF
--- a/unix/hlib/mkfloat.csh
+++ b/unix/hlib/mkfloat.csh
@@ -1,0 +1,1 @@
+mkfloat

--- a/unix/hlib/mkfloat.sh
+++ b/unix/hlib/mkfloat.sh
@@ -1,0 +1,1 @@
+mkfloat


### PR DESCRIPTION
Traditionally, the "mkfloat" script was a C shell, which was indicated by its suffix. This was converted to a POSIX shell script long time ago, without suffix.

The script however may be run during the build of external packages, and they may refer to `mkfloat.csh`. To allow an easier migration, we provide a compatiblity link here.

Although there is no known package that uses `mkfloat.sh`, we also provide it here.