### PR TITLE
NOIRLAB: tbtables: automatically add .tab extn if necessary

### DIFF
--- a/pkg/tbtables/tbttyp.x
+++ b/pkg/tbtables/tbttyp.x
@@ -56,9 +56,12 @@ define	SZ_FITS_BLOCK	2880	# one FITS block
 #
 # Phil Hodge, 16-Apr-1999  Function created.
 # Phil Hodge, 22-Oct-2004  Check for byte-swapped size information record.
-#
 # Frank Valdes, 18-Aug-2007:  Various changes to better control types and
 # extensions.
+# Phil Hodge, 21-Mar-2012  When checking for a filename extension of ".fits"
+#                       (or ".fit", or ".??f"), also check that the file
+#                       name is longer than the extension being tested for.
+#
 
 int procedure tbttyp (tablename, exists)
 
@@ -93,8 +96,6 @@ string	naxis    "NAXIS   =                "
 int	i_sizinfo[LEN_SIZINFO]	# size information record
 char	c_sizinfo[SZ_SIZINFO * 8]
 char    cache[SZ_FNAME], src[SZ_FNAME], extn[SZ_FNAME]
-
-
 equivalence (i_sizinfo[1], c_sizinfo[1])
 int	b_sizinfo[LEN_SIZINFO]	# byte-swapped size information record
 
@@ -126,24 +127,6 @@ begin
 	} else {
 	    call strcpy (tablename, Memc[fname], SZ_FNAME)
 	}
-
-	# Make sure we've cached the file.
-        # Delete a cached version of the file.
-if (1<0) {
-	if (strncmp ("http://", Memc[fname], 7) == 0) {
-            if (envgets ("cache", cache, SZ_FNAME) > 0) {
-                call fclookup (cache, Memc[fname], src, extn, SZ_FNAME)
-                if (src[1] != EOS) {
-	    	    tp = tbtopn (Memc[fname], READ_ONLY, NULL)
-	    	    call tbtclo (tp)
-
-		    ttype = TBL_TYPE_FITS
-		    call sfree (sp)
-		    return (ttype)
-	        }
-	    }
-	}
-}
 
 	# From now on we'll use Memc[fname] as the file name.
 	iferr {

--- a/pkg/tbtables/tbttyp.x
+++ b/pkg/tbtables/tbttyp.x
@@ -80,8 +80,8 @@ int	ofd, fstdfile()	# to check for STDIN, STDOUT, etc.; ofd is ignored
 bool	streq()
 
 pointer fname		# file name without trailing brackets
+pointer fullname        # input file name with ".tab" appended
 int	extname, hdu, dummy	# returned by tbparse and ignored
-pointer	tbtopn(), tp
 int	tbparse()
 
 # These are used for checking for a FITS file.
@@ -95,11 +95,9 @@ string	naxis    "NAXIS   =                "
 # These are used for checking for an STSDAS binary table.
 int	i_sizinfo[LEN_SIZINFO]	# size information record
 char	c_sizinfo[SZ_SIZINFO * 8]
-char    cache[SZ_FNAME], src[SZ_FNAME], extn[SZ_FNAME]
 equivalence (i_sizinfo[1], c_sizinfo[1])
 int	b_sizinfo[LEN_SIZINFO]	# byte-swapped size information record
 
-int     envgets()
 errchk	open, read, tbparse
 
 begin
@@ -134,6 +132,20 @@ begin
 	} then {
 	    exists = NO
 	}
+
+        if (exists == NO) {
+            # Append default extension and try again.
+            call salloc (fullname, SZ_FNAME, TY_CHAR)
+            call strcpy (Memc[fname], Memc[fullname], SZ_FNAME)
+            call strcat (".tab", Memc[fullname], SZ_FNAME)
+            iferr {
+                fd = open (Memc[fullname], READ_ONLY, BINARY_FILE)
+            } then {
+                exists = NO
+            } else {
+                exists = YES
+            }
+        }
 
 	if (exists == YES) {
 


### PR DESCRIPTION
Taken over from NOIRLab code:

* fa05e8e09b0ef742858a28cc885d690c062600a3 removed file caching code
* d55036b96e79363375b1c44da67c4673a4e84bc6 automatically add .tab extn if necessary

The first one removes a code fragment that was permanently disabled.