### PR TITLE
NOIRLAB: Add a new 16K frame buffer

### DIFF
--- a/dev/graphcap
+++ b/dev/graphcap
@@ -260,6 +260,8 @@ imt56|imtwttm|11K frame buffer:cn#56:xr#11000:yr#11000:\
 imt57|imtwttm|12K frame buffer:cn#57:xr#12000:yr#12000:\
         :LC:BS@:z0#1:zr#200:DD=node!imtool,,12000,12000:tc=iism70:
 
+imt60|16K frame buffer:cn#60:xr#16000:yr#16000:\
+        :LC:BS@:z0#1:zr#200:DD=node!imtool,,16000,16000:tc=iism70:
 
 iism70d|iism70c|iism70l|NOAO Draco hosted IIS model 70:\
 	:BS:DD=draco!iism70,iia0:tc=iism70:

--- a/dev/imtoolrc
+++ b/dev/imtoolrc
@@ -72,4 +72,5 @@
 
 # User added formats.  (start with #64)
 # (add here)
+60  1 16000  16000      # imt60|imt16k
 


### PR DESCRIPTION
Added a new 16K frame buffer to the `lib$imtoolrc` and `dev$graphcap` files.

This is taken from NOIRLABs branch, commit

* 5c927156e added a new 16K frame buffer
