### PR TITLE
Don't print some warnings in mkpkg's `$ifolder`/`$ifnewer`

### DIFF
--- a/unix/boot/mkpkg/scanlib.c
+++ b/unix/boot/mkpkg/scanlib.c
@@ -86,7 +86,6 @@ h_scanlibrary (char *library)
 	/* Open the UNIX archive file.
 	 */
 	if ((fp = fopen (libfname, "r")) == NULL) {
-	    printf ("warning: library `%s' not found\n", libfname);
 	    fflush (stdout);
 	    return (0);
 	}

--- a/unix/boot/mkpkg/tok.c
+++ b/unix/boot/mkpkg/tok.c
@@ -441,14 +441,13 @@ do_if (struct context *cx, char	*keyword)
 	} else if (strcmp (key, "older") == 0) {
 	    /* $IFOLDER.  Check if the named file is older than any of the
 	     * listed files.  If the named file does not exist the result
-	     * is true.  If any of the listed files do not exist a warning
-	     * is printed and they are ignored.
+	     * is true.  If the named file do not exist a warning
+	     * is printed.
 	     */
 	    if (os_access (argv[1], 0,0) == NO) {
 		warns ("file `%s' not found", argv[1]);
 		bval = 1;
 	    } else if ((fdate = os_fdate(argv[0])) <= 0) {
-		warns ("file `%s' not found", argv[0]);
 		bval = 1;
 	    } else {
 		for (i=1;  i < argc;  i++) {
@@ -468,10 +467,9 @@ do_if (struct context *cx, char	*keyword)
 	    /* $IFNEWER.  Check if the named file is newer than any of the
 	     * listed files.  If the named file does not exist the result
 	     * is false.  If any of the listed files do not exist a warning
-	     * is printed and they are ignored.
+	     * is printed.
 	     */
 	    if (os_access (argv[1], 0,0) == NO) {
-		warns ("file `%s' not found", argv[1]);
 		bval = 1;
 	    } else if ((fdate = os_fdate(argv[0])) <= 0) {
 		warns ("file `%s' not found", argv[0]);


### PR DESCRIPTION
Specifically, don't print warnings if the first file does not exist in `$ifolder`, or of the second file does not exist in `$ifnewer`.

Reason is that `$ifolder`/`$ifnewer` are used to (re-)create a file when it is older than its origin. Usually however the generated file does not exist at all in the beginning; this is a normal case and shall not cause a warning.