### PR TITLE
Protoize CL and ECL

### DIFF
--- a/pkg/cl/binop.c
+++ b/pkg/cl/binop.c
@@ -326,7 +326,7 @@ binop (int opcode)
 		    first_char = o1.o_val.v_s[0];
 		    
 		    /* Null patterns match any string. */
-		    if (first_char == NULL) {
+		    if (first_char == '\0') {
 			result.o_val.v_i = 1;
 			result.o_type = OT_INT;
 			goto pushresult;
@@ -368,7 +368,7 @@ binop (int opcode)
 		    first_char = o1.o_val.v_s[0];
 		    
 		    /* Null patterns match any string. */
-		    if (first_char == NULL) {
+		    if (first_char == '\0') {
 			result.o_val.v_i = 1;
 			result.o_type = OT_INT;
 			goto pushresult;

--- a/pkg/cl/builtin.c
+++ b/pkg/cl/builtin.c
@@ -1900,7 +1900,6 @@ cledit (void)
 	char	oscmd[SZ_LINE], os_filelist[SZ_LINE];
 	char	osfn[SZ_PATHNAME];
 	struct	operand o;
-	char	*envget();
 	int	n;
 
 	pfp = newtask->t_pfp;

--- a/pkg/cl/builtin.c
+++ b/pkg/cl/builtin.c
@@ -2100,8 +2100,8 @@ setbuiltins (register struct package *pkp)
 {
 	/* Debugging functions are in debug.c.
 	 */
-	extern void d_f(), d_l(), d_d(), d_off(), d_on(), d_p(), d_t();
-	extern void pr_listcache();
+	extern void d_f(void), d_l(void), d_d(void), d_off(void), d_on(void), d_p(void), d_t(void);
+	extern void pr_listcache(FILE *fp);
 
 	static struct builtin {
 		char	*b_name;

--- a/pkg/cl/builtin.c
+++ b/pkg/cl/builtin.c
@@ -266,7 +266,7 @@ cl_locate (char *task_spec, int first_only)
 	    }
 	}
 
-	if (found == NULL)
+	if (found == 0)
 	    oprintf ("%s: task not found.\n", task_spec);
 	else
 	    oprintf ("\n");

--- a/pkg/cl/debug.c
+++ b/pkg/cl/debug.c
@@ -32,7 +32,7 @@
 extern	char *nullstr;
 extern	int cldebug;
 extern	int cltrace;
-static	void dd_f();
+static	void dd_f(char *msg, char *fname);
 
 
 /* D_STACK -- Go through the instruction stack, starting at locpc, printing

--- a/pkg/cl/edcap.c
+++ b/pkg/cl/edcap.c
@@ -41,7 +41,7 @@
  */
 
 static	char ed_editorcmd[SZ_LINE+1];
-static	void map_escapes();
+static	void map_escapes(char *input, char *output);
 
 
 /* EDTINIT -- Initialize the editor.

--- a/pkg/cl/eparam.c
+++ b/pkg/cl/eparam.c
@@ -452,7 +452,7 @@ e_repaint (void)
 		 * label columns (if desired).
 		 */
 		p = parmlist[keyid]->p_prompt;
-		if (p == NULL || *p == NULL)
+		if (p == NULL || *p == '\0')
 		    p = static_prompt;
 
 		/* e_indent_prompt (p, promptbuf, startcol); */

--- a/pkg/cl/eparam.c
+++ b/pkg/cl/eparam.c
@@ -1141,7 +1141,7 @@ editstring (
   int	eparam 				/* flag to indicate eparam or ehis  */
 )
 {
-	char	oldchar;		/* save old character after delete  */
+	char	oldchar = '\0';		/* save old character after delete  */
 	char    oldword[G_MAXSTRING];   /* save the deleted word            */
 	char    oldline[G_MAXSTRING];	/* save the deleted line            */
 	char	tempstr[G_MAXSTRING];

--- a/pkg/cl/eparam.c
+++ b/pkg/cl/eparam.c
@@ -92,7 +92,7 @@ int	eh_standout = YES;		/* ehist default for standout         */
 int	eh_bol      = NO;		/* start ehist at beginning of line   */
 int	eh_verify   = NO;		/* use ehist with history meta-chars  */
 
-char	*e_tonextword(), *e_toprevword();
+char	*e_tonextword(register char *ip), *e_toprevword(char *ip, char *string);
 
 int eparam (struct ep_context *cx, int *update, int *nextcmd, char *nextpset);
 
@@ -705,7 +705,7 @@ e_check_vals (
   char    *string
 )
 {
-	char *gquery();		/* declare gquery as returning a pointer  */
+	char *gquery(struct param *pp, char *string);		/* declare gquery as returning a pointer  */
 	char *errstr;		/* pointer to the error string (or 0)     */
 	char message[SZ_LINE+1];/* error message string			  */
 	int  badnews;		/* a flag if an array element is in error */
@@ -722,7 +722,7 @@ e_check_vals (
 
 	if (isarray) {
 	    char    outstring[G_MAXSTRING];
-	    char    *in, *e_getfield();
+	    char    *in, *e_getfield(register char *ip, char *outstr, int maxch);
 	    int	    first, nelem, flen;
 	    
 	    /* Get the length of the first dimension, and the starting point.

--- a/pkg/cl/eparam.h
+++ b/pkg/cl/eparam.h
@@ -104,5 +104,5 @@ extern struct edit_commands command[MAX_COMMANDS];
 extern char *cmdnames[MAX_COMMANDS];
 extern int numcommands;
 
-char	*enumin(), *minmax();
-char	*host_editor();
+char	*enumin(register struct param *pp), *minmax(register struct param *pp);
+char	*host_editor(char *editor);

--- a/pkg/cl/exec.c
+++ b/pkg/cl/exec.c
@@ -255,7 +255,6 @@ execnewtask (void)
 	static	struct pfile *pfp;
 
 	struct	param *pp;
-	FILE	*fopen();
 
 	if (newtask == NULL)
 	    /* if this ever happens, i don't want to know about it. */
@@ -684,7 +683,6 @@ findexe (
 	char	root[SZ_FNAME+1], root_path[SZ_PATHNAME+1];
 	char	bindir[SZ_FNAME+1], *ip = NULL, *arch = NULL;
 	char	bin_root[SZ_PATHNAME+1];
-	char   *envget();
 
 
 	memset (root, 0, SZ_FNAME);

--- a/pkg/cl/gram.c
+++ b/pkg/cl/gram.c
@@ -40,7 +40,6 @@ extern	int cldebug;
 
 extern	int inarglist;		/* set by parser when in argument list	*/
 extern	int parenlevel;		/* nesting level of parens		*/
-extern	int get_nscanval();
 int	pipetable[MAXPIPES];	/* for maintaining pipe temp files	*/
 int	nextpipe = 0;
 
@@ -862,7 +861,6 @@ char *
 addpipe (void)
 {
 	static	int pipecode = 0;
-	char	*pipefile();
 
 	if (pipecode == 0)
 	    pipecode = c_getpid();
@@ -903,8 +901,6 @@ addpipe (void)
 char *
 getpipe (void)
 {
-	char	*pipefile();
-
 	if (nextpipe == 0)
 	    cl_error (E_IERR, "Pipestack underflow");
 	return (pipefile (pipetable[nextpipe-1]));
@@ -919,7 +915,6 @@ void
 delpipes (register int npipes)
 {
 	register int pipe;
-	char	*pipefile();
 
 	if (npipes == 0) {
 	    while (nextpipe > 0)
@@ -942,7 +937,6 @@ pipefile (int pipecode)
 {
 	static	char fname[SZ_PIPEFILENAME+1];
 	char	*dir;
-	char	*envget();
 
 	/* Put pipefiles in 'pipes' or 'uparm' if defined, else use tmp.  Do
 	 * not put pipe files in current directory or pipe commands will fail

--- a/pkg/cl/grammar.h
+++ b/pkg/cl/grammar.h
@@ -58,4 +58,4 @@ extern int parse_state;			/* What are we parsing?	*/
 extern int proc_script;			/* In a procedure script? */
 extern struct pfile *parse_pfile;	/* Where parsed params are added. */
 
-char *today();				/* returns pointer to todays date */
+char *today(void);				/* returns pointer to todays date */

--- a/pkg/cl/grammar.y
+++ b/pkg/cl/grammar.y
@@ -99,9 +99,6 @@ extern	char	cmdblk[SZ_CMDBLK+1];	/* Command buffer in history.c */
 extern	char	*ip_cmdblk;		/* Pointer to current char in command.*/
 extern	char	*err_cmdblk;		/* ip_cmdblk when error detected. */
 
-struct	param *initparam();
-struct	label *getlabel(), *setlabel();
-
 /* arbitrary large number for bracelevel in a procedure script 
  */
 #define MAX_ERR    10

--- a/pkg/cl/grammar.y
+++ b/pkg/cl/grammar.y
@@ -1189,7 +1189,7 @@ arg	:	/* nothing - compile a null posargset to bump nargs */
 			     */
 			    breakout (stkop($1)->o_val.v_s, &pk, &t, &p, &f);
 			    pfp = currentask->t_pfp;
-			    if (*pk == NULL && *t == NULL &&
+			    if (*pk == '\0' && *t == '\0' &&
 				pfp && paramfind(pfp,p,0,1)) {
 
 				sprintf (pname, "%s.%s",

--- a/pkg/cl/history.c
+++ b/pkg/cl/history.c
@@ -769,7 +769,7 @@ int
 get_history (int record, char *command, int maxch)
 {
 	char	*recptr;
-	char	*find_history();
+	char	*find_history(int record);
 
 	if ((recptr = find_history (record)) == NULL) {
 	    *command = EOS;
@@ -884,7 +884,7 @@ show_history (FILE *fp, int max_commands)
 	char	*recptr[MAX_SHOWHIST];
 	char	cmdblk[SZ_CMDBLK+1];
 	int	record;
-	char	*find_history();
+	char	*find_history(int record);
 
 	/* Flush the "history" command so that it shows up in the history. */
 	yy_startblock (LOG);
@@ -1082,7 +1082,7 @@ putlog (
 	register char	*ip, *op, *otop;
 	register int	n;
 	char	msg[SZ_LOGBUF], job[5];
-	char	*pkg, *tname, *today();
+	char	*pkg, *tname, *today(void);
 	extern  int  bkgno;			/* job number if bkg job */
 
 	if (!keeplog())

--- a/pkg/cl/lexicon.c
+++ b/pkg/cl/lexicon.c
@@ -148,7 +148,7 @@ lexicon (void)
 	char	*bkgerr = "ERROR: cannot submit background job inside {}\n";
 	register int	ch, cch;
 	register int	token;
-	int	stringtok, identifier, setlevel;
+	int	stringtok = 1, identifier = 1, setlevel = 0;
 	int	clswitch;
 	char	*op;
 

--- a/pkg/cl/lexicon.c
+++ b/pkg/cl/lexicon.c
@@ -646,7 +646,7 @@ eatwhite_:
 /* LEXINIT -- Initialize the internal state variables of the lexical analyzer,
  * e.g. when processing is interrupted by an interrupt.
  */
-int 
+void
 lexinit (void)
 {
 	if (lexmodes() && !lex_cpumodeset (currentask->t_in)) {

--- a/pkg/cl/main.c
+++ b/pkg/cl/main.c
@@ -89,7 +89,7 @@ static void login(char *cmd), logout(void);
 static void startup(void), shutdown(void);
 
 static void onint (int *vex, int (**next_handler)(void));
-extern int yyparse();
+extern int yyparse(void);
 
 
 /* C_MAIN -- Called by the SPP procedure in cl.x to fire up the CL.

--- a/pkg/cl/main.c
+++ b/pkg/cl/main.c
@@ -84,9 +84,9 @@ long	cpustart, clkstart;	/* starting cpu, clock times if bkg	*/
 int	logout_status = 0;	/* optional status arg to logout()	*/
 
 
-static void execute();
-static void login(), logout();
-static void startup(), shutdown();
+static void execute(int mode);
+static void login(char *cmd), logout(void);
+static void startup(void), shutdown(void);
 
 static void onint (int *vex, int (**next_handler)(void));
 extern int yyparse();
@@ -252,7 +252,7 @@ execute (int mode)
 {
 	int	parsestat;
 	XINT	old_parhead;
-	char	*curcmd();
+	char	*curcmd(void);
 
 	alldone = 0;
 	gologout = 0;

--- a/pkg/cl/mem.h
+++ b/pkg/cl/mem.h
@@ -105,5 +105,5 @@ extern XINT pc;			/* program counter			*/
  */
 #define	coderef(x)	((struct codeentry *)&stack[x])
 
-extern char *memneed();		/* insures enough core, returns start	*/
-extern char *comdstr();		/* compile string at topd, return start	*/
+extern char *memneed(int incr);		/* insures enough core, returns start	*/
+extern char *comdstr(char *s);		/* compile string at topd, return start	*/

--- a/pkg/cl/modes.c
+++ b/pkg/cl/modes.c
@@ -751,7 +751,7 @@ bkg_query (
 {
 	char	bqfile[SZ_PATHNAME], qrfile[SZ_PATHNAME];
 	int	waitime, delay;
-	char	*envget(), *fgets_status;
+	char	*fgets_status;
 	FILE	*fp, *in;
 
 	if (notify())
@@ -866,7 +866,6 @@ void
 get_bkgqfiles (int bkgno, int pid, char *bkg_query_file, char *query_response_file)
 {
 	int	filecode;
-	char	*envget();
 
 	if (envget (UPARM) == NULL)
 	    cl_error (E_UERR,

--- a/pkg/cl/modes.c
+++ b/pkg/cl/modes.c
@@ -268,8 +268,8 @@ query (struct param *pp)
 	char	buf[SZ_PROMPTBUF+1];
 	struct	operand o;
 	int	bastype, batch, arrflag, offset=0, n_ele, max_ele, fd;
-	char	*nlp, *nextstr();
-	char	*bkg_query(), *query_status;
+	char	*nlp, *nextstr(char **pbuf, FILE *fp);
+	char	*bkg_query(char *obuf, int maxch, register struct param *pp), *query_status;
 	char	*abuf;
 
 	bastype = pp->p_type & OT_BASIC;
@@ -537,7 +537,7 @@ testval:
 char *
 nextstr (char **pbuf, FILE *fp)
 {
-	char	*p, *nxtchr();
+	char	*p, *nxtchr(char *p, FILE *fp);
 	static	char	tbuf[SZ_LINE];
 	char	quote;
 	int	cnt;

--- a/pkg/cl/opcodes.c
+++ b/pkg/cl/opcodes.c
@@ -39,8 +39,8 @@
 extern	int cldebug;
 extern	char *nullstr;
 int	binpipe;			/* last pipe binary or text ? */
-char	*comdstr();
-extern	struct param *ppfind();		/* search task psets for param */
+char	*comdstr(char *s);
+extern	struct param *ppfind(struct pfile *pfp, char *tn, char *pn, int pos, int abbrev);		/* search task psets for param */
 
 void
 o_undefined (memel *argp)
@@ -973,7 +973,7 @@ o_doaddpipe (memel *argp)
 	char	*ltname;
 	struct	operand	o;
 	struct	ltask *ltp;
-	char	*addpipe();
+	char	*addpipe(void);
 
 	/* ADDPIPE is called immediately before REDIR and before EXEC so we
 	 * do not have to worry about storing the pipefile name in the dict.
@@ -1005,7 +1005,7 @@ o_dogetpipe (
 )
 {
 	struct	operand o;
-	char	*getpipe(), *comdstr();
+	char	*getpipe(void), *comdstr(char *s);
 
 	/* GETPIPE is called immediately before REDIRIN and before EXEC so we
 	 * do not have to worry about storing the pipefile name in the dict.

--- a/pkg/cl/opcodes.h
+++ b/pkg/cl/opcodes.h
@@ -16,7 +16,7 @@ struct codeentry {
 	memel c_args;		/* addr of this is addr of first arg	*/
 };
 
-extern void (*opcodetbl[])();
+extern void (*opcodetbl[])(memel *arg);
 
 /* manifest constant opcodes used in c_opcode.
  * value is index into opcodetbl[].

--- a/pkg/cl/operand.h
+++ b/pkg/cl/operand.h
@@ -161,7 +161,6 @@ struct arr_desc {
 
 extern char *truestr, *falsestr;
 
-struct operand popop(), pushop();
-struct operand makeop();
-struct operand readlist();	/* read and return operand from list	*/
-struct operand sexa();		/* convert n:n:n string to sexagesimal	*/
+struct operand popop(void), pushop(struct operand *op);
+struct operand makeop(char *str, int type);
+struct operand sexa(char *);		/* convert n:n:n string to sexagesimal	*/

--- a/pkg/cl/param.c
+++ b/pkg/cl/param.c
@@ -706,7 +706,7 @@ paramsrch (char *pkname, char *ltname, char *pname)
 {
 	register struct param *pp;
 	struct	pfile *pfp;
-	struct	param *lookup_param();
+	struct	param *lookup_param(char *pkname, char *ltname, char *pname);
 
 	/* First search for a regular parameter.  If this fails then we 
 	 * handle the case when currentask has no pfile.

--- a/pkg/cl/param.h
+++ b/pkg/cl/param.h
@@ -200,21 +200,21 @@ struct pfile {
 #define	V_FILE		9
 
 
-char	*nextfield();		/* cracks next pfile line field		*/
-char	*makelower();		/* upper to lower, in place and return	*/
+char	*nextfield(char **pp, FILE *fp);		/* cracks next pfile line field		*/
+char	*makelower(register char *cp);		/* upper to lower, in place and return	*/
 
-struct	param *paramfind();	/* searches for a param on a given pfile*/
-struct	param *paramsrch();	/* search, make sure param is there	*/
-struct	param *lookup_param();	/* search standard path for a param	*/
-struct	param *newparam();	/* allocate and link a new param	*/
-struct	param *addparam();	/* make a new param off given pfile	*/
-struct	param *newfakeparam();	/* add a fake param to pfile		*/
-struct	pfile *pfilesrch();	/* read named pfile or ltask pfile	*/
-struct	pfile *pfileload();	/* load pfile for ltask into memory	*/
-struct	pfile *pfileread();	/* read and make params from a pfile	*/
-struct	pfile *pfilefind();	/* look for pfile with given name	*/
-struct	pfile *newpfile();	/* add a new pfile off parhead		*/
-struct	pfile *pfilecopy();	/* make an in-core copy of a pfile	*/
+struct	param *paramfind(struct pfile *pfp, char *pname, int pos, int exact);	/* searches for a param on a given pfile*/
+struct	param *paramsrch(char *pkname, char *ltname, char *pname);	/* search, make sure param is there	*/
+struct	param *lookup_param(char *pkname, char *ltname, char *pname);	/* search standard path for a param	*/
+struct	param *newparam(struct pfile *pfp);	/* allocate and link a new param	*/
+struct	param *addparam(struct pfile *pfp, char *buf, FILE *fp);	/* make a new param off given pfile	*/
+struct	param *newfakeparam(struct pfile *pfp, char *name, int pos, int type, int string_len);	/* add a fake param to pfile		*/
+struct	pfile *pfilesrch(char *pfilepath);	/* read named pfile or ltask pfile	*/
+struct	pfile *pfileload(register struct ltask *ltp);	/* load pfile for ltask into memory	*/
+struct	pfile *pfileread(struct ltask *ltp, char *pfilename, int checkmode);	/* read and make params from a pfile	*/
+struct	pfile *pfilefind(register struct ltask *ltp);	/* look for pfile with given name	*/
+struct	pfile *newpfile(struct ltask *ltp);	/* add a new pfile off parhead		*/
+struct	pfile *pfilecopy(register struct pfile *pfp);	/* make an in-core copy of a pfile	*/
 
-int	defpar();		/* determine whether param exists	*/
-int	defvar();		/* determine whether envvar exists	*/
+int	defpar(char *param_spec);		/* determine whether param exists	*/
+int	defvar(char *envvar);		/* determine whether envvar exists	*/

--- a/pkg/cl/pfiles.c
+++ b/pkg/cl/pfiles.c
@@ -908,10 +908,10 @@ pfilecopy (register struct pfile *pfp)
 
 		    p = parrd->a_ptr.a_s;
 		    q = qarrd->a_ptr.a_s;
-		    for (d=0;  d < size_arr;  d++) {
+		    for (d=0;  d < size_arr; d++, q++, p++) {
 			*q = memneed (btoi(len));
-			strncpy (*q++, *p++, len-1);
-			*(q+len-1) = '\0' ;
+			strncpy (*q, *p, len-1);
+			(*q)[len-1] = '\0';
 		    }
 		}
 

--- a/pkg/cl/pfiles.c
+++ b/pkg/cl/pfiles.c
@@ -511,7 +511,7 @@ pfileread (
 		goto error_;
 
 	} else if (procscript (fp)) {
-	    extern int yyparse ();
+	    extern int yyparse (void);
 
 	    /* Parse the declarations section of a procedure script.
 	     * The procscript() call leaves us positioned to the procedure

--- a/pkg/cl/pfiles.c
+++ b/pkg/cl/pfiles.c
@@ -30,8 +30,8 @@ extern	char *nullstr;
 extern	char *indefstr, *indeflc;
 extern	FILE *yyin;
 char	*uparmdir = UPARM;
-long	filetime();
-static	void mapname();
+long	filetime(char *fname, char *timecode);
+static	void mapname(char *in, char *out, int maxlen);
 
 
 /* NEWPFILE -- Allocate a new pfile on the dictionary and link in at parhead.

--- a/pkg/cl/prcache.c
+++ b/pkg/cl/prcache.c
@@ -88,7 +88,7 @@ int	pr_pno = 1;			/* incremented for each connect	*/
 int	sz_prcache = 2;			/* nprocess slots in cache	*/
 struct	process pr_cache[MAXSUBPROC];
 struct	process *pr_head = NULL, *pr_tail = NULL;
-extern	char *findexe();
+extern	char *findexe(struct package *pkg, char *pkg_path);
 
 static void pr_pdisconnect (struct process *pr);
 static void pr_tohead (struct process *pr);
@@ -193,7 +193,7 @@ pr_pconnect (
 )
 {
 	struct process *pr;
-	struct	process *pr_findproc();
+	struct	process *pr_findproc(char *process);
 	struct	_finfo fi;
 	int	fd_in, fd_out;
 

--- a/pkg/cl/prcache.c
+++ b/pkg/cl/prcache.c
@@ -127,7 +127,7 @@ pr_connect (
 	register int	pid;
 
 	/* Connect subprocess. */
-	if ((pid = pr_pconnect (process, in, out)) == NULL)
+	if ((pid = pr_pconnect (process, in, out)) == 0)
 	    c_erract (EA_ERROR);
 
 
@@ -225,7 +225,7 @@ pr_pconnect (
 	    /* Get process slot. */
 	    for (pr=pr_tail;  pr != NULL;  pr=pr->pr_up)
 		if (!pr_busy(pr)) {
-		    if (pr->pr_pid != NULL)
+		    if (pr->pr_pid != 0)
 			pr_pdisconnect (pr);
 		    break;
 		}
@@ -239,7 +239,7 @@ pr_pconnect (
 	    if (cltrace)
 		eprintf ("\t----- connect to %s -----\n", process);
 	    intr_disable();
-	    if ((pr->pr_pid = c_propen (process, &fd_in, &fd_out)) == NULL) {
+	    if ((pr->pr_pid = c_propen (process, &fd_in, &fd_out)) == 0) {
 		intr_enable();
 		return (0);
 	    }

--- a/pkg/cl/proto.h
+++ b/pkg/cl/proto.h
@@ -259,7 +259,7 @@ extern void putlog(struct task *tp, char *usermsg);
 /* lexicon.c */
 extern int yylex(void);
 extern int lexicon(void);
-extern int lexinit(void);
+extern void lexinit(void);
 /* lists.c */
 extern struct operand readlist(struct param *pp);
 extern void closelist(register struct param *pp);

--- a/pkg/cl/task.h
+++ b/pkg/cl/task.h
@@ -203,8 +203,8 @@ struct package {
 #define	LTASKSIZ	btoi (sizeof (struct ltask))
 #define	PACKAGESIZ	btoi (sizeof (struct package))
 
-struct	package *newpac(), *pacfind();
-struct	ltask *addltask(), *newltask(), *ltaskfind(), *cmdsrch();
-struct	ltask *ltasksrch(), *_ltasksrch();
-struct	task *pushtask(), *poptask();
-int	deftask(), defpac();
+struct	package *newpac(char *name, char *bin), *pacfind(char *name);
+struct	ltask *addltask(struct package *pkp, char *ptname, char *ltname, int redef), *newltask(register struct package *pkp, char *lname, char *pname, struct ltask *oldltp), *ltaskfind(struct package *pkp, char *name, int enable_abbreviations), *cmdsrch(char *pkname, char *ltname);
+struct	ltask *ltasksrch(char *pkname, char *ltname), *_ltasksrch(char *pkname, char *ltname, struct package **o_pkp);
+struct	task *pushtask(void), *poptask(void);
+int	deftask(char *task_spec), defpac(char *pkname);

--- a/pkg/ecl/binop.c
+++ b/pkg/ecl/binop.c
@@ -371,7 +371,7 @@ binop (int opcode)
 		    first_char = o1.o_val.v_s[0];
 		    
 		    /* Null patterns match any string. */
-		    if (first_char == NULL) {
+		    if (first_char == '\0') {
 			result.o_val.v_i = 1;
 			result.o_type = OT_INT;
 			goto pushresult;
@@ -413,7 +413,7 @@ binop (int opcode)
 		    first_char = o1.o_val.v_s[0];
 		    
 		    /* Null patterns match any string. */
-		    if (first_char == NULL) {
+		    if (first_char == '\0') {
 			result.o_val.v_i = 1;
 			result.o_type = OT_INT;
 			goto pushresult;

--- a/pkg/ecl/builtin.c
+++ b/pkg/ecl/builtin.c
@@ -270,7 +270,7 @@ cl_locate (char *task_spec, int first_only)
 	    }
 	}
 
-	if (found == NULL)
+	if (found == 0)
 	    oprintf ("%s: task not found.\n", task_spec);
 	else
 	    oprintf ("\n");

--- a/pkg/ecl/builtin.c
+++ b/pkg/ecl/builtin.c
@@ -2013,7 +2013,7 @@ cledit (void)
 	char	oscmd[SZ_LINE], os_filelist[SZ_LINE];
 	char	osfn[SZ_PATHNAME];
 	struct	operand o;
-	char	*envget();
+	char	*envget(char *name);
 	int	n;
 
 	pfp = newtask->t_pfp;

--- a/pkg/ecl/builtin.c
+++ b/pkg/ecl/builtin.c
@@ -2292,9 +2292,9 @@ setbuiltins (register struct package *pkp)
 {
 	/* Debugging functions are in debug.c.
 	 */
-	extern void d_f(), d_l(), d_d(), d_off(), d_on(), d_p(), d_t();
-	extern void d_asmark(), d_assemble(), d_prof(), d_trace();
-	extern void pr_listcache();
+	extern void d_f(void), d_l(void), d_d(void), d_off(void), d_on(void), d_p(void), d_t(void);
+	extern void d_asmark(void), d_assemble(void), d_prof(void), d_trace(int value);
+	extern void pr_listcache(FILE *fp);
 
 	static struct builtin {
 		char	*b_name;

--- a/pkg/ecl/debug.c
+++ b/pkg/ecl/debug.c
@@ -32,7 +32,7 @@
 extern	char *nullstr;
 extern	int cldebug;
 extern	int cltrace;
-static	void dd_f();
+static	void dd_f(char *msg, char *fname);
 
 
 /* D_STACK -- Go through the instruction stack, starting at locpc, printing

--- a/pkg/ecl/decl.c
+++ b/pkg/ecl/decl.c
@@ -78,7 +78,7 @@ getlimits (
 int
 get_dim (char *pname)
 {
-	struct param *pp, *lookup_param();
+	struct param *pp;
 	char	*pk, *t, *p, *f;
 	int 	dim;
 

--- a/pkg/ecl/edcap.c
+++ b/pkg/ecl/edcap.c
@@ -41,7 +41,7 @@
  */
 
 static	char ed_editorcmd[SZ_LINE+1];
-static	void map_escapes();
+static	void map_escapes(char *input, char *output);
 
 
 /* EDTINIT -- Initialize the editor.

--- a/pkg/ecl/eparam.c
+++ b/pkg/ecl/eparam.c
@@ -98,7 +98,7 @@ int	eh_readline 	= YES;		/* use readline() for terminal input  */
 #endif
 int	eh_longprompt 	= YES;		/* print full package name as prompt  */
 
-char	*e_tonextword(), *e_toprevword();
+char	*e_tonextword(register char *ip), *e_toprevword(char *ip, char *string);
 
 char	epar_cmdbuf[SZ_LINE];
 
@@ -716,7 +716,7 @@ e_check_vals (
   char    *string
 )
 {
-	char *gquery();		/* declare gquery as returning a pointer  */
+	char *gquery(struct param *pp, char *string);		/* declare gquery as returning a pointer  */
 	char *errstr;		/* pointer to the error string (or 0)     */
 	char message[SZ_LINE+1];/* error message string			  */
 	int  badnews;		/* a flag if an array element is in error */
@@ -733,7 +733,7 @@ e_check_vals (
 
 	if (isarray) {
 	    char    outstring[G_MAXSTRING];
-	    char    *in, *e_getfield();
+	    char    *in, *e_getfield(register char *ip, char *outstr, int maxch);
 	    int	    first, nelem, flen;
 	    
 	    /* Get the length of the first dimension, and the starting point.

--- a/pkg/ecl/eparam.c
+++ b/pkg/ecl/eparam.c
@@ -463,7 +463,7 @@ e_repaint (void)
 		 * label columns (if desired).
 		 */
 		p = parmlist[keyid]->p_prompt;
-		if (p == NULL || *p == NULL)
+		if (p == NULL || *p == '\0')
 		    p = static_prompt;
 
 		/* e_indent_prompt (p, promptbuf, startcol); */

--- a/pkg/ecl/eparam.c
+++ b/pkg/ecl/eparam.c
@@ -1152,7 +1152,7 @@ editstring (
   int	eparam 				/* flag to indicate eparam or ehis  */
 )
 {
-	char	oldchar;		/* save old character after delete  */
+	char	oldchar = '\0';		/* save old character after delete  */
 	char    oldword[G_MAXSTRING];   /* save the deleted word            */
 	char    oldline[G_MAXSTRING];	/* save the deleted line            */
 	char	tempstr[G_MAXSTRING];

--- a/pkg/ecl/eparam.h
+++ b/pkg/ecl/eparam.h
@@ -104,5 +104,5 @@ extern struct edit_commands command[MAX_COMMANDS];
 extern char *cmdnames[MAX_COMMANDS];
 extern int numcommands;
 
-char	*enumin(), *minmax();
-char	*host_editor();
+char	*enumin(register struct param *pp), *minmax(register struct param *pp);
+char	*host_editor(char *editor);

--- a/pkg/ecl/errs.c
+++ b/pkg/ecl/errs.c
@@ -348,7 +348,7 @@ cl_error (int errtype, char *diagstr, ...)
 void 
 erract_init (void)
 {
-	char *act, *envget();
+	char *act;
 	char opt[SZ_LINE];
 
 	/* Parse the erract string to pick up new options.

--- a/pkg/ecl/exec.c
+++ b/pkg/ecl/exec.c
@@ -297,7 +297,6 @@ execnewtask (void)
 	static	struct pfile *pfp;
 
 	struct	param *pp;
-	FILE	*fopen();
 
 	if (newtask == NULL)
 	    /* if this ever happens, i don't want to know about it. */
@@ -730,7 +729,6 @@ findexe (
 	char	root[SZ_FNAME+1], root_path[SZ_PATHNAME+1];
 	char	bindir[SZ_FNAME+1], *ip = NULL, *arch = NULL;
 	char	bin_root[SZ_PATHNAME+1];
-	char   *envget();
 
 
 	memset (root, 0, SZ_FNAME);

--- a/pkg/ecl/gram.c
+++ b/pkg/ecl/gram.c
@@ -44,7 +44,6 @@ extern	int cldebug;
 
 extern	int inarglist;		/* set by parser when in argument list	*/
 extern	int parenlevel;		/* nesting level of parens		*/
-extern	int get_nscanval();
 extern	int do_error;		/* runtime error handling		*/
 int	pipetable[MAXPIPES];	/* for maintaining pipe temp files	*/
 int	nextpipe = 0;
@@ -1055,7 +1054,6 @@ char *
 addpipe (void)
 {
 	static	int pipecode = 0;
-	char	*pipefile();
 
 	if (pipecode == 0)
 	    pipecode = c_getpid();
@@ -1096,8 +1094,6 @@ addpipe (void)
 char *
 getpipe (void)
 {
-	char	*pipefile();
-
 	if (nextpipe == 0)
 	    cl_error (E_IERR, "Pipestack underflow");
 	return (pipefile (pipetable[nextpipe-1]));
@@ -1112,7 +1108,6 @@ void
 delpipes (register int npipes)
 {
 	register int pipe;
-	char	*pipefile();
 
 	if (npipes == 0) {
 	    while (nextpipe > 0)
@@ -1135,7 +1130,6 @@ pipefile (int pipecode)
 {
 	static	char fname[SZ_PIPEFILENAME+1];
 	char	*dir;
-	char	*envget();
 
 	/* Put pipefiles in 'pipes' or 'uparm' if defined, else use tmp.  Do
 	 * not put pipe files in current directory or pipe commands will fail

--- a/pkg/ecl/grammar.h
+++ b/pkg/ecl/grammar.h
@@ -58,4 +58,4 @@ extern int parse_state;			/* What are we parsing?	*/
 extern int proc_script;			/* In a procedure script? */
 extern struct pfile *parse_pfile;	/* Where parsed params are added. */
 
-char *today();				/* returns pointer to todays date */
+char *today(void);				/* returns pointer to todays date */

--- a/pkg/ecl/grammar.y
+++ b/pkg/ecl/grammar.y
@@ -105,9 +105,6 @@ extern	char	cmdblk[SZ_CMDBLK+1];	/* Command buffer in history.c */
 extern	char	*ip_cmdblk;		/* Pointer to current char in command.*/
 extern	char	*err_cmdblk;		/* ip_cmdblk when error detected. */
 
-struct	param *initparam();
-struct	label *getlabel(), *setlabel();
-
 /* arbitrary large number for bracelevel in a procedure script 
  */
 #define MAX_ERR    10

--- a/pkg/ecl/grammar.y
+++ b/pkg/ecl/grammar.y
@@ -1142,8 +1142,6 @@ command	:	tasknam {
 		} BARG {
 		    inarglist = 1;
 		} args EARG {
-		    extern char *onerr_handler;
-
 		    inarglist = 0;
 		    parenlevel = 0;
 		    scanstmt = 0;

--- a/pkg/ecl/grammar.y
+++ b/pkg/ecl/grammar.y
@@ -1204,7 +1204,7 @@ arg	:	/* nothing - compile a null posargset to bump nargs */
 			     */
 			    breakout (stkop($1)->o_val.v_s, &pk, &t, &p, &f);
 			    pfp = currentask->t_pfp;
-			    if (*pk == NULL && *t == NULL &&
+			    if (*pk == '\0' && *t == '\0' &&
 				pfp && paramfind(pfp,p,0,1)) {
 
 				sprintf (pname, "%s.%s",

--- a/pkg/ecl/history.c
+++ b/pkg/ecl/history.c
@@ -822,7 +822,7 @@ int
 get_history (int record, char *command, int maxch)
 {
 	char	*recptr;
-	char	*find_history();
+	char	*find_history(int record);
 
 	if ((recptr = find_history (record)) == NULL) {
 	    *command = EOS;
@@ -937,7 +937,7 @@ show_history (FILE *fp, int max_commands)
 	char	*recptr[MAX_SHOWHIST];
 	char	cmdblk[SZ_CMDBLK+1];
 	int	record;
-	char	*find_history();
+	char	*find_history(int record);
 
 	/* Flush the "history" command so that it shows up in the history. */
 	yy_startblock (LOG);
@@ -1170,7 +1170,7 @@ putlog (
 	register char	*ip, *op, *otop;
 	register int	n;
 	char	msg[SZ_LOGBUF], job[5];
-	char	*pkg, *tname, *today();
+	char	*pkg, *tname, *today(void);
 	extern  int  bkgno;			/* job number if bkg job */
 
 	if (!keeplog())

--- a/pkg/ecl/lexicon.c
+++ b/pkg/ecl/lexicon.c
@@ -650,7 +650,7 @@ eatwhite_:
 /* LEXINIT -- Initialize the internal state variables of the lexical analyzer,
  * e.g. when processing is interrupted by an interrupt.
  */
-int 
+void
 lexinit (void)
 {
 	if (lexmodes() && !lex_cpumodeset (currentask->t_in)) {

--- a/pkg/ecl/lexicon.c
+++ b/pkg/ecl/lexicon.c
@@ -148,7 +148,7 @@ lexicon (void)
 	char	*bkgerr = "ERROR: cannot submit background job inside {}\n";
 	register int	ch, cch;
 	register int	token;
-	int	stringtok, identifier, setlevel;
+	int	stringtok = 1, identifier = 1, setlevel = 0;
 	int	clswitch;
 	char	*op;
 

--- a/pkg/ecl/main.c
+++ b/pkg/ecl/main.c
@@ -86,9 +86,9 @@ long	cpustart, clkstart;	/* starting cpu, clock times if bkg	*/
 int	logout_status = 0;	/* optional status arg to logout()	*/
 
 
-static void execute();
-static void login(), logout();
-static void startup(), shutdown();
+static void execute(int mode);
+static void login(char *cmd), logout(void);
+static void startup(void), shutdown(void);
 static  char *file_concat (char  *in1, char  *in2);
 
 static void onint (int *vex, int (**next_handler)(void));
@@ -263,7 +263,7 @@ execute (int mode)
 {
 	int	parsestat;
 	XINT	old_parhead;
-	char	*curcmd();
+	char	*curcmd(void);
 
 	alldone = 0;
 	gologout = 0;

--- a/pkg/ecl/main.c
+++ b/pkg/ecl/main.c
@@ -92,7 +92,7 @@ static void startup(void), shutdown(void);
 static  char *file_concat (char  *in1, char  *in2);
 
 static void onint (int *vex, int (**next_handler)(void));
-extern int yyparse();
+extern int yyparse(void);
 
 static  char *tmpfile = NULL;
 extern	char epar_cmdbuf[];

--- a/pkg/ecl/mem.h
+++ b/pkg/ecl/mem.h
@@ -105,5 +105,5 @@ extern XINT pc;			/* program counter			*/
  */
 #define	coderef(x)	((struct codeentry *)&stack[x])
 
-extern char *memneed();		/* insures enough core, returns start	*/
-extern char *comdstr();		/* compile string at topd, return start	*/
+extern char *memneed(int incr);		/* insures enough core, returns start	*/
+extern char *comdstr(char *s);		/* compile string at topd, return start	*/

--- a/pkg/ecl/modes.c
+++ b/pkg/ecl/modes.c
@@ -751,7 +751,7 @@ bkg_query (
 {
 	char	bqfile[SZ_PATHNAME], qrfile[SZ_PATHNAME];
 	int	waitime, delay;
-	char	*envget(), *fgets_status;
+	char	*fgets_status;
 	FILE	*fp, *in;
 
 	if (notify())
@@ -866,7 +866,6 @@ void
 get_bkgqfiles (int bkgno, int pid, char *bkg_query_file, char *query_response_file)
 {
 	int	filecode;
-	char	*envget();
 
 	if (envget (UPARM) == NULL)
 	    cl_error (E_UERR,

--- a/pkg/ecl/modes.c
+++ b/pkg/ecl/modes.c
@@ -268,8 +268,8 @@ query (struct param *pp)
 	char	buf[SZ_PROMPTBUF+1];
 	struct	operand o;
 	int	bastype, batch, arrflag, offset=0, n_ele, max_ele, fd;
-	char	*nlp, *nextstr();
-	char	*bkg_query(), *query_status;
+	char	*nlp, *nextstr(char **pbuf, FILE *fp);
+	char	*bkg_query(char *obuf, int maxch, register struct param *pp), *query_status;
 	char	*abuf;
 
 	bastype = pp->p_type & OT_BASIC;
@@ -537,7 +537,7 @@ testval:
 char *
 nextstr (char **pbuf, FILE *fp)
 {
-	char	*p, *nxtchr();
+	char	*p, *nxtchr(char *p, FILE *fp);
 	static	char	tbuf[SZ_LINE];
 	char	quote;
 	int	cnt;

--- a/pkg/ecl/opcodes.c
+++ b/pkg/ecl/opcodes.c
@@ -39,8 +39,8 @@
 extern	int cldebug;
 extern	char *nullstr;
 int	binpipe;			/* last pipe binary or text ? */
-char	*comdstr();
-extern	struct param *ppfind();		/* search task psets for param */
+char	*comdstr(char *s);
+extern	struct param *ppfind(struct pfile *pfp, char *tn, char *pn, int pos, int abbrev);		/* search task psets for param */
 extern	int currentline;
 
 void 
@@ -972,7 +972,7 @@ o_doaddpipe (memel *argp)
 	char	*ltname;
 	struct	operand	o;
 	struct	ltask *ltp;
-	char	*addpipe();
+	char	*addpipe(void);
 
 	/* ADDPIPE is called immediately before REDIR and before EXEC so we
 	 * do not have to worry about storing the pipefile name in the dict.
@@ -1004,7 +1004,7 @@ o_dogetpipe (
 )
 {
 	struct	operand o;
-	char	*getpipe(), *comdstr();
+	char	*getpipe(void), *comdstr(char *s);
 
 	/* GETPIPE is called immediately before REDIRIN and before EXEC so we
 	 * do not have to worry about storing the pipefile name in the dict.

--- a/pkg/ecl/opcodes.h
+++ b/pkg/ecl/opcodes.h
@@ -20,7 +20,7 @@ struct codeentry {
 #define	SZ_CE		4	/* size of codeentry			*/
 
 
-extern void (*opcodetbl[])();
+extern void (*opcodetbl[])(memel *arg);
 
 /* manifest constant opcodes used in c_opcode.
  * value is index into opcodetbl[].

--- a/pkg/ecl/operand.h
+++ b/pkg/ecl/operand.h
@@ -192,7 +192,6 @@ struct arr_desc {
 
 extern char *truestr, *falsestr;
 
-struct operand popop(), pushop();
-struct operand makeop();
-struct operand readlist();	/* read and return operand from list	*/
-struct operand sexa();		/* convert n:n:n string to sexagesimal	*/
+struct operand popop(void), pushop(struct operand *op);
+struct operand makeop(char *str, int type);
+struct operand sexa(char *);		/* convert n:n:n string to sexagesimal	*/

--- a/pkg/ecl/param.c
+++ b/pkg/ecl/param.c
@@ -717,7 +717,7 @@ paramsrch (char *pkname, char *ltname, char *pname)
 {
 	register struct param *pp;
 	struct	pfile *pfp;
-	struct	param *lookup_param();
+	struct	param *lookup_param(char *pkname, char *ltname, char *pname);
 
 	/* First search for a regular parameter.  If this fails then we 
 	 * handle the case when currentask has no pfile.

--- a/pkg/ecl/param.h
+++ b/pkg/ecl/param.h
@@ -200,21 +200,21 @@ struct pfile {
 #define	V_FILE		9
 
 
-char	*nextfield();		/* cracks next pfile line field		*/
-char	*makelower();		/* upper to lower, in place and return	*/
+char	*nextfield(char **pp, FILE *fp);		/* cracks next pfile line field		*/
+char	*makelower(register char *cp);		/* upper to lower, in place and return	*/
 
-struct	param *paramfind();	/* searches for a param on a given pfile*/
-struct	param *paramsrch();	/* search, make sure param is there	*/
-struct	param *lookup_param();	/* search standard path for a param	*/
-struct	param *newparam();	/* allocate and link a new param	*/
-struct	param *addparam();	/* make a new param off given pfile	*/
-struct	param *newfakeparam();	/* add a fake param to pfile		*/
-struct	pfile *pfilesrch();	/* read named pfile or ltask pfile	*/
-struct	pfile *pfileload();	/* load pfile for ltask into memory	*/
-struct	pfile *pfileread();	/* read and make params from a pfile	*/
-struct	pfile *pfilefind();	/* look for pfile with given name	*/
-struct	pfile *newpfile();	/* add a new pfile off parhead		*/
-struct	pfile *pfilecopy();	/* make an in-core copy of a pfile	*/
+struct	param *paramfind(struct pfile *pfp, char *pname, int pos, int exact);	/* searches for a param on a given pfile*/
+struct	param *paramsrch(char *pkname, char *ltname, char *pname);	/* search, make sure param is there	*/
+struct	param *lookup_param(char *pkname, char *ltname, char *pname);	/* search standard path for a param	*/
+struct	param *newparam(struct pfile *pfp);	/* allocate and link a new param	*/
+struct	param *addparam(struct pfile *pfp, char *buf, FILE *fp);	/* make a new param off given pfile	*/
+struct	param *newfakeparam(struct pfile *pfp, char *name, int pos, int type, int string_len);	/* add a fake param to pfile		*/
+struct	pfile *pfilesrch(char *pfilepath);	/* read named pfile or ltask pfile	*/
+struct	pfile *pfileload(register struct ltask *ltp);	/* load pfile for ltask into memory	*/
+struct	pfile *pfileread(struct ltask *ltp, char *pfilename, int checkmode);	/* read and make params from a pfile	*/
+struct	pfile *pfilefind(register struct ltask *ltp);	/* look for pfile with given name	*/
+struct	pfile *newpfile(struct ltask *ltp);	/* add a new pfile off parhead		*/
+struct	pfile *pfilecopy(register struct pfile *pfp);	/* make an in-core copy of a pfile	*/
 
-int	defpar();		/* determine whether param exists	*/
-int	defvar();		/* determine whether envvar exists	*/
+int	defpar(char *param_spec);		/* determine whether param exists	*/
+int	defvar(char *envvar);		/* determine whether envvar exists	*/

--- a/pkg/ecl/pfiles.c
+++ b/pkg/ecl/pfiles.c
@@ -908,10 +908,10 @@ pfilecopy (register struct pfile *pfp)
 
 		    p = parrd->a_ptr.a_s;
 		    q = qarrd->a_ptr.a_s;
-		    for (d=0;  d < size_arr;  d++) {
+		    for (d=0;  d < size_arr; d++, q++, p++) {
 			*q = memneed (btoi(len));
-			strncpy (*q++, *p++, len-1);
-			*(q+len-1) = '\0' ;
+			strncpy (*q, *p, len-1);
+			(*q)[len-1] = '\0';
 		    }
 		}
 

--- a/pkg/ecl/pfiles.c
+++ b/pkg/ecl/pfiles.c
@@ -511,7 +511,7 @@ pfileread (
 		goto error_;
 
 	} else if (procscript (fp)) {
-	    extern int yyparse ();
+	    extern int yyparse (void);
 
 	    /* Parse the declarations section of a procedure script.
 	     * The procscript() call leaves us positioned to the procedure

--- a/pkg/ecl/pfiles.c
+++ b/pkg/ecl/pfiles.c
@@ -30,8 +30,8 @@ extern	char *nullstr;
 extern	char *indefstr, *indeflc;
 extern	FILE *yyin;
 char	*uparmdir = UPARM;
-long	filetime();
-static	void mapname();
+long	filetime(char *fname, char *timecode);
+static	void mapname(char *in, char *out, int maxlen);
 
 
 /* NEWPFILE -- Allocate a new pfile on the dictionary and link in at parhead.

--- a/pkg/ecl/prcache.c
+++ b/pkg/ecl/prcache.c
@@ -88,7 +88,7 @@ int	pr_pno = 1;			/* incremented for each connect	*/
 int	sz_prcache = 2;			/* nprocess slots in cache	*/
 struct	process pr_cache[MAXSUBPROC];
 struct	process *pr_head = NULL, *pr_tail = NULL;
-extern	char *findexe();
+extern	char *findexe(struct package *pkg, char *pkg_path);
 
 static void pr_pdisconnect (struct process *pr);
 static void pr_tohead (struct process *pr);
@@ -193,7 +193,7 @@ pr_pconnect (
 )
 {
 	struct process *pr;
-	struct	process *pr_findproc();
+	struct	process *pr_findproc(char *process);
 	struct	_finfo fi;
 	int	fd_in, fd_out;
 

--- a/pkg/ecl/prcache.c
+++ b/pkg/ecl/prcache.c
@@ -127,7 +127,7 @@ pr_connect (
 	register int	pid;
 
 	/* Connect subprocess. */
-	if ((pid = pr_pconnect (process, in, out)) == NULL)
+	if ((pid = pr_pconnect (process, in, out)) == 0)
 	    c_erract (EA_ERROR);
 
 
@@ -225,7 +225,7 @@ pr_pconnect (
 	    /* Get process slot. */
 	    for (pr=pr_tail;  pr != NULL;  pr=pr->pr_up)
 		if (!pr_busy(pr)) {
-		    if (pr->pr_pid != NULL)
+		    if (pr->pr_pid != 0)
 			pr_pdisconnect (pr);
 		    break;
 		}
@@ -239,7 +239,7 @@ pr_pconnect (
 	    if (cltrace)
 		eprintf ("\t----- connect to %s -----\n", process);
 	    intr_disable();
-	    if ((pr->pr_pid = c_propen (process, &fd_in, &fd_out)) == NULL) {
+	    if ((pr->pr_pid = c_propen (process, &fd_in, &fd_out)) == 0) {
 		intr_enable();
 		return (0);
 	    }

--- a/pkg/ecl/proto.h
+++ b/pkg/ecl/proto.h
@@ -259,7 +259,7 @@ extern void putlog(struct task *tp, char *usermsg);
 /* lexicon.c */
 extern int yylex(void);
 extern int lexicon(void);
-extern int lexinit(void);
+extern void lexinit(void);
 /* lists.c */
 extern struct operand readlist(struct param *pp);
 extern void closelist(register struct param *pp);

--- a/pkg/ecl/task.h
+++ b/pkg/ecl/task.h
@@ -218,8 +218,8 @@ struct package {
 #define	PACKAGESIZ	btoi (sizeof (struct package))
 #define	TCALLSIZ	btoi (sizeof (struct task_call))
 
-struct	package *newpac(), *pacfind();
-struct	ltask *addltask(), *newltask(), *ltaskfind(), *cmdsrch();
-struct	ltask *ltasksrch(), *_ltasksrch();
-struct	task *pushtask(), *poptask();
-int	deftask(), defpac();
+struct	package *newpac(char *name, char *bin), *pacfind(char *name);
+struct	ltask *addltask(struct package *pkp, char *ptname, char *ltname, int redef), *newltask(register struct package *pkp, char *lname, char *pname, struct ltask *oldltp), *ltaskfind(struct package *pkp, char *name, int enable_abbreviations), *cmdsrch(char *pkname, char *ltname);
+struct	ltask *ltasksrch(char *pkname, char *ltname), *_ltasksrch(char *pkname, char *ltname, struct package **o_pkp);
+struct	task *pushtask(void), *poptask(void);
+int	deftask(char *task_spec), defpac(char *pkname);

--- a/sys/libc/calloc.c
+++ b/sys/libc/calloc.c
@@ -10,7 +10,7 @@
 /* CALLOC -- Allocate memory for NELEM elements of size ELSIZE bytes per
 ** element.  The space is initialized to all zeros.
 */
-char *
+void *
 calloc (
   unsigned int nelems,
   unsigned int elsize

--- a/sys/libc/free.c
+++ b/sys/libc/free.c
@@ -12,7 +12,7 @@
 */
 void
 free (
-  char	*buf
+  void	*buf
 )
 {
 	XINT	x_ptr, x_dtype = TY_CHAR;

--- a/sys/libc/malloc.c
+++ b/sys/libc/malloc.c
@@ -9,7 +9,7 @@
 
 /* MALLOC -- Allocate an uninitialized block of memory at least nbytes in size.
 */
-char *
+void *
 malloc (
   unsigned nbytes
 )
@@ -20,5 +20,5 @@ malloc (
 	iferr (MALLOC (&x_ptr, &x_nchars, &x_dtype))
 	    return (NULL);
 	else
-	    return ((char *)&Memc[x_ptr]);
+	    return ((void *)&Memc[x_ptr]);
 }

--- a/sys/libc/realloc.c
+++ b/sys/libc/realloc.c
@@ -11,9 +11,9 @@
 ** allocated buffer.  If necessary the buffer is moved, preserving any
 ** data in the buffer.
 */
-char *
+void *
 realloc (
-  char	*buf,
+  void	*buf,
   unsigned newsize
 )
 {
@@ -24,5 +24,5 @@ realloc (
 	iferr (REALLOC (&x_ptr, &x_nchars, &x_dtype))
 	    return (NULL);
 	else
-	    return ((char *)&Memc[x_ptr]);
+	    return ((void *)&Memc[x_ptr]);
 }

--- a/unix/hlib/libc/iraf_libc.h
+++ b/unix/hlib/libc/iraf_libc.h
@@ -124,14 +124,14 @@ extern char    *c_cnvtime (long clktime, char *outstr, int maxch);
 extern char    *c_getuid (char *outstr, int maxch);
 extern char    *c_salloc (unsigned nbytes);
 extern char    *c_strpak (short *sppstr, char *cstr, int maxch);
-extern char    *calloc (unsigned int nelems, unsigned int elsize);
+extern void    *calloc (unsigned int nelems, unsigned int elsize);
 extern char    *envget (char *var);
 extern char    *fgets (char *buf, int maxch, struct _iobuf *fp);
 extern char    *gets (char *buf);
-extern char    *malloc (unsigned nbytes);
+extern void    *malloc (unsigned nbytes);
 extern char    *mktemp (char *template);
 extern char    *freadline (char *prompt);
-extern char    *realloc (char *buf, unsigned newsize);
+extern void    *realloc (void *buf, unsigned newsize);
 extern char    *sprintf (char *str, char *format, ...);
 
 extern double   atof (char *str);
@@ -285,7 +285,7 @@ extern void	c_xwhen (int exception, funcptr_t new_handler, funcptr_t *old_handle
 extern void	eprintf (char *format, ...);
 extern void	fprintf (struct _iobuf *fp, char *format, ...);
 extern void	fputs (char *str, struct _iobuf *fp);
-extern void	free (char *buf);
+extern void	free (void *buf);
 extern void	perror (char *prefix);
 extern void	printf (char *format, ...);
 extern void	setbuf (struct _iobuf *fp, char *buf);


### PR DESCRIPTION
This is done on an Ubuntu Trusty machine, with the command

    protoize -g -l -N -c "-I${iraf}unix/hlib/libc" *.c

There was already an attempt to protoize CL and ECL in the NOIRLab tree (https://github.com/iraf-community/iraf/commit/f46b82791601b3379ee5a9f0c117a30b214c1fe9), but this was not applicable, because the source trees deviate now significantly here because of #32 and a number of other bug fixes and clean-ups that were applied here but not in the NOIRLab tree. Also, it was incomplete, there are quite a number of prototypes missing. However, I checked this commit completely for potential bug fixes to be applied here (no findings for here; but NOIRLab obviously has some bugs...). _The joys of missing coordination and a forked source tree._

The **protoize** tool is unfortunately removed from the gcc distribution after Ubuntu Trusty, so we had to use a VM to finally get this done. It seems that there are no more missing prototypes in IRAF; at least **protoize** didn't convert any other C file.

Another change here is that in `sys/libc`, the memory allocation functions should be declared in a more recent way, i.e. the memory is of type `void *` instead of `char *`.

This way, we found one bug in `pkg/ecl/pfiles.c#L911-L915` (traceable back to version 2.8, 1989!):
```c
    for (d=0;  d < size_arr;  d++) {
	*q = memneed (btoi(len));
	strncpy (*q++, *p++, len-1);
	*(q+len-1) = '\0' ;
    }
```
(with `char **p, **p;`)
Obviously, the last line should force-add a `'\0'` at the end of each string (in case the length exceeded the maximum), but that is somehow different. NOIRLabs change 

```diff
diff --git a/pkg/ecl/pfiles.c b/pkg/ecl/pfiles.c
index 08de7aa92..585d9954a 100644
--- a/pkg/ecl/pfiles.c
+++ b/pkg/ecl/pfiles.c
@@ -910,7 +948,7 @@ pfilecopy (register struct pfile *pfp)
    for (d=0;  d < size_arr;  d++) {
        *q = memneed (btoi(len));
        strncpy (*q++, *p++, len-1);
-       *(q+len-1) = '\0' ;
+       *(q+len-1) = (char *)'\0' ;
    }
```

just silences the warning, but doesn't resolve the bug. IMO correct is

```c
    for (d=0;  d < size_arr; d++, q++, p++) {
	*q = memneed (btoi(len));
	strncpy (*q, *p, len-1);
	(*q)[len-1] = '\0';
    }
```

@mjfitzpatrick, you should change this in your fork as well.

We also take the opportunity here to fix few other (minor) warnings.