### PR TITLE
NOIRLAB: Fix a segvio in the CL/ECL when doing 'flpr'

### DIFF
--- a/pkg/cl/opcodes.c
+++ b/pkg/cl/opcodes.c
@@ -437,7 +437,7 @@ o_indirabsset (memel *argp)
 	char	*pk, *t, *p, *f;
 	struct	pfile *pfp;
 	struct	param *pp;
-	int	type, string_len;
+	int	type, string_len = 0;
 
 	pfp = newtask->t_pfp;
 	if (pfp->pf_flags & PF_FAKE) {
@@ -495,7 +495,7 @@ o_indirposset (memel *argp)
 	int pos = (int) *argp;
 	struct pfile *pfp;
 	struct param *pp;
-	int type, string_len;
+	int type, string_len = 0;
 
 	pfp = newtask->t_pfp;
 	if (pfp->pf_flags & PF_FAKE) {

--- a/pkg/ecl/opcodes.c
+++ b/pkg/ecl/opcodes.c
@@ -438,7 +438,7 @@ o_indirabsset (memel *argp)
 	char	*pk, *t, *p, *f;
 	struct	pfile *pfp;
 	struct	param *pp;
-	int	type, string_len;
+	int	type, string_len=0;
 
 	pfp = newtask->t_pfp;
 	if (pfp->pf_flags & PF_FAKE) {
@@ -496,7 +496,7 @@ o_indirposset (memel *argp)
 	int pos = (int) *argp;
 	struct pfile *pfp;
 	struct param *pp;
-	int type, string_len;
+	int type, string_len=0;
 
 	pfp = newtask->t_pfp;
 	if (pfp->pf_flags & PF_FAKE) {


### PR DESCRIPTION
This is taken from NOIRLABs commit

* 3bdefe7e0 initialize string_len to fix segvio when doing e.g. 'flpr 0'