### PR TITLE
Make handling of multiple -c arguments in irafcl portable

### DIFF
--- a/unix/hlib/irafcl.sh
+++ b/unix/hlib/irafcl.sh
@@ -80,17 +80,19 @@ while getopts "h?Voxf:c:" opt; do
 	if [ -z "$cmdline" ] ; then
 	    cmdline="$OPTARG"
 	else
-	    cmdline="${cmdline}"'\n'"$OPTARG"
+	    cmdline="${cmdline}
+$OPTARG"
 	fi
 	;;
     esac
 done
 
 if [ "${cmdline}" ] ; then
-    cmdline="${cmdline}"'\n'"logout"
+    cmdline="${cmdline}
+logout"
     script=$(mktemp -t irafcl.XXXXXX) || exit 1
     trap 'rm -f "$script"' EXIT
-    echo "$cmdline" > "$script"
+    printf '%s\n' "$cmdline" > "$script"
 fi
 
 # Workaround for autoconf scripts attempting to use this command as a


### PR DESCRIPTION
Bash interprets `'\n'` as a literal backslash followed by an `n` and not as a newline, in contrast to Debian's `/bin/sh`.

Therefore we need to use a real newline here.

Closes: #478