### PR TITLE
Use newer images for builds

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -18,19 +18,20 @@ jobs:
             os: ubuntu-latest
             cflags: -O2 -g -Wall -Wno-stringop-truncation -Wno-unused-result -Wno-format-overflow -Wno-parentheses
 
-          - name: Ubuntu 20.04 Focal i386
-            os: ubuntu-20.04
+          - name: Ubuntu 22.04 Focal i386
+            os: ubuntu-22.04
             irafarch: linux
             ldflags: -m32
             cflags: -m32 -O2 -g -Wall -Wno-stringop-truncation -Wno-unused-result -Wno-format-overflow -Wno-parentheses
 
-          - name: macOS x86_64
-            os: macos-latest
+          - name: macOS 15 Sequoia arm64
+            os: macos-15
             cflags: -O2 -g -Wall -Wno-logical-op-parentheses
 
-          - name: macOS arm64
-            os: macos-14
-            cflags: -O2 -g -Wall -Wno-logical-op-parentheses
+          - name: macOS 13 Ventura x86_64
+            os: macos-13
+            cflags: -O1 -g -Wall -Wno-logical-op-parentheses -arch x86_64
+            ldflags: -arch x86_64
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Ubuntu 24.04 for linux64 (unchanged)
Ubuntu 22.04 for linux (32 bit)
MacOS 13 for macintel
MacOS 15 for macos64 (ARM)

For Macintel, the optimization is set to -O1 because with -O2 the compilation is buggy and the `rmfiles.e unix/hlib/strip.iraf` call fails with

    illegal `-f progfile' switch

This seems a compiler bug, as there is nothing in `rmfiles.c` that could cause this, https://github.com/iraf-community/iraf/blob/c679e01fe5a2d8ecec7f7477eefde20cf4f249e0/unix/boot/rmfiles/rmfiles.c#L81-L88