### PR TITLE
Use ssh by default to call remote kernel (with contributions from NOIRLAB)

### DIFF
--- a/unix/os/zfioks.c
+++ b/unix/os/zfioks.c
@@ -917,13 +917,8 @@ ZARDKS (
   XLONG	*loffset 		/* not used				*/
 )
 {
-#ifdef ANSI
 	volatile char	*op;
 	volatile int	fd, nbytes;
-#else
-	char	*op;
-	int	fd, nbytes;
-#endif
 	void	(*sigint)(int), (*sigterm)(int);
 	int	status = ERR;
 


### PR DESCRIPTION
This started from NOIRLAB:

* c9dc421f1 removed typo code from pr_mask()
* a835f6cd6 added coded accidently previously deleted
* 841034e0 code ordering

The first commit message was however misleading. For the PR, the commits were split into a number of individual changes:

* Fix few typos in comments
* Use ssh by default to call remote kernel (written as new commit)
* Make some variables volatile: This seems (except for **unauth** in **ZOPNKS()**) not really necessary, but it also doesn't harm (except for performance, which isn't an issue here).

There were a few changes in the original commit that are not applied here. Except from removing re-entrance possibility, they don't change behaviour:
* Make **op** and **nbytes** static in **ZARDKS()**
  ```diff
  @@ -917,13 +917,9 @@ ZARDKS (
     XLONG	*loffset 		/* not used				*/
   )
   {
  -#ifdef ANSI
  -	volatile char	*op;
  -	volatile int	fd, nbytes;
  -#else
  -	char	*op;
  -	int	fd, nbytes;
  -#endif
  +	static  char	*op;
  +	static  int	nbytes;
  +	int	fd;
   	void	(*sigint)(int), (*sigterm)(int);
   	int	status = ERR;
   ```

* Make **irafhost**, **nodelist** and **update** static in **ks_getlogin()**
  ```diff
  @ -1393,15 +1393,16 @@ ks_getlogin (
     struct ksparam *ks 		/* networking parameters */
   )
   {
  +	static struct irafhosts *hp = (struct irafhosts *)NULL;
  +	static struct	nodelist *np = (struct nodelist *)NULL;
  +	static int	update = 0;
  +
   	register int i;
  -	struct  irafhosts *hp;
   	char	userfile[SZ_PATHNAME];
   	char	sysfile[SZ_PATHNAME];
   	char	fname[SZ_PATHNAME];
   	char	username[SZ_NAME];
   	char	*namep, *authp;
  -	struct	nodelist *np;
  -	int	update = 0;
   	int	auth;
   
   	/* Get path to user irafhosts file. */
  ```

Also, the extensive addition of unconditional debug messages was not applied here.


Pinging @mjfitzpatrick for a potential discussion.
