### PR TITLE
Fix type of jumpcon in (e)cl/main.c

### DIFF
--- a/doc/releases/v218revs.rst
+++ b/doc/releases/v218revs.rst
@@ -70,6 +70,7 @@ Since 2.18
 - Silence warnings (`#435 <https://github.com/iraf-community/iraf/pull/435>`__,
   `#432 <https://github.com/iraf-community/iraf/pull/432>`__)
 - Shrink math bevington (`437 <https://github.com/iraf-community/iraf/pull/437>`__)
+- Fix type of jumpcon in (e)cl/main.c (`439 <https://github.com/iraf-community/iraf/pull/439>`__)
 - Prepare release (`#434 <https://github.com/iraf-community/iraf/pull/434>`__,
   `#438 <https://github.com/iraf-community/iraf/pull/438>`__)
 

--- a/pkg/cl/main.c
+++ b/pkg/cl/main.c
@@ -63,7 +63,7 @@ int	cldebug = 0;		/* print out lots of goodies if > 0	*/
 int	cltrace = 0;		/* trace instruction execution if > 0	*/
 
 static	funcptr_t old_onipc;	/* X_IPC handler chained to onint()	*/
-static	long *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
+static	XINT *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
 static	jmp_buf jmp_save;	/* save IRAF Main jump vector		*/
 static	jmp_buf jmp_clexit;	/* clexit() jumps here			*/
 static	int intr_sp;		/* interrupt save stack pointer		*/
@@ -109,7 +109,7 @@ c_main (
 	 * ourselves during normal execution, but when the CL exits we are
 	 * not prepared to deal with errors occuring during shutdown.
 	 */
-	XMJBUF (&bp);  jumpcom = (long *)&Memc[bp];
+	XMJBUF (&bp);  jumpcom = (XINT *)&Memc[bp];
 	cl_amovi ((int *)jumpcom, (int *)jmp_save, LEN_JUMPBUF);
 
 	/* Init clexit() in case we have to panic stop.  */

--- a/pkg/ecl/main.c
+++ b/pkg/ecl/main.c
@@ -63,7 +63,7 @@ int	cldebug = 0;		/* print out lots of goodies if > 0	*/
 int	cltrace = 0;		/* trace instruction execution if > 0	*/
 
 static	funcptr_t old_onipc;	/* X_IPC handler chained to onint()	*/
-static	long *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
+static	XINT *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
 static	jmp_buf jmp_save;	/* save IRAF Main jump vector		*/
 static	jmp_buf jmp_clexit;	/* clexit() jumps here			*/
 static	int intr_sp;		/* interrupt save stack pointer		*/
@@ -115,7 +115,7 @@ c_main (
 	 * ourselves during normal execution, but when the CL exits we are
 	 * not prepared to deal with errors occuring during shutdown.
 	 */
-	XMJBUF (&bp);  jumpcom = (long *)&Memc[bp];
+	XMJBUF (&bp);  jumpcom = (XINT *)&Memc[bp];
 	cl_amovi ((int *)jumpcom, (int *)jmp_save, LEN_JUMPBUF);
 
 	/* Init clexit() in case we have to panic stop.  */


### PR DESCRIPTION
This fixes the build on 32 bit. It was on Debian already for a while, but was forgotten to push to upstream.