### PR TITLE
Add hurd64 to the list of supported architectures

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,6 +54,7 @@ Architecture | Operating system | Supported CPU types
 `macosx`     | macOS 32 bit     | i386
 `freebsd64`  | FreeBSD 64 bit   | x86\_64
 `freebsd`    | FreeBSD 32 bit   | i386, arm
+`hurd64`     | GNU HURD 64 bit  | x86\_64
 `hurd`       | GNU HURD 32 bit  | i386
 
 Note that Cygwin and big endian architectures like macosx/ppc are not


### PR DESCRIPTION
On the Debian 64-bit HURD architecture is [built and tested sucessfully](https://buildd.debian.org/status/logs.php?pkg=iraf&arch=hurd-amd64). That's why we can add this architecture to the list of supported architectures.