### PR TITLE
NOIRLAB: Fix invalid use of errstr

### DIFF
--- a/noao/onedspec/odcombine/srcwt/icgscale.x
+++ b/noao/onedspec/odcombine/srcwt/icgscale.x
@@ -61,11 +61,11 @@ begin
 		call close (fd)
 		if (i < nimages) {
 		    call salloc (errstr, SZ_LINE, TY_CHAR)
-		    call sprintf (errstr, SZ_FNAME,
+		    call sprintf (Memc[errstr], SZ_FNAME,
 			"Insufficient %s values in %s")
 			call pargstr (param)
 			call pargstr (name[2])
-		    call error (1, errstr)
+		    call error (1, Memc[errstr])
 		}
 	    }
 	} else if (name[1] == '!') {

--- a/pkg/images/immatch/src/imcombine/src/icgscale.x
+++ b/pkg/images/immatch/src/imcombine/src/icgscale.x
@@ -57,11 +57,11 @@ begin
 		call close (fd)
 		if (i < nimages) {
 		    call salloc (errstr, SZ_LINE, TY_CHAR)
-		    call sprintf (errstr, SZ_FNAME,
+		    call sprintf (Memc[errstr], SZ_FNAME,
 			"Insufficient %s values in %s")
 			call pargstr (param)
 			call pargstr (name[2])
-		    call error (1, errstr)
+		    call error (1, Memc[errstr])
 		}
 	    }
 	} else if (name[1] == '!') {

--- a/pkg/obsolete/imcombine/icscale.x
+++ b/pkg/obsolete/imcombine/icscale.x
@@ -331,10 +331,11 @@ begin
 	    call close (fd)
 	    if (i < nimages) {
 		call salloc (errstr, SZ_LINE, TY_CHAR)
-		call sprintf (errstr, SZ_FNAME, "Insufficient %s values in %s")
-		    call pargstr (param)
-		    call pargstr (name[2])
-		call error (1, errstr)
+		call sprintf (Memc[errstr], SZ_FNAME,
+                    "Insufficient %s values in %s")
+		        call pargstr (param)
+		        call pargstr (name[2])
+		call error (1, Memc[errstr])
 	    }
 	} else if (name[1] == '!') {
 	    type = S_KEYWORD

--- a/pkg/proto/vol/src/i2sun/t_i2sun.x
+++ b/pkg/proto/vol/src/i2sun/t_i2sun.x
@@ -19,7 +19,7 @@ pointer	sp, tr, input, im, rfnames, clutfile, transform, cur_rf
 pointer	ulutfile, ulut, colormap, pk_colormap, lut
 int	list, lfd, rfd, nslices, stat, nimages
 int	rheader[RAS_HDR_INTS], ras_maptype, ras_maplength, frame, slice, i, j
-short	lut1, lut2
+int	lut1, lut2
 bool	use_clut, make_map
 
 pointer immap()
@@ -80,7 +80,7 @@ begin
 	# Check if there are no images.
 	nimages = imtlen (list)
 	if (nimages == 0) {
-	    call eprintf (0, "No input images to convert")
+	    call eprintf ("No input images to convert")
 	    goto wrapup_
 	}
 


### PR DESCRIPTION
**errstr** is an array index and needs to be dereferenced when used in **error()**, **sprintf()** and others.

Taken from NOIRLAB:

* fb0d48ba5 fixed use of 'errstr' pointer
* cac0e90a7 fixed invalid use of pointer
* 55d971cef minor bug fixes

