### PR TITLE
Obey  $TMPDIR in f77.sh

### DIFF
--- a/unix/hlib/f77.sh
+++ b/unix/hlib/f77.sh
@@ -42,7 +42,7 @@
 # https://bugs.mageia.org/show_bug.cgi?id=11507
 set -e
 
-s=/tmp/stderr_$$
+s=${TMPDIR:-/tmp}/stderr_$$
 CC=${CC_f2c:-${CC:-cc}}
 CFLAGS="-I${iraf}include ${XC_CFLAGS} -std=gnu11 -Wno-deprecated-non-prototype -Wno-maybe-uninitialized -Wno-strict-aliasing -Wno-unknown-warning-option -Wno-return-type -fcommon"
 EFL=${EFL:-/v/bin/efl}


### PR DESCRIPTION
This is not always `/tmp`, f.e. not on termux.