### PR TITLE
Fix argument type of a_off in CHRPAK

### DIFF
--- a/sys/osb/chrpak.c
+++ b/sys/osb/chrpak.c
@@ -12,7 +12,7 @@
  * negative values.
  */
 void
-CHRPAK (XCHAR *a, XCHAR *a_off, PKCHAR *b, XINT *b_off, XINT *nchars)
+CHRPAK (XCHAR *a, XINT *a_off, PKCHAR *b, XINT *b_off, XINT *nchars)
 {
 	register XCHAR	*ip;
 	register unsigned char *op;


### PR DESCRIPTION
This was found by comparing with NOIRLABs fork.