### PR TITLE
Fix build on Fedora-40: Use explicit pointer casts in some more places

### DIFF
--- a/sys/libc/system.c
+++ b/sys/libc/system.c
@@ -21,7 +21,7 @@ system (
 	XINT	status;
 
 	nullstr[0] = EOS;
-	ZOSCMD (cmd, nullstr, nullstr, nullstr, &status);
+	ZOSCMD ((PKCHAR *)cmd, nullstr, nullstr, nullstr, &status);
 
 	return ((int) status);
 }

--- a/unix/os/zfiobf.c
+++ b/unix/os/zfiobf.c
@@ -767,7 +767,7 @@ vm_connect (void)
 		"vmclient (%s): open server connection `%s' -> ",
 		vm_client, osfn);
 
-	ZOPNND (osfn, &acmode, &fd);
+	ZOPNND ((PKCHAR *)osfn, &acmode, &fd);
 	if (fd == XERR) {
 	    if (vm_debug)
 		fprintf (stderr, "failed\n");

--- a/unix/os/zfioks.c
+++ b/unix/os/zfioks.c
@@ -1620,7 +1620,7 @@ ks_sysname (char *filename, char *pathname)
 	XCHAR	irafdir[SZ_PATHNAME+1];
 	XINT	x_maxch=SZ_PATHNAME, x_nchars;
 
-	ZGTENV ((const int*)"iraf", irafdir, &x_maxch, &x_nchars);
+	ZGTENV ((PKCHAR *)"iraf", irafdir, &x_maxch, &x_nchars);
 	if (x_nchars <= 0)
 	    return (NULL);
 


### PR DESCRIPTION
The first argument in ZOPNND() should really be declared as a `char *`. However it is a SPP called function and therefore limited to the SPP data types; so the first argument is declared as `PKG_CHAR *` (which is a `short int`). Therefore we need to cast it when called from C.

Another point is the wrong pointer type in zfioks.c, which is resolved here as well.

Fixes: #395 