### PR TITLE
Silence warnings

### DIFF
--- a/sys/mkpkg
+++ b/sys/mkpkg
@@ -191,7 +191,6 @@ libcur.a:
 	;
 
 libmain.o:				# The root object module
-	$set XFLAGS = "-c $(HSI_XF)"
 	$checkout zmain.c host$os/
 	$omake	  zmain.c
 	$iffile (bin$libsys.a)		# store all binaries in BIN?

--- a/unix/boot/mkpkg/host.c
+++ b/unix/boot/mkpkg/host.c
@@ -86,7 +86,7 @@ h_updatelibrary (
 )
 {
 	char	cmd[SZ_CMD+1], *args;
-	int	exit_status, baderr, npass;
+	int	exit_status, baderr;
 	int	nsources, nfiles, ndone, nleft;
 	int	hostnames, status;
 	char	libfname[SZ_PATHNAME+1];
@@ -184,10 +184,10 @@ h_updatelibrary (
 	 * are typically processed in each iteration.
 	 */
 	args  = &cmd[strlen(cmd)];
-	nleft = totfiles;
-	ndone = 0;
 
-	for (npass=0; nleft > 0; npass++) {
+	for (nleft = totfiles, ndone = 0;
+	     nleft > 0;
+	     nleft -= nfiles, ndone += nfiles) {
 
 	    /* Add as many filenames as will fit on the command line.  */
 	    nfiles = add_objects (cmd, SZ_CMD, &flist[ndone], nleft,
@@ -225,9 +225,6 @@ h_updatelibrary (
 	    /* Truncate command and repeat with the next few files.
 	     */
 	    (*args) = EOS;
-
-	    ndone += nfiles;
-	    nleft -= nfiles;
 
 	}
 

--- a/unix/boot/rmfiles/rmfiles.c
+++ b/unix/boot/rmfiles/rmfiles.c
@@ -135,12 +135,6 @@ rmfiles (
 	FILE	*fp = NULL;
 
 
-        /* Hardwire an exclusion for a .git directory so we don't
-         * unintentially delete the repo files.
-         */
-        if (strncmp (".git", dir, 4) == 0)
-            return;
-
 	if (debug) {
 	    fprintf (stderr, "rmfiles @(%s), exe=%d, ver=%d\n", prog, execute,
 		verbose);
@@ -286,6 +280,12 @@ stripdir (
 	char	newpath[SZ_PATHNAME+1];
 	char	fname[SZ_PATHNAME+1];
 	int	deleteit, dp;
+
+	/* Hardwire an exclusion for a .git directory so we don't
+	 * unintentially delete the repo files.
+	 */
+	if (strncmp (".git", dir, 4) == 0)
+	    return;
 
 	if (debug) {
 	    fprintf (stderr, "stripdir %s%s\n", path, dir);

--- a/unix/boot/spp/rpp/rppfor/errchk.f
+++ b/unix/boot/spp/rpp/rppfor/errchk.f
@@ -1,6 +1,5 @@
       subroutine errchk
       integer tok, lastt0, gnbtok, token(100)
-      integer ntok
       integer mktabl
       common /cdefio/ bp, buf (4096)
       integer bp
@@ -80,7 +79,6 @@
      *d0(22)/103/,serrd0(23)/44/,serrd0(24)/32/,serrd0(25)/120/,serrd0(2
      *6)/101/,serrd0(27)/114/,serrd0(28)/112/,serrd0(29)/97/,serrd0(30)/
      *100/,serrd0(31)/-2/
-      ntok = 0
       tok = 0
 23000 continue
       lastt0 = tok

--- a/unix/boot/spp/rpp/rpprat/errchk.r
+++ b/unix/boot/spp/rpp/rpprat/errchk.r
@@ -5,13 +5,11 @@ include defs
 subroutine errchk
 
 character tok, last_tok, gnbtok, token(MAXTOK)
-integer	ntok
 pointer	mktabl
 include	COMMON_BLOCKS
 string	serrcom1 "logical xerflg, xerpad(84)"
 string	serrcom2 "common /xercom/ xerflg, xerpad"
 
-	ntok = 0
 	tok = 0
 
 	repeat {

--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -186,7 +186,7 @@ static void  fatal (char *s);
 int
 main (int argc, char *argv[])
 {
-	int	i, j, nargs, ncomp;
+	int	i, j, nargs;
 	char	*arglist[MAXFILE+MAXFLAG+10];
 	char	*arg, *ip, *s;
 	int	status, noperands;
@@ -472,7 +472,7 @@ main (int argc, char *argv[])
 			     */
 			    link_nfs = YES;
 			} else {
-passflag:		    mkobject = YES;
+			    mkobject = YES;
 			    if (!cflagseen)
 				mktask = YES;
 			    *bp++ = *ip;
@@ -748,7 +748,6 @@ passflag:		    mkobject = YES;
 	    sprintf (tempfile, "T_%s", outfile);
 	arglist[nargs++] = tempfile;
 
-	ncomp = 0;
 	for (i=0;  i < nfiles;  i++)
 	    if (*(ip = lfiles[i]) != '-') {
 		while (*ip++ != EOS)
@@ -763,7 +762,6 @@ passflag:		    mkobject = YES;
 		    case 's':
 		    case 'e':
 			ip[1] = 'o';
-			ncomp++;
 		    }
 	    }
 

--- a/unix/boot/wtar/wtar.c
+++ b/unix/boot/wtar/wtar.c
@@ -543,11 +543,11 @@ copyfile (
 {
 	register char	*bp;
 	register int	i;
-	int	nbytes, nleft, blocks, fd, count, total, ch;
+	int	nbytes, nleft, blocks, fd, count, ch;
 	char	buf[TBLOCK*2];
 
 	bp = buf;
-	total = nbytes = 0;
+	nbytes = 0;
 	blocks = (fh->size + TBLOCK - 1 ) / TBLOCK;
 
 	if ((fd = os_open (fname, 0, ftype)) == ERR) {
@@ -585,7 +585,6 @@ copyfile (
 			nleft = 0;
 
 		    bp = (char *) ((long)buf + nleft);
-		    total += nbytes;
 		    nbytes = nleft;
 		}
 	    }

--- a/unix/boot/xyacc/y1.c
+++ b/unix/boot/xyacc/y1.c
@@ -251,7 +251,6 @@ others (void)
 {
     extern int gen_lines;
     int c, i, j;
-    int tmpline;
 
     finput = fopen (parser, "r");
     if (finput == NULL)
@@ -295,11 +294,8 @@ others (void)
 
     if (gen_lines)
 	(void) fprintf (fsppout, "# line\t1 \"%s\"\n", parser);
-    tmpline = 1;
     /* copy parser text */
     while ((c = getc (finput)) != EOF) {
-	if (c == '\n')
-	    tmpline++;
 	if (c == '$') {
 	    if ((c = getc (finput)) == 'A') {
 		/* Replace $A macro by the user declarations.

--- a/unix/hlib/f77.sh
+++ b/unix/hlib/f77.sh
@@ -44,7 +44,7 @@ set -e
 
 s=/tmp/stderr_$$
 CC=${CC_f2c:-${CC:-cc}}
-CFLAGS="-I${iraf}include ${XC_CFLAGS} -std=gnu11 -Wno-deprecated-non-prototype -Wno-maybe-uninitialized -Wno-strict-aliasing -Wno-unknown-warning-option -fcommon"
+CFLAGS="-I${iraf}include ${XC_CFLAGS} -std=gnu11 -Wno-deprecated-non-prototype -Wno-maybe-uninitialized -Wno-strict-aliasing -Wno-unknown-warning-option -Wno-return-type -fcommon"
 EFL=${EFL:-/v/bin/efl}
 EFLFLAGS=${EFLFLAGS:-'system=portable deltastno=10'}
 F2C=${F2C:-${iraf}unix/bin/f2c.e}

--- a/unix/os/zalloc.c
+++ b/unix/os/zalloc.c
@@ -15,8 +15,6 @@
 
 #include "osproto.h"
 
-static int loggedin (int uid);
-
 /*
  * ZALLOC.C -- Device allocation interface.  Requires the dev$devices table,
  * which is read by the high level code before we are called.
@@ -130,7 +128,6 @@ ZDVOWN (
 	    *status = DV_DEVFREE;
 	else if (uid == getuid())
 	    *status = DV_DEVALLOC;
-	/* else if (!loggedin (uid)) */
 	else if (u_allocstat ((char *)device) == DV_DEVFREE)
 	    *status = DV_DEVFREE;
 	else {
@@ -142,38 +139,6 @@ ZDVOWN (
 	}
 
 	return (*status);
-}
-
-
-/* LOGGEDIN -- Return 1 if uid is logged in, else 0.
- */
-static int
-loggedin (int uid)
-{
-	struct	utmpx ubuf;
-	struct	passwd *pw;
-	FILE	*ufp;
-
-	if ((ufp = fopen ("/var/run/utmp", "r")) == NULL) {
-	    printf ("zdvown: cannot open /var/run/utmp\n");
-	    return (1);
-	}
-
-	if ((pw = getpwuid (uid)) == NULL) {
-	    fclose (ufp);
-	    return (0);
-	}
-
-	do {
-	    if (fread (&ubuf, sizeof (struct utmpx), 1, ufp) == (size_t) 0) {
-		fclose (ufp);
-		return (0);
-	    }
-	} while (strncmp (ubuf.ut_user, pw->pw_name, 8) != 0);
-
-	fclose (ufp);
-
-	return (1);
 }
 
 


### PR DESCRIPTION
This removes many of the warnings; also one bug in **rmfiles** was fixed here.

Most of the warnings came from the compilation of **rpp**. The majority was because f2c converts f77 **SUBROUTINE** into C **int()** functions (on purpose), but does not apply a return value then. These warnings are removed by adding `-Wno-return-type` to the compiler flags.

The other fixes were about unused code, where this code just got removed.

There are some warnings left:

1. many "unused but set variable" warning, because **rpp** often ignores the return value of functions (but sometimes uses it). I don't want to silence this, because unused variables are generally a good cause for a warning.
2. In function ‘penencode’, inlined from ‘translate’ at sgi2ueps.c:328:10 (this is most probably a bug):
   ```
   sgi2ueps.c:481:19: warning: ‘__builtin_memcpy’ writing 16 bytes into a region of size 14 [-Wstringop-overflow=]
     481 |             *op++ = *ip++;
         |             ~~~~~~^~~~~~~
   sgi2ueps.c: In function ‘translate’:
   sgi2ueps.c:472:25: note: at offset 3 into destination object ‘obuf’ of size 17
     472 |         static char     obuf[SZ_PENCMD+1];
         |                         ^~~~
   ```
3. wtar.c: In function ‘tarfileout’ (probably on purpose):
   ```
   wtar.c:429:45: warning: ‘__builtin___snprintf_chk’ output truncated before the last format character [-Wformat-truncation=]
     429 |         snprintf (hb.dbuf.size,  12, "%11lo ", fh->size);
         |                                             ^
   ```
4. When compiling cl/ecl (not sure; if this is a bug than it is there for ages):
   ```
   grammar.y: warning: 10 shift/reduce conflicts [-Wconflicts-sr]
   grammar.y: note: rerun with option '-Wcounterexamples' to generate conflict counterexamples
   ```

The warnings however mainly come from code in `unix/`, as most of the **xc** calls come with a `-w` flag which switches off all warnings. Not sure whether one should open this can of worms...
