### PR TITLE
Changes in unix/os/zfiotx (inspired by NOIRLAB)

### DIFF
--- a/unix/os/zfiotx.c
+++ b/unix/os/zfiotx.c
@@ -248,8 +248,14 @@ ZCLSTX (XINT *fd, XINT *status)
 	 * [NOTE] -- fclose errors are ignored if we are closing a terminal
 	 * device.  This was necessary on the Suns and it was not clear why
 	 * a close error was occuring (errno was EPERM - not owner).
+	 *
+	 * [NOTE] -- fclose can throw a EBADF when used from a background 
+         * process, this affects closing the env files such as zzsetenv.def
+         * only so we will ignore it for now.
 	 */
-	*status = (fclose(kfp->fp) == EOF && kfp->flags&KF_NOSTTY) ? XERR : XOK;
+	*status = (fclose(kfp->fp) == EOF
+		   && errno != EBADF
+		   && kfp->flags&KF_NOSTTY)? XERR : XOK;
 
 	kfp->fp = NULL;
 	if (port) {


### PR DESCRIPTION
This is inspired by two commits from NOIRLAB:

1. dcba1364e fixed 'var might be clobbered by longjmp' warning on linux

   I can't reproduce the warning on Linux; however the right solution here would not be declaring a `static CHAR *abuf`, but instead having a `volatile XCHAR *op`   Therefore, the original commit is replaced with this one. 

   Also, as `tty_getraw` is set in (possibly asynchronuous) signal handlers, it must be declared as `static	volatile sig_atomic_t tty_getraw`.

2.  cd4dc304e, bdfd8e78c catch/ignore EBADF when closing fd on background jobs (Mac)

    These commits look overly complicated.
     ```diff
     -       *status = (fclose(kfp->fp) == EOF && kfp->flags&KF_NOSTTY) ? XERR : XOK;
    +        if ((*status = (fclose(kfp->fp) == EOF && kfp->flags&KF_NOSTTY) ?  XERR : XOK) == XERR) {
    +            if (errno == EBADF)
    +                *status = XOK;
    +        }
     ```
    Why not just
    ```C
         *status = (fclose(kfp->fp) == EOF && errno != EBADF && kfp->flags && KF_NOSTTY)? XERR : XOK;
    ```
    Also, Just ignoring an error for `EBADF` seems not thre right solution - *why* does EBADF appear in background jobs?

Independent of this, there is a use of **fcancel(fp)**, which is similar to what is in `zxwhen.c`. There, it was replaced in #366 with something more portable; maybe we should re-use it here (moved to `osproto.h`?).

Pinging @mjfitzpatrick for a potential discussion.