### PR TITLE
Make IRAF compileable with gcc-15 and newer clang

### DIFF
--- a/pkg/cl/decl.c
+++ b/pkg/cl/decl.c
@@ -78,7 +78,7 @@ getlimits (
 int
 get_dim (char *pname)
 {
-	struct param *pp, *lookup_param();
+	struct param *pp;
 	char	*pk, *t, *p, *f;
 	int 	dim;
 

--- a/pkg/cl/opcodes.c
+++ b/pkg/cl/opcodes.c
@@ -1324,7 +1324,7 @@ o_fixlanguage (memel *argp)
  * then precede it with "do" but alphabetize it according to its intended name.
  */
 
-void (*opcodetbl[])() = {
+void (*opcodetbl[])(memel *arg) = {
 /*  0 */	o_undefined,
 
 /*  1 */	o_absargset,

--- a/unix/hlib/f77.sh
+++ b/unix/hlib/f77.sh
@@ -44,7 +44,7 @@ set -e
 
 s=/tmp/stderr_$$
 CC=${CC_f2c:-${CC:-cc}}
-CFLAGS="-I${iraf}include ${XC_CFLAGS} -Wno-maybe-uninitialized -Wno-strict-aliasing -Wno-unknown-warning-option -fcommon"
+CFLAGS="-I${iraf}include ${XC_CFLAGS} -std=gnu11 -Wno-deprecated-non-prototype -Wno-maybe-uninitialized -Wno-strict-aliasing -Wno-unknown-warning-option -fcommon"
 EFL=${EFL:-/v/bin/efl}
 EFLFLAGS=${EFLFLAGS:-'system=portable deltastno=10'}
 F2C=${F2C:-${iraf}unix/bin/f2c.e}


### PR DESCRIPTION
This is the companion to https://github.com/iraf-community/x11iraf/pull/75. gcc-15 defaults to C23 as C standard, which interprets empty argument lists in functions as void, i.e. **foo()** is now equivalent to **foo(void)**.

This is a problem with f2c generated code, because this comes without proper prototypes (they don't exist in Fortran and in SPP). So, the only solution here is to fix the C standard to one where empty function args are interpreted as an unspecified argument list.

The C files here are already mostly C23 compliant, except for two places in pkg/cl, which are now fixed as well.

Additionally to the CI tests here this was tested with gcc-15 and clang-19.

See also [Debian#1096852](https://bugs.debian.org/1096852)