### PR TITLE
NOIRLAB: Exclude common non-IRAF extensions from removal with rmbin

### DIFF
--- a/unix/boot/rmbin/rmbin.c
+++ b/unix/boot/rmbin/rmbin.c
@@ -74,6 +74,8 @@ main (int argc, char *argv[])
 	excl[ex++] = ".txt";
 	excl[ex++] = ".fits";
 	excl[ex++] = ".fz";
+	excl[ex++] = ".tar";
+	excl[ex++] = ".tgz";
 
 	for (argno=1;  (argp = argv[argno]) != NULL;  argno++)
 	    if (*argp == '-') {


### PR DESCRIPTION
Exclude the following extensions from removal with rmbin: `.ppt`, `.doc`, `.docx`, `.txt`, `.fits`,`.fz,` `.tar`, `.tgz`.
This applies

* bfebe242d added .tar and .tgz files to default exclusion list
* 4e0fd2ad2 exclude special files

from NOIRLABs fork.

I am not sure why these files should be kept. `.fits` files may be created f.e. by tests. And there are no word documents in the IRAF repositories. And why `.docx` bit not `.odt`?