### PR TITLE
NOIRLAB: Add GHOST2MS task to the PROTO package

### DIFF
--- a/pkg/proto/doc/ghost2ms.hlp
+++ b/pkg/proto/doc/ghost2ms.hlp
@@ -1,0 +1,84 @@
+.help ghost2ms Jul25 proto
+.ih
+NAME ghost2ms -- Convert Gemini/DRAGONS GHOST format to IRAF multispec format
+.ih
+USAGE ghost2ms input output
+.ih
+PARAMETERS
+.ls input
+Input GHOST file from DRAGONS.
+.le
+.ls output = ""
+Output base name.
+.le
+.ls order1 = 1
+Starting order to extract.
+.le
+.ls order2 = 33
+Ending order to extract.
+.le
+.ls version = 1
+Version to extract.
+.le
+.ls clobber = no
+Clobber existing output?
+.le
+.ls verbose = yes
+Verbose output?
+.le
+.ih
+DESCRIPTION The GHOST2MS task converts the DRAGONS-calibrated output for the
+red and blue arms on the GHOST instrument to a standard IRAF multispec format
+to permit further analysis and visualization using standard ONEDSPEC tasks.
+It makes use of a task from the artdata package to set up the echelle
+structure and then the linear spectrum WCS and the flux values are added.
+The default is to extract all the orders from extension version 1.
+
+For context: this data format is specific to the GHOST instrument. When
+reduced using DRAGONS, two different outputs are produced (for each "blue"
+and "red" arms of the spectrograph):
+
+.ls *_calibrated.fits
+Reduced spectra before stitching the orders. The flux pixels are in a 3D
+array with the first axis of size 2, one for the target, one for the sky,
+then a second axis for the wavelength direction, and finally a third axis
+with several orders. The WAVL extension contains the wavelength at each pixel
+in the wavelength-order array.
+.le
+.ls *_dragons.fits
+1D extracted spectrum. Orders have been stitched together. The algorithm
+resamples the order wavelengths to a common log-spaced scale, interpolates
+the orders to that new wavelength scale, and then averages the fluxes from
+each order with an inverse variance weighting.
+.le
+
+There are two issues here: the "*dragons.fits" file opens on "splot" but
+the wavelength solution is wrong. The DRAGONS team provided a recipe to fix
+that, so we have a file called "_dragons_irafCompatible.fits". However, many
+of our users want to normalize the spectra order-by-order, so none of those
+are good options.
+
+This task is a script and so users may copy it and modify it as desired.
+
+.ih
+EXAMPLES
+1. Compute the ring averages with labels and output to the terminal.
+
+.nf
+    # Convert the red arm calibrated frame.
+    onedspec> ghost2ms S20230416S0079_red001_calibrated.fits
+    S20230416S0079_red_calib[SCI,1][*,1:33] -> S20230416S0079_red_calib_iraf
+
+    # Convert the blue arm calibrated frame.
+    onedspec> ghost2ms S20240322S0068_blue001_calibrated.fits
+    S20240322S0068_blue_calib[SCI,1][*,1:33] -> S20240322S0068_blue_calib_iraf
+
+    # Use SPLOT to view the result.
+    onedspec> splot S20230416S0079_red_calib_iraf 1 unit=nm
+    onedspec> splot S20240322S0068_blue_calib_iraf 1 unit=nm
+.fi
+
+.ih
+SEE ALSO
+mkechelle, sapertures, imcopy
+.endhelp

--- a/pkg/proto/ghost2ms.cl
+++ b/pkg/proto/ghost2ms.cl
@@ -1,0 +1,107 @@
+# GHOST2MS - Convert Gemini/DRAGONS GHOST format to IRAF multispec format.
+
+procedure ghost2ms (input)
+
+file	input			{prompt="Input GHOST file from DRAGONS"}
+string	output = ""		{prompt="Output base name"}
+int	order1 = 1		{prompt="Starting order to extract"}
+int	order2 = 33		{prompt="Ending order to extract"}
+int	version = 1		{prompt="Version to extract"}
+bool	clobber = no		{prompt="Clobber existing output?"}
+bool	verbose = yes		{prompt="Verbose output?"}
+
+begin
+	file	in, out, sci, awav
+	int	nvers, ndisp, nspec, order
+	int	nver, ns, o1, o2, c1, c2
+	real	w1, w2, dw,  unitscale
+	string	unit
+
+
+	# Set input and output.
+	in = input
+	if (strstr(".fits",in) > 0)
+	    in = substr (in, 1, strstr(".fits",in)-1)
+	out = output
+	if (out == "")
+	    out = in // "_iraf"
+	else if (strstr(".fits",out) > 0)
+	    out = substr (out, 1, strstr(".fits",out)-1)
+
+	if (imaccess(out) == YES) {
+	    if (clobber) {
+	        imdel (out)
+		del (out//".hdr")
+		del (out//".aptable")
+	    } else {
+		printf ("%s already exists\n", out)
+		return
+	    }
+	}
+
+	# Extract a header for the final file.
+	imhead (in//"[1]", l+, > out//".hdr")
+
+	# Check the format.
+	imextensions (in, output="none", index="1-", extname="SCI",
+	    extver="", lindex=no, lname=yes, lver=yes, ikparams="")
+	nvers = imextensions.nimages
+	nver = max (1, min (nvers, version))
+
+	# Get the size information and set the orders to extract.
+	printf ("%s[SCI,%d]\n", in, nver) | scan (sci)
+	hselect (sci, "NAXIS1,NAXIS2", yes) | scan (ndisp, nspec)
+	o1 = max (1, min (nspec, order1))
+	o2 = max (1, min (nspec, order2))
+	printf ("%s[SCI,%d][*,%d:%d]\n", in, nver, o1, o2) | scan (sci)
+
+	if (verbose)
+	    printf ("%s -> %s\n", sci, out)
+
+	# Create an aperture table.  The dispersion is set to linear
+	# with the average dispersion per pixel.
+	# Because there is no simple way to define the units we
+	# set the dispersion to the assumed Angstroms units.  The user
+	# can then use the options to display in whatever desired
+	# units.
+
+	if (access(out//".aptable"))
+	    delete (out//".aptable")
+	match ("CUNIT1", out//".hdr") | scan (unit, unit, unit)
+	if (unit == "'nm")
+	    unitscale = 10
+	else
+	    unitscale = 1
+	for (ns=o1; ns<=o2; ns += 1) {
+	    printf ("%s[AWAV,%d][1,%d]\n", in, nver, ns) | scan (awav)
+	    listpix (awav) |& match ("Warn", stop+) | scan (w1, w1)
+	    w1 *= unitscale
+	    printf ("%s[AWAV,%d][%d,%d]\n", in, nver, ndisp, ns) | scan (awav)
+	    listpix (awav) |& match ("Warn", stop+) | scan (w2, w2)
+	    w2 *= unitscale
+	    dw = (w2 - w1) / (ndisp - 1)
+	    printf ("%d %d 0 %.g %.3g INDEF INDEF INDEF INDEF\n",
+	        ns, 0, w1, dw, >> out//".aptable")
+	}
+
+	# Use MKECHELLE to take care of the basic multispec structure.
+	ns = o2 - o1 + 1
+	order = o1 + ns / 2
+	mkechelle (out, yes, ncols=1, nlines=ndisp, norders=ns,
+	    title="", header=out//".hdr", list=no, make=yes, comments=no,
+	    xc=235.5, yc=INDEF, pixsize=0.027, profile="extracted",
+	    width=20., scattered=0., f=590., gmm=INDEF, blaze=INDEF,
+	    theta=INDEF, order=order, wavelength=5007.49, dispersion=2.61,
+	    cf=590., cgmm=226., cblaze=4.53, ctheta=-11.97, corder=1,
+	    cwavelength=6700., cdispersion=70., rv=0., z=no,
+	    continuum=1000., temperature=5700., lines="", nrandom=k,
+	    peak=-0.5, sigma=0.5, seed=i, >& "dev$null")
+
+	# Update the dispersion to the input.
+	sapertures (out, apertures="", apidtable=out//".aptable",
+	    wcsreset="no", verbose=no)
+
+	# Replace the MKECHELLE fluxes with the input fluxes.
+	imcopy (sci, out//"[*,*]", v-)
+
+end

--- a/pkg/proto/proto.cl
+++ b/pkg/proto/proto.cl
@@ -26,12 +26,14 @@ task	binfil,
 	text2mask 	= proto$x_proto.e
 
 task	ringavg 	= proto$ringavg.cl
+task	ghost2ms	= proto$ghost2ms.cl
 
 set	color		= "proto$color/"
 set	vol		= "proto$vol/"
 
 task	color.pkg	= color$color.cl
 task	vol.pkg		= vol$vol.cl
+
 
 hidetask	mask2text
 

--- a/pkg/proto/proto.hd
+++ b/pkg/proto/proto.hd
@@ -28,6 +28,7 @@ fields		hlp =doc$fields.hlp,	src = fields.x
 hfix		hlp =doc$hfix.hlp,	src = t_hfix.x
 imcntr		hlp =doc$imcntr.hlp,	src = t_imcntr.x
 fixpix		hlp =doc$fixpix.hlp,	src = t_fixpix.x
+ghost2ms	hlp =doc$ghost2ms.hlp,	src = ghost2ms.cl
 imextensions	hlp =doc$imextensions.hlp, src = t_imext.x
 imscale		hlp =doc$imscale.hlp,	src = t_imscale.x
 interp		hlp =doc$interp.hlp,	src = interp.x

--- a/pkg/proto/proto.men
+++ b/pkg/proto/proto.men
@@ -7,6 +7,7 @@
 	   epix - Edit pixels in an image
 	 fields - Extract specified fields from a list
 	 fixpix - Fix bad pixels by linear interpolation from nearby pixels
+       ghost2ms - Convert Gemini/DRAGONS GHOST format to IRAF multispec format
 	   hfix - Fix image headers with a user specified command
 	 imcntr - Locate the center of a stellar image
    imextensions - Make a list of image extensions

--- a/pkg/proto/proto.par
+++ b/pkg/proto/proto.par
@@ -1,3 +1,3 @@
 # PROTO package parameter file.
 
-version,s,h,"October 2010"
+version,s,h,"July 2025"


### PR DESCRIPTION
This task will  convert output of a DRAGONS-reduced GHOST file to an IRAF compatible multispec format.

This is taken from 17e018d82 in noirlabs fork.